### PR TITLE
docs: add db:generate step to local setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ cp .env.example .env
 docker compose up -d
 
 # 5. Apply schema and seed demo data
+pnpm db:generate
 pnpm db:push
 pnpm db:seed
 


### PR DESCRIPTION
## Changes
Add missing pnpm db:generate step to local setup guide.

## Reason
While setting up locally Prisma client was missing causing seed to fail.

## Result
Developers can now setup project without prisma client errors.