### PR TITLE
feat: allow users to delete pending submissions

### DIFF
--- a/__tests__/submission-permissions.test.ts
+++ b/__tests__/submission-permissions.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { canDeleteModule } from "@/lib/submission-permissions";
+
+describe("canDeleteModule", () => {
+  it("allows admins to delete any submission", () => {
+    expect(
+      canDeleteModule({
+        isAdmin: true,
+        isOwner: false,
+        status: "APPROVED",
+      })
+    ).toBe(true);
+  });
+
+  it("allows authors to delete pending submissions", () => {
+    expect(
+      canDeleteModule({
+        isAdmin: false,
+        isOwner: true,
+        status: "PENDING",
+      })
+    ).toBe(true);
+  });
+
+  it("prevents authors from deleting approved submissions", () => {
+    expect(
+      canDeleteModule({
+        isAdmin: false,
+        isOwner: true,
+        status: "APPROVED",
+      })
+    ).toBe(false);
+  });
+
+  it("prevents authors from deleting rejected submissions", () => {
+    expect(
+      canDeleteModule({
+        isAdmin: false,
+        isOwner: true,
+        status: "REJECTED",
+      })
+    ).toBe(false);
+  });
+
+  it("prevents non-owners from deleting submissions", () => {
+    expect(
+      canDeleteModule({
+        isAdmin: false,
+        isOwner: false,
+        status: "PENDING",
+      })
+    ).toBe(false);
+  });
+});

--- a/src/app/api/modules/[id]/route.ts
+++ b/src/app/api/modules/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
+import { canDeleteModule } from "@/lib/submission-permissions";
 import { adminReviewSchema } from "@/lib/validations";
 
 type Params = { params: Promise<{ id: string }> };
@@ -8,7 +9,7 @@ type Params = { params: Promise<{ id: string }> };
 // GET /api/modules/[id]
 export async function GET(_req: NextRequest, { params }: Params) {
   const { id } = await params;
-  const module = await db.miniApp.findUnique({
+  const submission = await db.miniApp.findUnique({
     where: { id },
     include: {
       category: true,
@@ -16,8 +17,10 @@ export async function GET(_req: NextRequest, { params }: Params) {
       _count: { select: { votes: true } },
     },
   });
-  if (!module) return NextResponse.json({ error: "Not found" }, { status: 404 });
-  return NextResponse.json(module);
+  if (!submission) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  return NextResponse.json(submission);
 }
 
 // PATCH /api/modules/[id] — admin approve/reject
@@ -53,13 +56,33 @@ export async function DELETE(_req: NextRequest, { params }: Params) {
   }
 
   const { id } = await params;
-  const module = await db.miniApp.findUnique({ where: { id } });
-  if (!module) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  const submission = await db.miniApp.findUnique({ where: { id } });
+  if (!submission) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
 
-  if (module.authorId !== session.user.id && !session.user.isAdmin) {
+  const isOwner = submission.authorId === session.user.id;
+  const canDelete = canDeleteModule({
+    isAdmin: session.user.isAdmin,
+    isOwner,
+    status: submission.status,
+  });
+
+  if (!canDelete) {
+    if (isOwner) {
+      return NextResponse.json(
+        { error: "Only pending submissions can be deleted." },
+        { status: 403 }
+      );
+    }
+
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  await db.miniApp.delete({ where: { id } });
+  await db.$transaction([
+    db.vote.deleteMany({ where: { moduleId: id } }),
+    db.miniApp.delete({ where: { id } }),
+  ]);
+
   return new NextResponse(null, { status: 204 });
 }

--- a/src/app/my-submissions/page.tsx
+++ b/src/app/my-submissions/page.tsx
@@ -2,12 +2,7 @@ import { redirect } from "next/navigation";
 import Link from "next/link";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
-
-const statusStyles: Record<string, string> = {
-  PENDING: "bg-yellow-50 text-yellow-700 border-yellow-200",
-  APPROVED: "bg-green-50 text-green-700 border-green-200",
-  REJECTED: "bg-red-50 text-red-700 border-red-200",
-};
+import { MySubmissionsList } from "@/components/my-submissions-list";
 
 export default async function MySubmissionsPage() {
   const session = await auth();
@@ -31,46 +26,7 @@ export default async function MySubmissionsPage() {
         </Link>
       </div>
 
-      {submissions.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-gray-300 p-12 text-center">
-          <p className="text-gray-500">No submissions yet.</p>
-          <Link
-            href="/submit"
-            className="mt-2 block text-sm text-blue-600 hover:underline"
-          >
-            Submit your first module →
-          </Link>
-        </div>
-      ) : (
-        <div className="space-y-3">
-          {submissions.map((sub) => (
-            <div
-              key={sub.id}
-              className="flex items-start justify-between rounded-xl border border-gray-200 bg-white p-4"
-            >
-              <div className="space-y-1">
-                <p className="font-medium text-gray-900">{sub.name}</p>
-                <p className="text-xs text-gray-400">
-                  {sub.category.name} ·{" "}
-                  {new Date(sub.createdAt).toLocaleDateString()}
-                </p>
-                {sub.feedback && (
-                  <p className="mt-1 rounded-md bg-gray-50 px-2 py-1 text-xs text-gray-600">
-                    Feedback: {sub.feedback}
-                  </p>
-                )}
-              </div>
-              <span
-                className={`shrink-0 rounded-full border px-2 py-0.5 text-xs font-medium ${
-                  statusStyles[sub.status]
-                }`}
-              >
-                {sub.status}
-              </span>
-            </div>
-          ))}
-        </div>
-      )}
+      <MySubmissionsList initialSubmissions={submissions} />
     </div>
   );
 }

--- a/src/components/my-submissions-list.tsx
+++ b/src/components/my-submissions-list.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect, useState, useTransition } from "react";
+import type { ModuleStatus } from "@/types";
+import { canDeleteModule } from "@/lib/submission-permissions";
+
+const statusStyles: Record<ModuleStatus, string> = {
+  PENDING: "bg-yellow-50 text-yellow-700 border-yellow-200",
+  APPROVED: "bg-green-50 text-green-700 border-green-200",
+  REJECTED: "bg-red-50 text-red-700 border-red-200",
+};
+
+const submissionDateFormatter = new Intl.DateTimeFormat("en-US", {
+  dateStyle: "medium",
+});
+
+interface SubmissionItem {
+  id: string;
+  name: string;
+  status: ModuleStatus;
+  feedback: string | null;
+  createdAt: Date;
+  category: {
+    name: string;
+  };
+}
+
+interface MySubmissionsListProps {
+  initialSubmissions: SubmissionItem[];
+}
+
+export function MySubmissionsList({
+  initialSubmissions,
+}: MySubmissionsListProps) {
+  const router = useRouter();
+  const [submissions, setSubmissions] = useState(initialSubmissions);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [isRefreshing, startTransition] = useTransition();
+
+  useEffect(() => {
+    setSubmissions(initialSubmissions);
+  }, [initialSubmissions]);
+
+  async function handleDelete(submission: SubmissionItem) {
+    const canDelete = canDeleteModule({
+      isAdmin: false,
+      isOwner: true,
+      status: submission.status,
+    });
+
+    if (!canDelete) return;
+
+    const confirmed = window.confirm(
+      `Delete "${submission.name}"? This action cannot be undone.`
+    );
+
+    if (!confirmed) return;
+
+    const previousSubmissions = submissions;
+    setDeleteError(null);
+    setDeletingId(submission.id);
+    setSubmissions((current) =>
+      current.filter((item) => item.id !== submission.id)
+    );
+
+    try {
+      const response = await fetch(`/api/modules/${submission.id}`, {
+        method: "DELETE",
+      });
+
+      if (!response.ok) {
+        setSubmissions(previousSubmissions);
+        setDeleteError(await getDeleteErrorMessage(response));
+        return;
+      }
+
+      startTransition(() => {
+        router.refresh();
+      });
+    } catch {
+      setSubmissions(previousSubmissions);
+      setDeleteError("Could not delete the submission. Please try again.");
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
+  return (
+    <>
+      {deleteError && (
+        <p
+          role="alert"
+          className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+        >
+          {deleteError}
+        </p>
+      )}
+
+      {submissions.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-gray-300 p-12 text-center">
+          <p className="text-gray-500">No submissions yet.</p>
+          <Link
+            href="/submit"
+            className="mt-2 block text-sm text-blue-600 hover:underline"
+          >
+            Submit your first module →
+          </Link>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {submissions.map((submission) => {
+            const canDelete = canDeleteModule({
+              isAdmin: false,
+              isOwner: true,
+              status: submission.status,
+            });
+
+            return (
+              <div
+                key={submission.id}
+                className="rounded-xl border border-gray-200 bg-white p-4"
+              >
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div className="space-y-1.5">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <p className="font-medium text-gray-900">
+                        {submission.name}
+                      </p>
+                      <span
+                        className={`rounded-full border px-2 py-0.5 text-xs font-medium ${
+                          statusStyles[submission.status]
+                        }`}
+                      >
+                        {submission.status}
+                      </span>
+                    </div>
+
+                    <p className="text-xs text-gray-400">
+                      {submission.category.name} ·
+                      {submissionDateFormatter.format(
+                        new Date(submission.createdAt)
+                      )}
+                    </p>
+
+                    {submission.feedback && (
+                      <p className="rounded-md bg-gray-50 px-2 py-1 text-xs text-gray-600">
+                        Feedback: {submission.feedback}
+                      </p>
+                    )}
+                  </div>
+
+                  {canDelete ? (
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(submission)}
+                      disabled={deletingId !== null || isRefreshing}
+                      className="inline-flex items-center justify-center rounded-lg border border-red-200 px-3 py-2 text-sm font-medium text-red-700 transition-colors hover:border-red-300 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {deletingId === submission.id ? "Deleting..." : "Delete"}
+                    </button>
+                  ) : (
+                    <p className="text-xs text-gray-400">
+                      Only pending submissions can be deleted.
+                    </p>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </>
+  );
+}
+
+async function getDeleteErrorMessage(response: Response) {
+  try {
+    const body: unknown = await response.json();
+    if (
+      typeof body === "object" &&
+      body !== null &&
+      "error" in body &&
+      typeof body.error === "string"
+    ) {
+      return body.error;
+    }
+  } catch {
+    // Ignore JSON parsing errors and fall back to the generic message.
+  }
+
+  return "Could not delete the submission. Please try again.";
+}

--- a/src/lib/submission-permissions.ts
+++ b/src/lib/submission-permissions.ts
@@ -1,0 +1,17 @@
+import type { SubmissionStatus } from "@prisma/client";
+
+interface CanDeleteModuleArgs {
+  isAdmin: boolean;
+  isOwner: boolean;
+  status: SubmissionStatus;
+}
+
+export function canDeleteModule({
+  isAdmin,
+  isOwner,
+  status,
+}: CanDeleteModuleArgs): boolean {
+  if (isAdmin) return true;
+  if (!isOwner) return false;
+  return status === "PENDING";
+}


### PR DESCRIPTION
## Description

This PR allows authenticated users to delete their own pending submissions from the My Submissions page.

It adds a delete action with confirmation, updates the list without a full page reload, and preserves the existing rule that regular users cannot delete approved or rejected submissions.

## How to test

1. Sign in as a regular user with at least one `PENDING` submission.
2. Open `/my-submissions`.
3. Verify that pending submissions show a `Delete` button.
4. Click `Delete` and confirm the browser prompt.
5. Verify the submission is removed immediately and the page updates without a full reload.
6. Verify the empty state is shown if that was the last submission.
7. Verify that `APPROVED` and `REJECTED` submissions cannot be deleted by a regular user.
8. Optionally, send `DELETE /api/modules/:id` for a non-pending submission as the owner and confirm the API returns `403`.

## Approach

- Extracted the deletion rule into a shared permission helper so the UI and API enforce the same behavior.
- Moved the My Submissions list rendering into a client component to support confirmation, optimistic removal, inline error handling, and `router.refresh()`.
- Updated `DELETE /api/modules/[id]` so authors can delete only their own `PENDING` submissions, while admins can still delete any submission.
- Added unit tests covering admin, owner, and submission-status deletion rules.

## Checks

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`

## Notes

- `pnpm lint` is currently failing on existing ESLint issues outside the scope of this feature, so it is left unchecked here.