### PR TITLE
[Fix]: Add delete pending submissions

### DIFF
--- a/src/app/my-submissions/page.tsx
+++ b/src/app/my-submissions/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation";
 import Link from "next/link";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
+import { DeleteSubmissionButton } from "@/components/delete-submission-button";
 
 const statusStyles: Record<string, string> = {
   PENDING: "bg-yellow-50 text-yellow-700 border-yellow-200",
@@ -60,13 +61,12 @@ export default async function MySubmissionsPage() {
                   </p>
                 )}
               </div>
-              <span
-                className={`shrink-0 rounded-full border px-2 py-0.5 text-xs font-medium ${
-                  statusStyles[sub.status]
-                }`}
-              >
-                {sub.status}
-              </span>
+              <div className="flex shrink-0 items-center gap-2">
+                <span className={`rounded-full border px-2 py-0.5 text-xs font-medium ${statusStyles[sub.status]}`}>
+                  {sub.status}
+                </span>
+                {sub.status === "PENDING" && <DeleteSubmissionButton id={sub.id} />}
+              </div>
             </div>
           ))}
         </div>

--- a/src/components/delete-submission-button.tsx
+++ b/src/components/delete-submission-button.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+export function DeleteSubmissionButton({ id }: { id: string }) {
+  const router = useRouter();
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  async function handleDelete() {
+    if (!confirm("Are you sure you want to delete this submission?")) return;
+    setIsDeleting(true);
+    try {
+      await fetch(`/api/modules/${id}`, { method: "DELETE" });
+      router.refresh();
+    } finally {
+      setIsDeleting(false);
+    }
+  }
+
+  return (
+    <button
+      onClick={handleDelete}
+      disabled={isDeleting}
+      className="shrink-0 rounded-md border border-red-200 px-2 py-1 text-xs font-medium text-red-600 hover:bg-red-50 disabled:opacity-50"
+    >
+      {isDeleting ? "Deleting…" : "Delete"}
+    </button>
+  );
+}


### PR DESCRIPTION
## What does this PR do?

Add a Delete button on the My Submissions page so users can remove their own `PENDING` submissions. Clicking the button shows a confirmation dialog before calling the existing `DELETE /api/modules/[id]` endpoint, then refreshes the list in-place without a full page reload.

## Related Issue

Closes #19

## How to test

1. Run the project with `pnpm dev`
2. Go to `http://localhost:3000/my-submissions` (must be signed in)
3. Confirm a `PENDING` submission shows a **Delete** button — `APPROVED` and `REJECTED` do not
4. Click Delete → a confirmation dialog appears; dismiss it → nothing changes
5. Click Delete → confirm → submission disappears from the list without a full page reload
6. Navigate to an empty submissions state — verify the empty state renders correctly

## Checklist

- Ran `pnpm lint` and `pnpm typecheck` successfully
- TypeScript types are correct

## How I used AI

Used AI for guidance on:
- the client component with loading/deleting state
- `useRouter().refresh()` to revalidate server data after deletion
-  reviewed to fit the existing codebase patterns
