### PR TITLE
feat: add delete feature for pending submissions

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { generateSlug, makeUniqueSlug, formatRelativeTime } from "@/lib/utils";
 
 // ============================================================
@@ -22,14 +22,21 @@ describe("generateSlug", () => {
     expect(generateSlug("a   b   c")).toBe("a-b-c");
   });
 
-  // TODO [easy-challenge]: Add test cases for the following:
-  // 1. A name that is already a valid slug (no changes needed)
-  // 2. A name with numbers (numbers should be preserved)
-  // 3. An empty string (what should the output be? Check the implementation)
-  // 4. A name with leading/trailing hyphens after special char removal
-  //
-  // Hint: read `src/lib/utils.ts` to understand the exact transformation rules
-  // before writing your assertions.
+  it("keeps a valid slug unchanged", () => {
+    expect(generateSlug("already-valid-slug")).toBe("already-valid-slug");
+  });
+
+  it("preserves numbers", () => {
+    expect(generateSlug("Version 2.0!")).toBe("version-20");
+  });
+
+  it("returns an empty string for an empty string", () => {
+    expect(generateSlug("")).toBe("");
+  });
+
+  it("removes leading and trailing hyphens after special character removal", () => {
+    expect(generateSlug("!hello-world!")).toBe("hello-world");
+  });
 });
 
 // ============================================================
@@ -49,23 +56,51 @@ describe("makeUniqueSlug", () => {
     expect(makeUniqueSlug("my-app", ["my-app", "my-app-1"])).toBe("my-app-2");
   });
 
-  // TODO [easy-challenge]: Add test cases for:
-  // 1. When many suffixed versions already exist (e.g. -1 through -5)
-  // 2. When the existing list contains similar but non-conflicting slugs
-  //    e.g. existing = ["my-app-tool"] should NOT block "my-app"
+  it("increments past many existing suffixed versions", () => {
+    expect(makeUniqueSlug("my-app", ["my-app", "my-app-1", "my-app-2", "my-app-3", "my-app-4", "my-app-5"])).toBe("my-app-6");
+  });
+
+  it("does not incorrectly conflict with prefix-matching slugs", () => {
+    expect(makeUniqueSlug("my-app", ["my-app-tool"])).toBe("my-app");
+  });
 });
 
 // ============================================================
 // formatRelativeTime — NOT yet tested, candidate must write all tests
 // ============================================================
 
-// TODO [easy-challenge]: Write a full test suite for `formatRelativeTime`.
-// Requirements:
-// - "just now" for dates less than 1 minute ago
-// - "{n}m ago" for dates 1–59 minutes ago
-// - "{n}h ago" for dates 1–23 hours ago
-// - "{n}d ago" for dates 1–29 days ago
-// - toLocaleDateString() format for dates 30+ days ago
-//
-// Hint: You'll need to mock or control `Date.now()` to make these tests
-// deterministic. Look into Vitest's `vi.setSystemTime()`.
+describe("formatRelativeTime", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-02T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns "just now" for dates less than 1 minute ago', () => {
+    const date = new Date("2026-04-02T11:59:30Z"); // 30 seconds ago
+    expect(formatRelativeTime(date)).toBe("just now");
+  });
+
+  it('returns "{n}m ago" for dates 1-59 minutes ago', () => {
+    const date = new Date("2026-04-02T11:45:00Z"); // 15 minutes ago
+    expect(formatRelativeTime(date)).toBe("15m ago");
+  });
+
+  it('returns "{n}h ago" for dates 1-23 hours ago', () => {
+    const date = new Date("2026-04-02T05:00:00Z"); // 7 hours ago
+    expect(formatRelativeTime(date)).toBe("7h ago");
+  });
+
+  it('returns "{n}d ago" for dates 1-29 days ago', () => {
+    const date = new Date("2026-03-23T12:00:00Z"); // 10 days ago
+    expect(formatRelativeTime(date)).toBe("10d ago");
+  });
+
+  it("returns toLocaleDateString() for dates 30+ days ago", () => {
+    const date = new Date("2026-01-01T12:00:00Z"); // ~3 months ago
+    expect(formatRelativeTime(date)).toBe(date.toLocaleDateString());
+  });
+});

--- a/src/app/my-submissions/page.tsx
+++ b/src/app/my-submissions/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import Link from "next/link";
+import { DeleteSubmissionButton } from "@/components/delete-submission-button";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 
@@ -60,13 +61,18 @@ export default async function MySubmissionsPage() {
                   </p>
                 )}
               </div>
-              <span
-                className={`shrink-0 rounded-full border px-2 py-0.5 text-xs font-medium ${
-                  statusStyles[sub.status]
-                }`}
-              >
-                {sub.status}
-              </span>
+              <div className="flex flex-col items-end space-y-2">
+                <span
+                  className={`shrink-0 rounded-full border px-2 py-0.5 text-xs font-medium ${
+                    statusStyles[sub.status]
+                  }`}
+                >
+                  {sub.status}
+                </span>
+                {sub.status === "PENDING" && (
+                  <DeleteSubmissionButton id={sub.id} />
+                )}
+              </div>
             </div>
           ))}
         </div>

--- a/src/components/delete-submission-button.tsx
+++ b/src/components/delete-submission-button.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+export function DeleteSubmissionButton({ id }: { id: string }) {
+  const [isDeleting, setIsDeleting] = useState(false);
+  const router = useRouter();
+
+  const handleDelete = async () => {
+    if (!window.confirm("Are you sure you want to delete this pending submission?")) {
+      return;
+    }
+
+    setIsDeleting(true);
+    try {
+      const res = await fetch(`/api/modules/${id}`, {
+        method: "DELETE",
+      });
+
+      if (!res.ok) {
+        throw new Error("Failed to delete submission");
+      }
+
+      router.refresh();
+    } catch (error) {
+      console.error(error);
+      alert("Something went wrong while deleting.");
+    } finally {
+      setIsDeleting(false);
+    }
+  }
+
+  return (
+    <button
+      onClick={handleDelete}
+      disabled={isDeleting}
+      className={`text-xs font-medium text-red-600 hover:text-red-800 disabled:opacity-50 transition-colors ${
+        isDeleting ? "cursor-not-allowed" : ""
+      }`}
+    >
+      {isDeleting ? "Deleting..." : "Delete"}
+    </button>
+  );
+}


### PR DESCRIPTION
## What does this PR do?

1. Allows users to directly delete their own PENDING submissions from the "My Submissions" page. I created a separate client component (DeleteSubmissionButton) that safely talks to the existing DELETE /api/modules/[id] endpoint. The UI asks for a quick prompt confirmation (window.confirm) and then calls router.refresh() to update the submission list seamlessly without a full page reload.

2. Related Issue Closes #27 

## How to test

1. Run pnpm dev and ensure you are logged in.
2. Click "Submit Module" at the top right and create a dummy module.
3. Once submitted, navigate to "My Submissions". You will see your newly created module listed as PENDING with a red Delete button below the badge.
4. Click Delete, accept the confirmation dialog, and observe the module gracefully disappearing from the DOM without a full page refresh.

## Screenshots / recordings (if UI change)

<!-- Drag and drop a screenshot or screen recording here -->
<img width="1919" height="1029" alt="image" src="https://github.com/user-attachments/assets/83c52140-c118-46cc-a09f-1ab547386f8b" />

## Checklist

- [x]  No unrelated visual/layout changes
- [x]  TypeScript types are correct
- [x]  I ran **pnpm lint** and **pnpm typecheck** locally
- [x]  I understand why I made each change

**How I used AI Used AI to:**

- Help scaffold the DeleteSubmissionButton React Client Component with native handling for hover states and async Loading/Disabled behaviours while waiting for the API.
- Ensure the seamless usage of Next.js useRouter().refresh() approach to revalidate server-side page data instantly without breaking UX.