### PR TITLE
feat: add module resubmission workflow with revision history

### DIFF
--- a/prisma/migrations/20260402130000_add_module_revisions/migration.sql
+++ b/prisma/migrations/20260402130000_add_module_revisions/migration.sql
@@ -1,0 +1,23 @@
+-- CreateTable
+CREATE TABLE "module_revisions" (
+    "id" TEXT NOT NULL,
+    "moduleId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "repoUrl" TEXT NOT NULL,
+    "demoUrl" TEXT,
+    "status" "SubmissionStatus" NOT NULL,
+    "categoryId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "module_revisions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "module_revisions_moduleId_createdAt_idx" ON "module_revisions"("moduleId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "module_revisions" ADD CONSTRAINT "module_revisions_moduleId_fkey" FOREIGN KEY ("moduleId") REFERENCES "mini_apps"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "module_revisions" ADD CONSTRAINT "module_revisions_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "categories"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/migration_lock.toml
+++ b/prisma/migrations/migration_lock.toml
@@ -1,0 +1,1 @@
+provider = "postgresql"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -71,10 +71,11 @@ model User {
 }
 
 model Category {
-  id      String    @id @default(cuid())
-  name    String    @unique
-  slug    String    @unique
-  modules MiniApp[]
+  id              String           @id @default(cuid())
+  name            String           @unique
+  slug            String           @unique
+  modules         MiniApp[]
+  moduleRevisions ModuleRevision[]
 
   @@map("categories")
 }
@@ -99,6 +100,7 @@ model MiniApp {
   authorId String
 
   votes     Vote[]
+  revisions ModuleRevision[]
   // Denormalized for read performance on the browse page.
   // DO NOT remove this field and replace with COUNT(*) without running EXPLAIN ANALYZE first.
   voteCount Int    @default(0)
@@ -107,6 +109,25 @@ model MiniApp {
   updatedAt DateTime @updatedAt
 
   @@map("mini_apps")
+}
+
+model ModuleRevision {
+  id          String           @id @default(cuid())
+  module      MiniApp          @relation(fields: [moduleId], references: [id], onDelete: Cascade)
+  moduleId    String
+  name        String
+  description String
+  repoUrl     String
+  demoUrl     String?
+  status      SubmissionStatus
+
+  category   Category @relation(fields: [categoryId], references: [id])
+  categoryId String
+
+  createdAt DateTime @default(now())
+
+  @@index([moduleId, createdAt])
+  @@map("module_revisions")
 }
 
 model Vote {

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -12,6 +12,14 @@ export default async function AdminPage() {
     include: {
       category: true,
       author: { select: { id: true, name: true, image: true } },
+      revisions: {
+        include: {
+          category: { select: { id: true, name: true, slug: true } },
+        },
+        orderBy: { createdAt: "desc" },
+        take: 2,
+      },
+      _count: { select: { revisions: true } },
     },
     orderBy: { createdAt: "asc" },
   });

--- a/src/app/api/modules/[id]/resubmit/route.test.ts
+++ b/src/app/api/modules/[id]/resubmit/route.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  return {
+    authMock: vi.fn(),
+    dbMock: {
+      miniApp: {
+        findUnique: vi.fn(),
+        update: vi.fn(),
+      },
+      moduleRevision: {
+        create: vi.fn(),
+      },
+      $transaction: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@/lib/auth", () => ({
+  auth: mocks.authMock,
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: mocks.dbMock,
+}));
+
+import { POST } from "./route";
+
+const validPayload = {
+  name: "Updated Module Name",
+  description: "Updated description that is long enough for validation.",
+  categoryId: "cjjj5f0aj0000f2x8z5bn8g7k",
+  repoUrl: "https://github.com/acme/updated-module",
+  demoUrl: "https://updated.example.com",
+};
+
+function makeRequest(body: unknown) {
+  return new Request("http://localhost/api/modules/module_1/resubmit", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/modules/[id]/resubmit", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when user is not authenticated", async () => {
+    mocks.authMock.mockResolvedValue(null);
+
+    const response = await POST(makeRequest(validPayload), {
+      params: Promise.resolve({ id: "module_1" }),
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 403 when user is not the module author", async () => {
+    mocks.authMock.mockResolvedValue({
+      user: { id: "user_1", isAdmin: false },
+    });
+    mocks.dbMock.miniApp.findUnique.mockResolvedValue({
+      id: "module_1",
+      authorId: "user_2",
+      status: "REJECTED",
+      name: "Original",
+      description: "Original description with enough content",
+      repoUrl: "https://github.com/acme/original",
+      demoUrl: null,
+      categoryId: "cat_1",
+    });
+
+    const response = await POST(makeRequest(validPayload), {
+      params: Promise.resolve({ id: "module_1" }),
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 409 when status is not REJECTED", async () => {
+    mocks.authMock.mockResolvedValue({
+      user: { id: "user_1", isAdmin: false },
+    });
+    mocks.dbMock.miniApp.findUnique.mockResolvedValue({
+      id: "module_1",
+      authorId: "user_1",
+      status: "APPROVED",
+      name: "Original",
+      description: "Original description with enough content",
+      repoUrl: "https://github.com/acme/original",
+      demoUrl: null,
+      categoryId: "cat_1",
+    });
+
+    const response = await POST(makeRequest(validPayload), {
+      params: Promise.resolve({ id: "module_1" }),
+    });
+
+    expect(response.status).toBe(409);
+  });
+
+  it("creates revision snapshot and updates module to PENDING", async () => {
+    const existing = {
+      id: "module_1",
+      authorId: "user_1",
+      status: "REJECTED",
+      name: "Original",
+      description: "Original description with enough content",
+      repoUrl: "https://github.com/acme/original",
+      demoUrl: null,
+      categoryId: "cat_1",
+    };
+
+    const updated = {
+      id: "module_1",
+      status: "PENDING",
+      name: validPayload.name,
+      description: validPayload.description,
+      repoUrl: validPayload.repoUrl,
+      demoUrl: validPayload.demoUrl,
+      categoryId: validPayload.categoryId,
+      category: { id: validPayload.categoryId, name: "Tools", slug: "tools" },
+      author: { id: "user_1", name: "Alice", image: null },
+    };
+
+    mocks.authMock.mockResolvedValue({
+      user: { id: "user_1", isAdmin: false },
+    });
+    mocks.dbMock.miniApp.findUnique.mockResolvedValue(existing);
+    mocks.dbMock.moduleRevision.create.mockResolvedValue({ id: "rev_1" });
+    mocks.dbMock.miniApp.update.mockResolvedValue(updated);
+    mocks.dbMock.$transaction.mockResolvedValue([{ id: "rev_1" }, updated]);
+
+    const response = await POST(makeRequest(validPayload), {
+      params: Promise.resolve({ id: "module_1" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(mocks.dbMock.moduleRevision.create).toHaveBeenCalledWith({
+      data: {
+        moduleId: "module_1",
+        name: existing.name,
+        description: existing.description,
+        repoUrl: existing.repoUrl,
+        demoUrl: existing.demoUrl,
+        status: existing.status,
+        categoryId: existing.categoryId,
+      },
+    });
+    expect(mocks.dbMock.miniApp.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "module_1" },
+        data: expect.objectContaining({
+          status: "PENDING",
+          feedback: null,
+          name: validPayload.name,
+        }),
+      })
+    );
+
+    const body = await response.json();
+    expect(body.status).toBe("PENDING");
+  });
+});

--- a/src/app/api/modules/[id]/resubmit/route.ts
+++ b/src/app/api/modules/[id]/resubmit/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { moduleResubmitSchema } from "@/lib/validations";
+import {
+  buildRevisionSnapshot,
+  canAuthorResubmit,
+  isAuthorOwner,
+} from "@/lib/module-workflow";
+
+type Params = { params: Promise<{ id: string }> };
+
+// POST /api/modules/[id]/resubmit — author updates rejected submission and resubmits
+export async function POST(req: Request, { params }: Params) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await req.json();
+  const parsed = moduleResubmitSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 422 });
+  }
+
+  const { id } = await params;
+  const miniApp = await db.miniApp.findUnique({ where: { id } });
+  if (!miniApp) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  if (!isAuthorOwner(session.user.id, miniApp.authorId)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  if (!canAuthorResubmit(miniApp.status)) {
+    return NextResponse.json(
+      { error: "Only rejected submissions can be revised and resubmitted." },
+      { status: 409 }
+    );
+  }
+
+  const revisionWrite = db.moduleRevision.create({
+    data: {
+      moduleId: miniApp.id,
+      ...buildRevisionSnapshot(miniApp),
+    },
+  });
+
+  const moduleWrite = db.miniApp.update({
+    where: { id: miniApp.id },
+    data: {
+      ...parsed.data,
+      status: "PENDING",
+      feedback: null,
+    },
+    include: {
+      category: true,
+      author: { select: { id: true, name: true, image: true } },
+    },
+  });
+
+  const [, updated] = await db.$transaction([revisionWrite, moduleWrite]);
+
+  return NextResponse.json(updated);
+}

--- a/src/app/api/modules/[id]/revisions/route.ts
+++ b/src/app/api/modules/[id]/revisions/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+
+type Params = { params: Promise<{ id: string }> };
+
+// GET /api/modules/[id]/revisions — author or admin can inspect revision history
+export async function GET(_req: NextRequest, { params }: Params) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+  const miniApp = await db.miniApp.findUnique({
+    where: { id },
+    select: { id: true, authorId: true },
+  });
+
+  if (!miniApp) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  if (!session.user.isAdmin && miniApp.authorId !== session.user.id) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const revisions = await db.moduleRevision.findMany({
+    where: { moduleId: miniApp.id },
+    include: {
+      category: { select: { id: true, name: true, slug: true } },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  return NextResponse.json({ items: revisions });
+}

--- a/src/app/my-submissions/[id]/edit/page.tsx
+++ b/src/app/my-submissions/[id]/edit/page.tsx
@@ -1,0 +1,52 @@
+import { notFound, redirect } from "next/navigation";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { canAuthorResubmit } from "@/lib/module-workflow";
+import { ResubmitForm } from "@/components/resubmit-form";
+
+type Props = { params: Promise<{ id: string }> };
+
+export default async function EditSubmissionPage({ params }: Props) {
+  const session = await auth();
+  if (!session?.user) {
+    redirect("/api/auth/signin");
+  }
+
+  const { id } = await params;
+  const miniApp = await db.miniApp.findFirst({
+    where: { id, authorId: session.user.id },
+  });
+
+  if (!miniApp) {
+    notFound();
+  }
+
+  if (!canAuthorResubmit(miniApp.status)) {
+    redirect("/my-submissions");
+  }
+
+  const categories = await db.category.findMany({ orderBy: { name: "asc" } });
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Revise and Resubmit</h1>
+        <p className="mt-1 text-sm text-gray-500">
+          Update your rejected submission and send it back for review.
+        </p>
+      </div>
+
+      <ResubmitForm
+        moduleId={miniApp.id}
+        categories={categories}
+        initialValues={{
+          name: miniApp.name,
+          description: miniApp.description,
+          categoryId: miniApp.categoryId,
+          repoUrl: miniApp.repoUrl,
+          demoUrl: miniApp.demoUrl ?? "",
+        }}
+      />
+    </div>
+  );
+}

--- a/src/app/my-submissions/page.tsx
+++ b/src/app/my-submissions/page.tsx
@@ -59,6 +59,14 @@ export default async function MySubmissionsPage() {
                     Feedback: {sub.feedback}
                   </p>
                 )}
+                {sub.status === "REJECTED" && (
+                  <Link
+                    href={`/my-submissions/${sub.id}/edit`}
+                    className="inline-block rounded-md border border-gray-300 px-2 py-1 text-xs font-medium text-gray-700 hover:bg-gray-50"
+                  >
+                    Revise and resubmit
+                  </Link>
+                )}
               </div>
               <span
                 className={`shrink-0 rounded-full border px-2 py-0.5 text-xs font-medium ${

--- a/src/components/admin-review-card.tsx
+++ b/src/components/admin-review-card.tsx
@@ -38,6 +38,29 @@ export function AdminReviewCard({ module }: AdminReviewCardProps) {
 
       <p className="text-sm text-gray-600">{module.description}</p>
 
+      <div className="rounded-lg border border-gray-200 bg-gray-50 p-3">
+        <p className="text-xs font-medium text-gray-700">
+          Revision history ({module._count?.revisions ?? 0})
+        </p>
+        {module.revisions && module.revisions.length > 0 ? (
+          <ul className="mt-2 space-y-2">
+            {module.revisions.map((revision, index) => (
+              <li key={revision.id} className="text-xs text-gray-600">
+                <p className="font-medium text-gray-700">
+                  {index === 0 ? "Latest snapshot" : "Previous snapshot"}
+                </p>
+                <p>
+                  {new Date(revision.createdAt).toLocaleString()} · {revision.category.name}
+                </p>
+                <p>{revision.name}</p>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="mt-1 text-xs text-gray-500">No prior revisions yet.</p>
+        )}
+      </div>
+
       <div className="flex gap-2 text-xs">
         <a href={module.repoUrl} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">
           GitHub →

--- a/src/components/resubmit-form.tsx
+++ b/src/components/resubmit-form.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { moduleResubmitSchema } from "@/lib/validations";
+import type { Category } from "@/types";
+
+type ResubmitFormValues = {
+  name: string;
+  description: string;
+  categoryId: string;
+  repoUrl: string;
+  demoUrl: string;
+};
+
+interface ResubmitFormProps {
+  moduleId: string;
+  categories: Category[];
+  initialValues: ResubmitFormValues;
+}
+
+export function ResubmitForm({
+  moduleId,
+  categories,
+  initialValues,
+}: ResubmitFormProps) {
+  const router = useRouter();
+  const [error, setError] = useState<Record<string, string[]>>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError({});
+
+    const data = Object.fromEntries(new FormData(e.currentTarget));
+    const parsed = moduleResubmitSchema.safeParse(data);
+
+    if (!parsed.success) {
+      setError(parsed.error.flatten().fieldErrors as Record<string, string[]>);
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const res = await fetch(`/api/modules/${moduleId}/resubmit`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(parsed.data),
+      });
+
+      if (!res.ok) {
+        const body = await res.json();
+        setError(body.error?.fieldErrors ?? { _: [body.error ?? "Resubmission failed."] });
+        return;
+      }
+
+      router.push("/my-submissions");
+      router.refresh();
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-5">
+      <Field label="Module name" name="name" error={error.name}>
+        <input
+          name="name"
+          type="text"
+          maxLength={60}
+          defaultValue={initialValues.name}
+          className={inputClass}
+        />
+      </Field>
+
+      <Field label="Description" name="description" error={error.description}>
+        <textarea
+          name="description"
+          rows={4}
+          maxLength={500}
+          defaultValue={initialValues.description}
+          className={inputClass}
+        />
+      </Field>
+
+      <Field label="Category" name="categoryId" error={error.categoryId}>
+        <select name="categoryId" className={inputClass} defaultValue={initialValues.categoryId}>
+          {categories.map((category) => (
+            <option key={category.id} value={category.id}>
+              {category.name}
+            </option>
+          ))}
+        </select>
+      </Field>
+
+      <Field label="GitHub repository URL" name="repoUrl" error={error.repoUrl}>
+        <input
+          name="repoUrl"
+          type="url"
+          defaultValue={initialValues.repoUrl}
+          className={inputClass}
+        />
+      </Field>
+
+      <Field label="Demo URL (optional)" name="demoUrl" error={error.demoUrl}>
+        <input
+          name="demoUrl"
+          type="url"
+          defaultValue={initialValues.demoUrl}
+          className={inputClass}
+        />
+      </Field>
+
+      {error._ && <p className="text-sm text-red-600">{error._.join(", ")}</p>}
+
+      <div className="flex gap-2">
+        <Link
+          href="/my-submissions"
+          className="rounded-lg border border-gray-300 px-4 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
+        >
+          Cancel
+        </Link>
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          {isSubmitting ? "Resubmitting..." : "Save and Resubmit"}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+const inputClass =
+  "w-full rounded-lg border border-gray-300 px-3 py-2 text-sm outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500";
+
+function Field({
+  label,
+  name,
+  error,
+  children,
+}: {
+  label: string;
+  name: string;
+  error?: string[];
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <label htmlFor={name} className="block text-sm font-medium text-gray-700">
+        {label}
+      </label>
+      {children}
+      {error && <p className="text-xs text-red-600">{error.join(", ")}</p>}
+    </div>
+  );
+}

--- a/src/lib/module-workflow.test.ts
+++ b/src/lib/module-workflow.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildRevisionSnapshot,
+  canAuthorResubmit,
+  isAuthorOwner,
+} from "@/lib/module-workflow";
+
+describe("module workflow guards", () => {
+  it("allows resubmission only for REJECTED status", () => {
+    expect(canAuthorResubmit("REJECTED")).toBe(true);
+    expect(canAuthorResubmit("PENDING")).toBe(false);
+    expect(canAuthorResubmit("APPROVED")).toBe(false);
+  });
+
+  it("checks ownership by user id", () => {
+    expect(isAuthorOwner("user_1", "user_1")).toBe(true);
+    expect(isAuthorOwner("user_1", "user_2")).toBe(false);
+  });
+});
+
+describe("buildRevisionSnapshot", () => {
+  it("returns immutable revision fields from module source", () => {
+    const snapshot = buildRevisionSnapshot({
+      name: "Original Name",
+      description: "Original description with enough content",
+      repoUrl: "https://github.com/acme/original",
+      demoUrl: "https://demo.example.com",
+      status: "REJECTED",
+      categoryId: "category_1",
+    });
+
+    expect(snapshot).toEqual({
+      name: "Original Name",
+      description: "Original description with enough content",
+      repoUrl: "https://github.com/acme/original",
+      demoUrl: "https://demo.example.com",
+      status: "REJECTED",
+      categoryId: "category_1",
+    });
+  });
+});

--- a/src/lib/module-workflow.ts
+++ b/src/lib/module-workflow.ts
@@ -1,0 +1,29 @@
+import type { SubmissionStatus } from "@prisma/client";
+
+export type ModuleSnapshotSource = {
+  name: string;
+  description: string;
+  repoUrl: string;
+  demoUrl: string | null;
+  status: SubmissionStatus;
+  categoryId: string;
+};
+
+export function canAuthorResubmit(status: SubmissionStatus): boolean {
+  return status === "REJECTED";
+}
+
+export function isAuthorOwner(actorUserId: string, authorId: string): boolean {
+  return actorUserId === authorId;
+}
+
+export function buildRevisionSnapshot(module: ModuleSnapshotSource) {
+  return {
+    name: module.name,
+    description: module.description,
+    repoUrl: module.repoUrl,
+    demoUrl: module.demoUrl,
+    status: module.status,
+    categoryId: module.categoryId,
+  };
+}

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -27,5 +27,8 @@ export const adminReviewSchema = z.object({
   feedback: z.string().max(500).optional(),
 });
 
+export const moduleResubmitSchema = submitModuleSchema;
+
 export type SubmitModuleInput = z.infer<typeof submitModuleSchema>;
 export type AdminReviewInput = z.infer<typeof adminReviewSchema>;
+export type ModuleResubmitInput = z.infer<typeof moduleResubmitSchema>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,11 +1,22 @@
-import type { MiniApp, Category, User, SubmissionStatus } from "@prisma/client";
+import type {
+  MiniApp,
+  Category,
+  User,
+  SubmissionStatus,
+  ModuleRevision,
+} from "@prisma/client";
+
+export type ModuleRevisionWithCategory = ModuleRevision & {
+  category: Pick<Category, "id" | "name" | "slug">;
+};
 
 // "Module" is the UI-facing term for a MiniApp DB record.
 // The naming difference is intentional — keep it consistent.
 export type Module = MiniApp & {
   category: Category;
   author: Pick<User, "id" | "name" | "image">;
-  _count?: { votes: number };
+  revisions?: ModuleRevisionWithCategory[];
+  _count?: { votes?: number; revisions?: number };
   hasVoted?: boolean;
 };
 


### PR DESCRIPTION
 **What does this PR do?**

This PR implements a revision-based resubmission workflow for module submissions.

It allows authors to revise and resubmit only their own rejected submissions, persists immutable revision snapshots for traceability, and adds revision context to admin review so moderators can see what changed between attempts.

**Related Issue**

Closes #26

**Goal**

1. Create a clear improvement loop after a submission is rejected.
2. Enforce strict authorization and valid status transitions.
3. Provide revision context so admin review is more informed.
4. Keep the existing approve/reject flow stable.

 **Implementation Approach**

1. Data model
- Added a `ModuleRevision` model to store immutable snapshots before each resubmission.
- Added relation from `MiniApp` to `revisions`.
- Added index on `moduleId` and `createdAt` for revision timeline queries.

2. Business rules
- Resubmission is allowed only when status is `REJECTED`.
- Only the submission author can resubmit.
- On successful resubmission:
  - A revision snapshot is created from current submission state.
  - Submission status is moved back to `PENDING`.
  - Previous feedback is cleared.

3. API
- `POST /api/modules/[id]/resubmit`
- `GET /api/modules/[id]/revisions`
- Returns explicit status codes for unauthorized, forbidden, invalid transition, and not found cases.

4. UI
- `My Submissions` shows `Revise and resubmit` only for `REJECTED` items.
- Added an edit page for author resubmission.
- Admin review card now shows revision count and latest revision snapshots.

5. Commit structure
1. Schema and migration
2. Validation and workflow guards
3. Resubmit and revisions APIs
4. Revise/resubmit UI flow
5. Admin revision context
6. Tests for guards and API transitions

**How to test**

1. Local setup
- `docker compose up -d`
- `pnpm db:push`
- `pnpm db:seed`
- `pnpm dev`

2. Author flow
- Sign in as a normal user.
- Open `My Submissions`.
- For a `REJECTED` item, verify `Revise and resubmit` is visible.
- Open edit page, update fields, click `Save and Resubmit`.
- Verify the item returns to `PENDING`.

3. API guard checks
- Call resubmit while unauthenticated, expect `401`.
- Call resubmit as non-owner, expect `403`.
- Call resubmit for non-`REJECTED` item, expect `409`.

4. Admin flow
- Sign in as admin.
- Open admin review page.
- Verify pending cards show revision history count and latest snapshots.

5. Quality gates run on this branch
- `pnpm typecheck`: pass
- `pnpm test`: pass
- `pnpm build`: pass

**Screenshots / recordings (if UI change)**

1. `My Submissions` with `Revise and resubmit` action.
2. Edit page for resubmission.
3. Admin review card showing revision context.

 **AI usage**

I used AI through a BA -> DEV -> QC pipeline instead of direct end-to-end code generation.

1. BA stage
- Used AI to refine scope, acceptance criteria, transition rules, and risk points.

2. DEV stage
- Used AI to scaffold implementation incrementally using a focused commit structure.
- Reviewed all generated changes manually before committing.

3. QC stage
- Used AI to run and summarize quality gates.
- Cross-checked outputs against acceptance criteria and regression risk.

I treated AI as an assistant, not as an authority:
- Final technical decisions and trade-offs were made manually.
- Behavior was verified with tests, typecheck, build, and manual UI checks.

**Checklist**

- [x] I read the relevant code before writing my own
- [x] My code follows the existing patterns in the codebase
- [ ] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
- [x] I added or updated tests where applicable
- [x] I can explain every line of code I wrote
- [x] I kept the PR focused with no unrelated feature changes

 **Notes for reviewer**

1. `pnpm typecheck`, `pnpm test`, and `pnpm build` pass on this branch.
2. `pnpm lint` still reports pre-existing baseline issues outside this PR scope.
3. This PR is intentionally scoped to issue #26 only.