### PR TITLE
feat: build contributor leaderboard with ISR

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -106,6 +106,7 @@ model MiniApp {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  @@index([status, createdAt])
   @@map("mini_apps")
 }
 

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+
+export const revalidate = 600;
+
+export async function GET() {
+  const now = new Date();
+  const startOfMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1, 0, 0, 0, 0));
+
+  const stats = await db.miniApp.groupBy({
+    by: ["authorId"],
+    where: {
+      status: "APPROVED",
+      createdAt: { gte: startOfMonth },
+    },
+    _count: { id: true },
+    orderBy: {
+      _count: { id: "desc" },
+    },
+    take: 10,
+  });
+
+  const authorIds = stats.map((s) => s.authorId);
+
+  const users = await db.user.findMany({
+    where: { id: { in: authorIds } },
+    select: { id: true, name: true, image: true },
+  });
+
+  const userMap = new Map(users.map((u) => [u.id, u]));
+
+  const leaderboard = stats.map((s, index) => ({
+    rank: index + 1,
+    authorId: s.authorId,
+    approvedCount: s._count.id,
+    user: userMap.get(s.authorId) || null,
+  }));
+
+  return NextResponse.json(leaderboard);
+}

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -1,0 +1,108 @@
+import { db } from "@/lib/db";
+import Image from "next/image";
+
+export const revalidate = 600;
+
+async function getLeaderboard() {
+  const now = new Date();
+  const startOfMonth = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1, 0, 0, 0, 0)
+  );
+
+  const stats = await db.miniApp.groupBy({
+    by: ["authorId"],
+    where: {
+      status: "APPROVED",
+      createdAt: { gte: startOfMonth },
+    },
+    _count: { id: true },
+    orderBy: {
+      _count: { id: "desc" },
+    },
+    take: 10,
+  });
+
+  const authorIds = stats.map((s) => s.authorId);
+
+  const users = await db.user.findMany({
+    where: { id: { in: authorIds } },
+    select: { id: true, name: true, image: true },
+  });
+
+  const userMap = new Map(users.map((u) => [u.id, u]));
+
+  return stats.map((s, index) => ({
+    rank: index + 1,
+    authorId: s.authorId,
+    approvedCount: s._count.id,
+    user: userMap.get(s.authorId) || null,
+  }));
+}
+
+export default async function LeaderboardPage() {
+  const leaderboard = await getLeaderboard();
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-8 pb-12">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight text-gray-900">
+          Leaderboard
+        </h1>
+        <p className="text-gray-500">
+          Top community contributors for the current calendar month.
+        </p>
+      </div>
+
+      <div className="rounded-xl border border-gray-200 bg-white overflow-hidden shadow-sm">
+        {leaderboard.length === 0 ? (
+          <div className="p-8 text-center text-gray-500">
+            No approved submissions this month yet. Be the first!
+          </div>
+        ) : (
+          <div className="divide-y divide-gray-200">
+            {leaderboard.map((entry) => (
+              <div
+                key={entry.authorId}
+                className="flex items-center justify-between p-4 px-6 hover:bg-gray-50 transition-colors"
+              >
+                <div className="flex items-center gap-4">
+                  <div className="flex h-8 w-8 items-center justify-center font-bold text-gray-400">
+                    #{entry.rank}
+                  </div>
+                  <div className="h-10 w-10 overflow-hidden rounded-full bg-gray-100 flex-shrink-0">
+                    {entry.user?.image ? (
+                      <Image
+                        src={entry.user.image}
+                        alt={entry.user.name || "Avatar"}
+                        width={40}
+                        height={40}
+                        className="object-cover"
+                      />
+                    ) : (
+                      <div className="h-full w-full bg-blue-100 flex items-center justify-center text-blue-600 font-bold">
+                        {entry.user?.name?.charAt(0).toUpperCase() || "?"}
+                      </div>
+                    )}
+                  </div>
+                  <div>
+                    <h3 className="font-semibold text-gray-900">
+                      {entry.user?.name || "Anonymous User"}
+                    </h3>
+                  </div>
+                </div>
+                <div className="text-right">
+                  <div className="text-2xl font-bold text-blue-600">
+                    {entry.approvedCount}
+                  </div>
+                  <div className="text-xs font-medium uppercase tracking-wider text-gray-500">
+                    Approved
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -43,63 +43,91 @@ export default async function LeaderboardPage() {
   const leaderboard = await getLeaderboard();
 
   return (
-    <div className="mx-auto max-w-4xl space-y-8 pb-12">
-      <div className="space-y-2">
-        <h1 className="text-3xl font-bold tracking-tight text-gray-900">
-          Leaderboard
+    <div className="mx-auto max-w-4xl space-y-10 pb-16 pt-8 px-4">
+      <div className="space-y-4 text-center">
+        <h1 className="text-4xl sm:text-5xl font-extrabold tracking-tight text-transparent bg-clip-text bg-gradient-to-r from-blue-600 to-indigo-600 pb-2 drop-shadow-sm">
+          Monthly Leaderboard
         </h1>
-        <p className="text-gray-500">
-          Top community contributors for the current calendar month.
+        <p className="text-gray-500 text-lg max-w-2xl mx-auto leading-relaxed">
+          Honoring the top community contributors who drive our ecosystem forward. The ranking fiercely resets every calendar month.
         </p>
       </div>
 
-      <div className="rounded-xl border border-gray-200 bg-white overflow-hidden shadow-sm">
+      <div className="rounded-3xl border border-gray-100/80 bg-white/60 backdrop-blur-xl overflow-hidden shadow-2xl ring-1 ring-black/5">
         {leaderboard.length === 0 ? (
-          <div className="p-8 text-center text-gray-500">
-            No approved submissions this month yet. Be the first!
+          <div className="p-16 text-center">
+            <div className="inline-flex items-center justify-center w-20 h-20 rounded-full bg-gradient-to-tr from-blue-50 to-indigo-50 mb-6 shadow-inner">
+              <span className="text-3xl">🏆</span>
+            </div>
+            <h3 className="text-xl font-bold text-gray-900">It's quiet in here...</h3>
+            <p className="text-gray-500 mt-2">No approved submissions this month yet. Be the first to claim the #1 spot!</p>
           </div>
         ) : (
-          <div className="divide-y divide-gray-200">
-            {leaderboard.map((entry) => (
-              <div
-                key={entry.authorId}
-                className="flex items-center justify-between p-4 px-6 hover:bg-gray-50 transition-colors"
-              >
-                <div className="flex items-center gap-4">
-                  <div className="flex h-8 w-8 items-center justify-center font-bold text-gray-400">
-                    #{entry.rank}
+          <div className="divide-y divide-gray-100">
+            {leaderboard.map((entry) => {
+              let rankStyle = "text-gray-400 font-medium text-lg";
+              let badgeColor = "bg-gray-100 ring-gray-200 text-gray-500";
+
+              if (entry.rank === 1) {
+                rankStyle = "text-amber-500 font-black text-2xl drop-shadow-md";
+                badgeColor = "bg-gradient-to-br from-amber-200 to-yellow-400 ring-yellow-300 text-yellow-900";
+              } else if (entry.rank === 2) {
+                rankStyle = "text-slate-400 font-black text-2xl drop-shadow-sm";
+                badgeColor = "bg-gradient-to-br from-slate-200 to-gray-300 ring-gray-200 text-gray-800";
+              } else if (entry.rank === 3) {
+                rankStyle = "text-orange-500 font-black text-2xl drop-shadow-sm";
+                badgeColor = "bg-gradient-to-br from-orange-200 to-amber-600 ring-orange-200 text-orange-950";
+              }
+
+              return (
+                <div
+                  key={entry.authorId}
+                  className="group flex flex-col sm:flex-row sm:items-center justify-between p-5 sm:p-7 hover:bg-gradient-to-r hover:from-blue-50/40 hover:to-indigo-50/40 transition-all duration-300 ease-out"
+                >
+                  <div className="flex items-center gap-5 sm:gap-6">
+                    <div className={`flex w-10 justify-center ${rankStyle} transform transition-transform group-hover:scale-110`}>
+                      #{entry.rank}
+                    </div>
+                    
+                    <div className={`relative h-14 w-14 overflow-hidden rounded-full ring-2 ring-offset-2 flex-shrink-0 transition-transform duration-300 group-hover:rotate-3 ${badgeColor}`}>
+                      {entry.user?.image ? (
+                        <Image
+                          src={entry.user.image}
+                          alt={entry.user.name || "Avatar"}
+                          width={56}
+                          height={56}
+                          className="object-cover h-full w-full"
+                        />
+                      ) : (
+                        <div className="h-full w-full flex items-center justify-center font-extrabold text-xl opacity-90">
+                          {entry.user?.name?.charAt(0).toUpperCase() || "?"}
+                        </div>
+                      )}
+                    </div>
+                    
+                    <div className="space-y-0.5">
+                      <h3 className="font-bold text-gray-900 text-lg sm:text-xl group-hover:text-blue-700 transition-colors">
+                        {entry.user?.name || "Anonymous Developer"}
+                      </h3>
+                      {entry.rank === 1 && (
+                        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold bg-amber-100 text-amber-800 border border-amber-200 shadow-sm">
+                          Current Champion 👑
+                        </span>
+                      )}
+                    </div>
                   </div>
-                  <div className="h-10 w-10 overflow-hidden rounded-full bg-gray-100 flex-shrink-0">
-                    {entry.user?.image ? (
-                      <Image
-                        src={entry.user.image}
-                        alt={entry.user.name || "Avatar"}
-                        width={40}
-                        height={40}
-                        className="object-cover"
-                      />
-                    ) : (
-                      <div className="h-full w-full bg-blue-100 flex items-center justify-center text-blue-600 font-bold">
-                        {entry.user?.name?.charAt(0).toUpperCase() || "?"}
-                      </div>
-                    )}
-                  </div>
-                  <div>
-                    <h3 className="font-semibold text-gray-900">
-                      {entry.user?.name || "Anonymous User"}
-                    </h3>
+                  
+                  <div className="text-left sm:text-right flex flex-col items-start sm:items-end mt-4 sm:mt-0 ml-16 sm:ml-0">
+                    <div className="text-3xl sm:text-4xl font-black text-transparent bg-clip-text bg-gradient-to-br from-blue-600 to-violet-600 transform transition-transform duration-300 group-hover:scale-105">
+                      {entry.approvedCount}
+                    </div>
+                    <div className="text-xs font-bold uppercase tracking-widest text-gray-400 mt-1">
+                      Submissions
+                    </div>
                   </div>
                 </div>
-                <div className="text-right">
-                  <div className="text-2xl font-bold text-blue-600">
-                    {entry.approvedCount}
-                  </div>
-                  <div className="text-xs font-medium uppercase tracking-wider text-gray-500">
-                    Submissions
-                  </div>
-                </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         )}
       </div>

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -95,7 +95,7 @@ export default async function LeaderboardPage() {
                     {entry.approvedCount}
                   </div>
                   <div className="text-xs font-medium uppercase tracking-wider text-gray-500">
-                    Approved
+                    Submissions
                   </div>
                 </div>
               </div>

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -109,11 +109,6 @@ export default async function LeaderboardPage() {
                       <h3 className="font-bold text-gray-900 text-lg sm:text-xl group-hover:text-blue-700 transition-colors">
                         {entry.user?.name || "Anonymous Developer"}
                       </h3>
-                      {entry.rank === 1 && (
-                        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold bg-amber-100 text-amber-800 border border-amber-200 shadow-sm">
-                          Current Champion 👑
-                        </span>
-                      )}
                     </div>
                   </div>
                   

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -14,6 +14,9 @@ export function Navbar() {
         </Link>
 
         <div className="flex items-center gap-4">
+          <Link href="/leaderboard" className="text-sm font-medium text-amber-600 hover:text-amber-700">
+            Leaderboard
+          </Link>
           {session ? (
             <>
               <Link href="/submit" className="text-sm text-gray-600 hover:text-gray-900">


### PR DESCRIPTION
## What does this PR do?

Builds the /leaderboard page and a backing API route (/api/leaderboard) to showcase the top 10 most active contributors for the current calendar month, ranked by the number of their APPROVED submissions. I also embedded a link to the Leaderboard in the main header navbar for effortless public access.

## Related Issue

Closes #30 

## How to test

1. Ensure your local server is on and run pnpm db:studio.
2. Find the MiniApp table, then manually edit some submissions to make sure their status is APPROVED and createdAt falls inside the current calendar month. Save the changes.
3. Open http://localhost:3000/leaderboard (or click on Leaderboard from the top navigation).
4. Verify the ranked users, their avatars, and the correct approved summation. (Note: As ISR is active (revalidate = 600), subsequent data modifications won't immediately reflect on hot-reload on production builds, conforming perfectly precisely to the 10-minutes constraint).
## Screenshots / recordings (if UI change)

<!-- Drag and drop a screenshot or screen recording here -->
<img width="1919" height="1031" alt="image" src="https://github.com/user-attachments/assets/694baa48-cfcc-44ae-b230-c52712b0f7f7" />

## Checklist

- [x]  No unrelated visual/layout changes
- [x]  TypeScript types are correct
- [x]  I ran pnpm lint and pnpm typecheck locally
- [x]  I understand why I made each change


## Notes for Reviewer: To address technical constraints upfront:
- N+1 Avoidance: Isolated keys via groupBy, then executed a single db.user.findMany({ id: { in: ... } }) to lazily map user profiles.
- Query Performance: Added @@index([status, createdAt]) into schema.prisma to prevent future table scans during aggregations.
- 00:01 UTC Rollover: Month boundaries rely entirely on absolute Date.UTC(). Once 00:01 hits, the Next.js ISR cache (revalidate = 600) will gracefully drop within 10 minutes max, autonomously generating a fresh leaderboard in the background.