### PR TITLE
test: implement comprehensive unit tests for core utilities (Easy Cha…

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { generateSlug, makeUniqueSlug, formatRelativeTime } from "@/lib/utils";
 
 // ============================================================
@@ -22,14 +22,21 @@ describe("generateSlug", () => {
     expect(generateSlug("a   b   c")).toBe("a-b-c");
   });
 
-  // TODO [easy-challenge]: Add test cases for the following:
-  // 1. A name that is already a valid slug (no changes needed)
-  // 2. A name with numbers (numbers should be preserved)
-  // 3. An empty string (what should the output be? Check the implementation)
-  // 4. A name with leading/trailing hyphens after special char removal
-  //
-  // Hint: read `src/lib/utils.ts` to understand the exact transformation rules
-  // before writing your assertions.
+  it("preserves a valid slug", () => {
+    expect(generateSlug("valid-slug-already")).toBe("valid-slug-already");
+  });
+
+  it("preserves numbers within the name", () => {
+    expect(generateSlug("App Version 2.0")).toBe("app-version-20");
+  });
+
+  it("returns an empty string when provided an empty string", () => {
+    expect(generateSlug("")).toBe("");
+  });
+
+  it("removes leading/trailing hyphens after special char removal", () => {
+    expect(generateSlug("!Hello World!")).toBe("hello-world");
+  });
 });
 
 // ============================================================
@@ -49,23 +56,51 @@ describe("makeUniqueSlug", () => {
     expect(makeUniqueSlug("my-app", ["my-app", "my-app-1"])).toBe("my-app-2");
   });
 
-  // TODO [easy-challenge]: Add test cases for:
-  // 1. When many suffixed versions already exist (e.g. -1 through -5)
-  // 2. When the existing list contains similar but non-conflicting slugs
-  //    e.g. existing = ["my-app-tool"] should NOT block "my-app"
+  it("handles when many suffixed versions already exist", () => {
+    expect(makeUniqueSlug("my-app", ["my-app", "my-app-1", "my-app-2", "my-app-3", "my-app-4", "my-app-5"])).toBe("my-app-6");
+  });
+
+  it("does not block if existing list contains similar but non-conflicting slugs", () => {
+    expect(makeUniqueSlug("my-app", ["my-app-tool"])).toBe("my-app");
+  });
 });
 
 // ============================================================
-// formatRelativeTime — NOT yet tested, candidate must write all tests
+// formatRelativeTime
 // ============================================================
 
-// TODO [easy-challenge]: Write a full test suite for `formatRelativeTime`.
-// Requirements:
-// - "just now" for dates less than 1 minute ago
-// - "{n}m ago" for dates 1–59 minutes ago
-// - "{n}h ago" for dates 1–23 hours ago
-// - "{n}d ago" for dates 1–29 days ago
-// - toLocaleDateString() format for dates 30+ days ago
-//
-// Hint: You'll need to mock or control `Date.now()` to make these tests
-// deterministic. Look into Vitest's `vi.setSystemTime()`.
+describe("formatRelativeTime", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-01T12:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns "just now" for dates less than 1 minute ago', () => {
+    const date = new Date("2024-01-01T11:59:30.000Z"); // 30 seconds ago
+    expect(formatRelativeTime(date)).toBe("just now");
+  });
+
+  it('returns "{n}m ago" for dates 1–59 minutes ago', () => {
+    const date = new Date("2024-01-01T11:30:00.000Z"); // 30 minutes ago
+    expect(formatRelativeTime(date)).toBe("30m ago");
+  });
+
+  it('returns "{n}h ago" for dates 1–23 hours ago', () => {
+    const date = new Date("2024-01-01T07:00:00.000Z"); // 5 hours ago
+    expect(formatRelativeTime(date)).toBe("5h ago");
+  });
+
+  it('returns "{n}d ago" for dates 1–29 days ago', () => {
+    const date = new Date("2023-12-20T12:00:00.000Z"); // 12 days ago
+    expect(formatRelativeTime(date)).toBe("12d ago");
+  });
+
+  it("returns toLocaleDateString() format for dates 30+ days ago", () => {
+    const date = new Date("2023-11-01T12:00:00.000Z"); // 61 days ago
+    expect(formatRelativeTime(date)).toBe(date.toLocaleDateString());
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Bổ sung toàn bộ unit tests (hoàn thành yêu cầu TODO của `easy-challenge`) cho các logic cấu lõi trong file [src/lib/utils.ts](cci:7://file:///d:/Project/intern-community-master/src/lib/utils.ts:0:0-0:0). 

- **Mục tiêu:** Tăng test coverage cho các hàm quản trị logic quan trọng là [generateSlug](cci:1://file:///d:/Project/intern-community-master/src/lib/utils.ts:7:0-28:1), [makeUniqueSlug](cci:1://file:///d:/Project/intern-community-master/src/lib/utils.ts:30:0-40:1), [formatRelativeTime](cci:1://file:///d:/Project/intern-community-master/src/lib/utils.ts:42:0-52:1) và đảm bảo tính ổn định vững chắc mỗi khi dự án được mở rộng sau này.
- **Cách sử dụng AI:** Mình sử dụng AI (Assistant) để tra cứu tìm ra test case mang tính thực tiễn cao nhất, đồng thời đề xuất sử dụng cơ chế `vi.useFakeTimers()` của Vitest nhằm fix cứng giả lập thời gian, chống lỗi logic đồng hồ thực khi chạy test đa môi trường. Mọi đoạn code sinh ra đều được mình tự kiểm chứng trước khi đưa vào code.

## Related Issue

Closes # <>

## How to test

1. Chạy cài đặt môi trường nếu cần thiết: `pnpm install`
2. Kích hoạt toàn bộ bộ test thông qua lệnh: `npx vitest run` hoặc `pnpm test`
3. Đảm bảo toàn bộ 18 test cases của file [utils.test.ts](cci:7://file:///d:/Project/intern-community/__tests__/utils.test.ts:0:0-0:0) (bao gồm các cases cơ bản cũ và các edge cases cấu hình mới) đều báo xanh (`Passed`).

## Screenshots / recordings (if UI change)

*(PR này tập trung vào xử lý logic backend test, không thay đổi về giao diện nên không có screenshot)*

## Checklist

- [x] I read the relevant code **before** writing my own
- [x] My code follows the existing patterns in the codebase
- [x] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
- [x] I added or updated tests where applicable
- [x] I can explain every line of code I wrote (reviewer will ask)
- [x] I kept the PR focused — no unrelated changes

## Notes for reviewer

**Ghi chú:** Logic khó chịu nhất nằm ở hàm [formatRelativeTime](cci:1://file:///d:/Project/intern-community-master/src/lib/utils.ts:42:0-52:1) vì nó trực tiếp đối chiếu với `Date.now()`. Mình đã quyết định sử dụng Vitest Fake Timers để khóa lại bộ đếm thay vì thay đổi parameter của hàm gốc, mục tiêu nhằm bảo toàn tính nguyên vẹn của luồng ứng dụng thực tế (Production).
