### PR TITLE
feat: add back to top button (#37)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist } from "next/font/google";
 import "./globals.css";
 import { Navbar } from "@/components/navbar";
 import { AuthSessionProvider } from "@/components/session-provider";
+import { BackToTop } from "@/components/back-to-top";
 
 const geist = Geist({ subsets: ["latin"], variable: "--font-geist" });
 
@@ -12,7 +13,11 @@ export const metadata: Metadata = {
     "An open platform for the TD developer community to submit and discover mini-app modules.",
 };
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   return (
     <html lang="en" className={`${geist.variable} h-full antialiased`}>
       <body className="flex min-h-full flex-col bg-gray-50 font-sans">
@@ -21,6 +26,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <main className="mx-auto w-full max-w-5xl flex-1 px-4 py-8">
             {children}
           </main>
+          <BackToTop />
         </AuthSessionProvider>
       </body>
     </html>

--- a/src/components/back-to-top.tsx
+++ b/src/components/back-to-top.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const cn = (...classes: string[]) => classes.filter(Boolean).join(" ");
+
+export function BackToTop() {
+    const [visible, setVisible] = useState(false);
+
+    useEffect(() => {
+        const onScroll = () => setVisible(window.scrollY > 10);
+        window.addEventListener("scroll", onScroll, { passive: true });
+
+        return () => window.removeEventListener("scroll", onScroll);
+    }, []);
+
+    return (
+        <button
+            onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+            aria-label="Back to top"
+            className={cn(
+                "fixed bottom-6 right-6 z-50",
+                "rounded-full w-10 h-10",
+                "bg-gray-900 text-white shadow-lg",
+                "flex items-center justify-center",
+                "hover:bg-gray-700 hover:-translate-y-0.5 hover:shadow-xl",
+                "transition-all duration-200",
+                visible
+                    ? "opacity-100 pointer-events-auto translate-y-0"
+                    : "opacity-0 pointer-events-none translate-y-2"
+            )}
+        >
+            <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            >
+                <path d="M18 15l-6-6-6 6" />
+            </svg>
+        </button>
+    );
+}


### PR DESCRIPTION
## Task description
The browse page can get long when there are many modules loaded. 
Users currently have no way to quickly return to the top without manually scrolling back up.

## Acceptance criteria
- [ ] A "Back to top" button appears when the user scrolls down more than 300px
- [ ] Clicking it smoothly scrolls back to the top of the page
- [ ] Button is hidden when the user is already at the top
- [ ] Button has proper `aria-label` for accessibility
- [ ] No new dependencies introduced
- [ ] No layout shift or flickering when button appears/disappears

## Files to modify
- `src/components/back-to-top.tsx` ← **create this new file**
- `src/app/layout.tsx` ← add `<BackToTop />` before `</body>`

## Hints
- Use `window.scrollY` inside a scroll event listener to track position
- `window.scrollTo({ top: 0, behavior: "smooth" })` for smooth scroll
- Use `opacity-0 pointer-events-none` / `opacity-100` with CSS transition for fade effect instead of conditional rendering — smoother animation
- Clean up your event listener in `useEffect` return callback

## Estimated time
1–2 hours

## Difficulty
🟢 Easy