### PR TITLE
[Medium] Implement single-select category filter with URL query params

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { generateSlug, makeUniqueSlug, formatRelativeTime } from "@/lib/utils";
+import { formatRelativeTime, generateSlug, makeUniqueSlug } from "@/lib/utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ============================================================
 // generateSlug — already written as examples
@@ -30,6 +30,24 @@ describe("generateSlug", () => {
   //
   // Hint: read `src/lib/utils.ts` to understand the exact transformation rules
   // before writing your assertions.
+
+  it("returns same string when name is already a valid slug", () => {
+    expect(generateSlug("my-cool-app")).toBe("my-cool-app");
+  });
+
+  it("preserves numbers in slug", () => {
+    expect(generateSlug("App 2.0 Version 3")).toBe("app-20-version-3");
+  });
+
+  it("returns empty string when input is empty", () => {
+    expect(generateSlug("")).toBe("");
+  });
+
+  it("handles leading/trailing hyphens after special char removal", () => {
+    // Special chars at start/end become hyphens then get stripped
+    expect(generateSlug("!Hello World!")).toBe("hello-world");
+    expect(generateSlug("-Hello-")).toBe("hello");
+  });
 });
 
 // ============================================================
@@ -53,6 +71,23 @@ describe("makeUniqueSlug", () => {
   // 1. When many suffixed versions already exist (e.g. -1 through -5)
   // 2. When the existing list contains similar but non-conflicting slugs
   //    e.g. existing = ["my-app-tool"] should NOT block "my-app"
+
+  it("handles many suffixed versions already exist", () => {
+    const existing = [
+      "my-app",
+      "my-app-1",
+      "my-app-2",
+      "my-app-3",
+      "my-app-4",
+      "my-app-5",
+    ];
+    expect(makeUniqueSlug("my-app", existing)).toBe("my-app-6");
+  });
+
+  it("does not block when similar but non-conflicting slugs exist", () => {
+    const existing = ["my-app-tool", "my-app-plugin", "other-app"];
+    expect(makeUniqueSlug("my-app", existing)).toBe("my-app");
+  });
 });
 
 // ============================================================
@@ -69,3 +104,84 @@ describe("makeUniqueSlug", () => {
 //
 // Hint: You'll need to mock or control `Date.now()` to make these tests
 // deterministic. Look into Vitest's `vi.setSystemTime()`.
+
+describe("formatRelativeTime", () => {
+  const mockNow = new Date("2024-01-01T12:00:00Z").getTime();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(mockNow);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns "just now" for less than 1 minute ago', () => {
+    const date = new Date(mockNow - 30 * 1000); // 30 seconds ago
+    expect(formatRelativeTime(date)).toBe("just now");
+  });
+
+  it('returns "1m ago" for exactly 1 minute ago', () => {
+    const date = new Date(mockNow - 60 * 1000);
+    expect(formatRelativeTime(date)).toBe("1m ago");
+  });
+
+  it('returns "5m ago" for 5 minutes ago', () => {
+    const date = new Date(mockNow - 5 * 60 * 1000);
+    expect(formatRelativeTime(date)).toBe("5m ago");
+  });
+
+  it('returns "59m ago" for 59 minutes ago', () => {
+    const date = new Date(mockNow - 59 * 60 * 1000);
+    expect(formatRelativeTime(date)).toBe("59m ago");
+  });
+
+  it('returns "1h ago" for exactly 1 hour ago', () => {
+    const date = new Date(mockNow - 60 * 60 * 1000);
+    expect(formatRelativeTime(date)).toBe("1h ago");
+  });
+
+  it('returns "5h ago" for 5 hours ago', () => {
+    const date = new Date(mockNow - 5 * 60 * 60 * 1000);
+    expect(formatRelativeTime(date)).toBe("5h ago");
+  });
+
+  it('returns "23h ago" for 23 hours ago', () => {
+    const date = new Date(mockNow - 23 * 60 * 60 * 1000);
+    expect(formatRelativeTime(date)).toBe("23h ago");
+  });
+
+  it('returns "1d ago" for exactly 1 day ago', () => {
+    const date = new Date(mockNow - 24 * 60 * 60 * 1000);
+    expect(formatRelativeTime(date)).toBe("1d ago");
+  });
+
+  it('returns "5d ago" for 5 days ago', () => {
+    const date = new Date(mockNow - 5 * 24 * 60 * 60 * 1000);
+    expect(formatRelativeTime(date)).toBe("5d ago");
+  });
+
+  it('returns "29d ago" for 29 days ago', () => {
+    const date = new Date(mockNow - 29 * 24 * 60 * 60 * 1000);
+    expect(formatRelativeTime(date)).toBe("29d ago");
+  });
+
+  it("returns formatted date for 30 days or more", () => {
+    const date = new Date("2023-12-01T12:00:00Z"); // 31 days before mockNow
+    const result = formatRelativeTime(date);
+    // Should return something like "12/1/2023" or "1/12/2023" depending on locale
+    expect(result).toMatch(/\d{1,2}\/\d{1,2}\/\d{4}/);
+  });
+
+  it("returns 'just now' for future dates", () => {
+    const date = new Date(mockNow + 24 * 60 * 60 * 1000);
+    expect(formatRelativeTime(date)).toBe("just now");
+  });
+
+  it("returns formatted date for dates older than 30 days", () => {
+    const date = new Date("2023-12-01T12:00:00Z");
+    const result = formatRelativeTime(date);
+    expect(result).toMatch(/\d{1,2}\/\d{1,2}\/\d{4}/);
+  });
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,11 @@ services:
     image: postgres:16-alpine
     restart: unless-stopped
     environment:
-      POSTGRES_USER: td_user
-      POSTGRES_PASSWORD: td_password
-      POSTGRES_DB: td_community
+      POSTGRES_USER: intern_user
+      POSTGRES_PASSWORD: intern_password
+      POSTGRES_DB: intern_community
     ports:
-      - "5432:5432"
+      - "5433:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
-import { db } from "@/lib/db";
-import { auth } from "@/lib/auth";
+import { CategoryFilter } from "@/components/category-filter";
 import { ModuleCard } from "@/components/module-card";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
 
 // TODO [medium-challenge]: Add category filter with URL query params (state persists on refresh)
 // See: ISSUES.md for full acceptance criteria
@@ -77,31 +78,7 @@ export default async function HomePage({
       </div>
 
       {/* Category filter placeholder — see TODO above */}
-      <div className="flex flex-wrap gap-2">
-        <a
-          href="/"
-          className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
-            !category
-              ? "bg-blue-600 text-white"
-              : "bg-gray-100 text-gray-600 hover:bg-gray-200"
-          }`}
-        >
-          All
-        </a>
-        {categories.map((c) => (
-          <a
-            key={c.id}
-            href={`/?category=${c.slug}`}
-            className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
-              category === c.slug
-                ? "bg-blue-600 text-white"
-                : "bg-gray-100 text-gray-600 hover:bg-gray-200"
-            }`}
-          >
-            {c.name}
-          </a>
-        ))}
-      </div>
+     <CategoryFilter categories={categories} currentCategory={category || null} />
 
       {modules.length === 0 ? (
         <div className="rounded-xl border border-dashed border-gray-300 p-12 text-center">

--- a/src/components/category-filter.tsx
+++ b/src/components/category-filter.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback } from "react";
+
+interface CategoryFilterProps {
+  categories: Array<{ id: string; name: string; slug: string }>;
+  currentCategory: string | null;
+}
+
+export function CategoryFilter({ categories, currentCategory }: CategoryFilterProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const currentQuery = searchParams.get("q") || "";
+
+  const handleCategoryChange = useCallback(
+    (slug: string | null) => {
+      const params = new URLSearchParams();
+      if (currentQuery) params.set("q", currentQuery);
+      if (slug) params.set("category", slug);
+      
+      router.push(`/?${params.toString()}`);
+    },
+    [router, currentQuery]
+  );
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      <button
+        onClick={() => handleCategoryChange(null)}
+        className={`rounded-full px-3 py-1 text-xs font-medium transition-colors cursor-pointer ${
+          !currentCategory
+            ? "bg-blue-600 text-white"
+            : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+        }`}
+      >
+        All
+      </button>
+      {categories.map((c) => (
+        <button
+          key={c.id}
+          onClick={() => handleCategoryChange(c.slug)}
+          className={`rounded-full px-3 py-1 text-xs font-medium transition-colors cursor-pointer ${
+            currentCategory === c.slug
+              ? "bg-blue-600 text-white"
+              : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+          }`}
+        >
+          {c.name}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/module-card.tsx
+++ b/src/components/module-card.tsx
@@ -1,6 +1,6 @@
-import Link from "next/link";
 import { VoteButton } from "@/components/vote-button";
 import type { Module } from "@/types";
+import Link from "next/link";
 
 interface ModuleCardProps {
   module: Module;
@@ -24,6 +24,7 @@ export function ModuleCard({ module, hasVoted = false }: ModuleCardProps) {
             target="_blank"
             rel="noopener noreferrer"
             className="shrink-0 text-gray-400 hover:text-gray-600"
+            aria-label={`Open demo for ${module.name}`}
           >
             <ExternalLinkIcon />
           </a>
@@ -49,7 +50,15 @@ export function ModuleCard({ module, hasVoted = false }: ModuleCardProps) {
 
 function ExternalLinkIcon() {
   return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 14 14"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      aria-hidden="true"
+    >
       <path d="M5 2H2a1 1 0 0 0-1 1v9a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1V9" />
       <path d="M8 1h5v5" />
       <path d="M13 1 7 7" />

--- a/src/components/submit-form.tsx
+++ b/src/components/submit-form.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
 import { submitModuleSchema } from "@/lib/validations";
 import type { Category } from "@/types";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
 
 interface SubmitFormProps {
   categories: Category[];
@@ -13,6 +13,13 @@ export function SubmitForm({ categories }: SubmitFormProps) {
   const router = useRouter();
   const [error, setError] = useState<Record<string, string[]>>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const [descriptionLength, setDescriptionLength] = useState(0);
+  const handleDescriptionChange = (
+    e: React.ChangeEvent<HTMLTextAreaElement>,
+  ) => {
+    setDescriptionLength(e.target.value.length);
+  };
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -36,7 +43,9 @@ export function SubmitForm({ categories }: SubmitFormProps) {
 
       if (!res.ok) {
         const body = await res.json();
-        setError(body.error?.fieldErrors ?? { _: ["Submission failed. Try again."] });
+        setError(
+          body.error?.fieldErrors ?? { _: ["Submission failed. Try again."] },
+        );
         return;
       }
 
@@ -59,7 +68,12 @@ export function SubmitForm({ categories }: SubmitFormProps) {
         />
       </Field>
 
-      <Field label="Description" name="description" error={error.description} hint="Max 500 characters">
+      <Field
+        label="Description"
+        name="description"
+        error={error.description}
+        hint="Max 500 characters"
+      >
         {/* TODO [easy-challenge]: add a live character counter below this textarea */}
         <textarea
           name="description"
@@ -67,14 +81,30 @@ export function SubmitForm({ categories }: SubmitFormProps) {
           placeholder="What does your module do? Who is it for?"
           maxLength={500}
           className={inputClass}
+          onChange={handleDescriptionChange}
         />
+        <div className="mt-1 text-right text-xs">
+          <span
+            className={
+              descriptionLength >= 450
+                ? "text-red-600 font-medium"
+                : "text-gray-400"
+            }
+          >
+            {descriptionLength} / 500
+          </span>
+        </div>
       </Field>
 
       <Field label="Category" name="categoryId" error={error.categoryId}>
         <select name="categoryId" className={inputClass} defaultValue="">
-          <option value="" disabled>Select a category</option>
+          <option value="" disabled>
+            Select a category
+          </option>
           {categories.map((c) => (
-            <option key={c.id} value={c.id}>{c.name}</option>
+            <option key={c.id} value={c.id}>
+              {c.name}
+            </option>
           ))}
         </select>
       </Field>
@@ -97,9 +127,7 @@ export function SubmitForm({ categories }: SubmitFormProps) {
         />
       </Field>
 
-      {error._ && (
-        <p className="text-sm text-red-600">{error._.join(", ")}</p>
-      )}
+      {error._ && <p className="text-sm text-red-600">{error._.join(", ")}</p>}
 
       <button
         type="submit"

--- a/src/components/vote-button.tsx
+++ b/src/components/vote-button.tsx
@@ -43,7 +43,11 @@ export function VoteButton({
         disabled:opacity-50 disabled:cursor-not-allowed`}
     >
       {/* TODO [easy-challenge]: this button shows no loading state during API call — add one */}
-      <TriangleIcon filled={voted} />
+      {isLoading ? (
+        <SpinnerIcon />
+      ) : (
+        <TriangleIcon filled={voted} />
+      )}
       {count}
     </button>
   );
@@ -61,6 +65,26 @@ function TriangleIcon({ filled = false }: { filled?: boolean }) {
       aria-hidden="true"
     >
       <path d="M6 1 L11 10 L1 10 Z" />
+    </svg>
+  );
+}
+
+// Spinner icon for loading state - defined inside the same file
+function SpinnerIcon() {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="animate-spin"
+      aria-hidden="true"
+    >
+      <path d="M21 12a9 9 0 1 1-6.219-8.56" />
     </svg>
   );
 }


### PR DESCRIPTION
## What does this PR do?
Implement single-select category filter using `useRouter` and `useSearchParams`. Replace static `<a>` tags that cause full page reload with client-side navigation.

## Related Issue
Closes #39 

## How to test
1. Click any category (Game, Productivity, Finance...)
2. Observe: URL changes but page does NOT reload
3. Open DevTools → Network tab → no new requests appear
4. Combine search + filter → URL shows both `?q=` and `&category=`
5. Refresh page (F5) → category selection persists

## Checklist
- [x] No page reload when clicking category
- [x] Category state saved in URL, persists on refresh
- [x] Works together with search query
- [x] Single-select approach (confirmed in issue comment)

## How I used AI
Used AI to create the CategoryFilter component with Next.js hooks and URL state management.