### PR TITLE
feat: implement multi-select category filter and fix optimistic vote …

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -38,8 +38,8 @@ export default async function AdminPage() {
           <p className="text-sm text-gray-400">No pending submissions. 🎉</p>
         ) : (
           <div className="grid gap-4 sm:grid-cols-2">
-            {pending.map((module) => (
-              <AdminReviewCard key={module.id} module={module} />
+            {pending.map((item) => (
+              <AdminReviewCard key={item.id} module={item} />
             ))}
           </div>
         )}
@@ -48,20 +48,20 @@ export default async function AdminPage() {
       <section className="space-y-4">
         <h2 className="text-lg font-semibold text-gray-700">Recently Reviewed</h2>
         <div className="space-y-2">
-          {recentlyReviewed.map((module) => (
+          {recentlyReviewed.map((item) => (
             <div
-              key={module.id}
+              key={item.id}
               className="flex items-center justify-between rounded-lg border border-gray-200 bg-white px-4 py-3"
             >
-              <span className="text-sm font-medium text-gray-800">{module.name}</span>
+              <span className="text-sm font-medium text-gray-800">{item.name}</span>
               <span
                 className={`rounded-full px-2 py-0.5 text-xs font-medium ${
-                  module.status === "APPROVED"
+                  item.status === "APPROVED"
                     ? "bg-green-50 text-green-700"
                     : "bg-red-50 text-red-700"
                 }`}
               >
-                {module.status}
+                {item.status}
               </span>
             </div>
           ))}

--- a/src/app/api/modules/[id]/route.ts
+++ b/src/app/api/modules/[id]/route.ts
@@ -8,7 +8,7 @@ type Params = { params: Promise<{ id: string }> };
 // GET /api/modules/[id]
 export async function GET(_req: NextRequest, { params }: Params) {
   const { id } = await params;
-  const module = await db.miniApp.findUnique({
+  const item = await db.miniApp.findUnique({
     where: { id },
     include: {
       category: true,
@@ -16,8 +16,8 @@ export async function GET(_req: NextRequest, { params }: Params) {
       _count: { select: { votes: true } },
     },
   });
-  if (!module) return NextResponse.json({ error: "Not found" }, { status: 404 });
-  return NextResponse.json(module);
+  if (!item) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  return NextResponse.json(item);
 }
 
 // PATCH /api/modules/[id] — admin approve/reject
@@ -53,10 +53,10 @@ export async function DELETE(_req: NextRequest, { params }: Params) {
   }
 
   const { id } = await params;
-  const module = await db.miniApp.findUnique({ where: { id } });
-  if (!module) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  const item = await db.miniApp.findUnique({ where: { id } });
+  if (!item) return NextResponse.json({ error: "Not found" }, { status: 404 });
 
-  if (module.authorId !== session.user.id && !session.user.isAdmin) {
+  if (item.authorId !== session.user.id && !session.user.isAdmin) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/src/app/api/modules/route.ts
+++ b/src/app/api/modules/route.ts
@@ -64,10 +64,10 @@ export async function POST(req: NextRequest) {
   const baseSlug = generateSlug(name);
   const existingSlugs = await db.miniApp
     .findMany({ where: { slug: { startsWith: baseSlug } }, select: { slug: true } })
-    .then((r) => r.map((m) => m.slug));
+    .then((r) => r.map((item) => item.slug));
   const slug = makeUniqueSlug(baseSlug, existingSlugs);
 
-  const module = await db.miniApp.create({
+  const createdItem = await db.miniApp.create({
     data: {
       slug,
       name,
@@ -80,5 +80,5 @@ export async function POST(req: NextRequest) {
     },
   });
 
-  return NextResponse.json(module, { status: 201 });
+  return NextResponse.json(createdItem, { status: 201 });
 }

--- a/src/app/modules/[slug]/page.tsx
+++ b/src/app/modules/[slug]/page.tsx
@@ -8,15 +8,15 @@ type Props = { params: Promise<{ slug: string }> };
 
 export async function generateMetadata({ params }: Props) {
   const { slug } = await params;
-  const module = await db.miniApp.findUnique({ where: { slug } });
-  return { title: module ? `${module.name} — Intern Community Hub` : "Not Found" };
+  const item = await db.miniApp.findUnique({ where: { slug } });
+  return { title: item ? `${item.name} — Intern Community Hub` : "Not Found" };
 }
 
 export default async function ModuleDetailPage({ params }: Props) {
   const { slug } = await params;
   const session = await auth();
 
-  const module = await db.miniApp.findUnique({
+  const item = await db.miniApp.findUnique({
     where: { slug, status: "APPROVED" },
     include: {
       category: true,
@@ -24,13 +24,13 @@ export default async function ModuleDetailPage({ params }: Props) {
     },
   });
 
-  if (!module) notFound();
+  if (!item) notFound();
 
   let hasVoted = false;
   if (session?.user) {
     const vote = await db.vote.findUnique({
       where: {
-        userId_moduleId: { userId: session.user.id, moduleId: module.id },
+        userId_moduleId: { userId: session.user.id, moduleId: item.id },
       },
     });
     hasVoted = !!vote;
@@ -44,32 +44,32 @@ export default async function ModuleDetailPage({ params }: Props) {
 
       <div className="space-y-2">
         <div className="flex items-start justify-between gap-4">
-          <h1 className="text-2xl font-bold text-gray-900">{module.name}</h1>
+          <h1 className="text-2xl font-bold text-gray-900">{item.name}</h1>
           <VoteButton
-            moduleId={module.id}
+            moduleId={item.id}
             initialVoted={hasVoted}
-            initialCount={module.voteCount}
+            initialCount={item.voteCount}
           />
         </div>
         <p className="text-sm text-gray-500">
-          by {module.author.name} · {module.category.name}
+          by {item.author.name} · {item.category.name}
         </p>
       </div>
 
-      <p className="text-gray-700">{module.description}</p>
+      <p className="text-gray-700">{item.description}</p>
 
       <div className="flex gap-3">
         <a
-          href={module.repoUrl}
+          href={item.repoUrl}
           target="_blank"
           rel="noopener noreferrer"
           className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
         >
           View on GitHub
         </a>
-        {module.demoUrl && (
+        {item.demoUrl && (
           <a
-            href={module.demoUrl}
+            href={item.demoUrl}
             target="_blank"
             rel="noopener noreferrer"
             className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
@@ -81,12 +81,12 @@ export default async function ModuleDetailPage({ params }: Props) {
 
       {/* TODO [hard-challenge]: Implement sandboxed iframe preview here.
           Requirements:
-          - Only show if module.demoUrl exists
+          - Only show if item.demoUrl exists
           - Use sandbox="allow-scripts allow-same-origin" at minimum
           - Add Content-Security-Policy header for the iframe origin
           - Show a loading skeleton while the iframe loads
           See: ISSUES.md for full acceptance criteria */}
-      {module.demoUrl && (
+      {item.demoUrl && (
         <div className="rounded-xl border border-dashed border-gray-300 p-8 text-center text-sm text-gray-400">
           Sandboxed preview coming soon. Contribute this feature! See{" "}
           <Link href="https://github.com" className="text-blue-600 hover:underline">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,8 @@
 import { db } from "@/lib/db";
 import { auth } from "@/lib/auth";
 import { ModuleCard } from "@/components/module-card";
+import { CategoryFilter } from "@/components/category-filter";
+import Link from "next/link";
 
 // TODO [medium-challenge]: Add category filter with URL query params (state persists on refresh)
 // See: ISSUES.md for full acceptance criteria
@@ -8,15 +10,16 @@ import { ModuleCard } from "@/components/module-card";
 export default async function HomePage({
   searchParams,
 }: {
-  searchParams: Promise<{ q?: string; category?: string }>;
+  searchParams: Promise<{ q?: string; category?: string | string[] }>;
 }) {
   const { q, category } = await searchParams;
+  const categoryArray = [category].flat().filter(Boolean) as string[];
   const session = await auth();
 
   const modules = await db.miniApp.findMany({
     where: {
       status: "APPROVED",
-      ...(category ? { category: { slug: category } } : {}),
+      ...(categoryArray.length > 0 ? { category: { slug: { in: categoryArray } } } : {}),
       ...(q
         ? {
             OR: [
@@ -77,48 +80,24 @@ export default async function HomePage({
       </div>
 
       {/* Category filter placeholder — see TODO above */}
-      <div className="flex flex-wrap gap-2">
-        <a
-          href="/"
-          className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
-            !category
-              ? "bg-blue-600 text-white"
-              : "bg-gray-100 text-gray-600 hover:bg-gray-200"
-          }`}
-        >
-          All
-        </a>
-        {categories.map((c) => (
-          <a
-            key={c.id}
-            href={`/?category=${c.slug}`}
-            className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
-              category === c.slug
-                ? "bg-blue-600 text-white"
-                : "bg-gray-100 text-gray-600 hover:bg-gray-200"
-            }`}
-          >
-            {c.name}
-          </a>
-        ))}
-      </div>
+      <CategoryFilter categories={categories} />
 
       {modules.length === 0 ? (
         <div className="rounded-xl border border-dashed border-gray-300 p-12 text-center">
           <p className="text-gray-500">No modules found.</p>
           {q && (
-            <a href="/" className="mt-2 block text-sm text-blue-600 hover:underline">
+            <Link href="/" className="mt-2 block text-sm text-blue-600 hover:underline">
               Clear search
-            </a>
+            </Link>
           )}
         </div>
       ) : (
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {modules.map((module) => (
+          {modules.map((item) => (
             <ModuleCard
-              key={module.id}
-              module={module}
-              hasVoted={votedIds.has(module.id)}
+              key={item.id}
+              module={item}
+              hasVoted={votedIds.has(item.id)}
             />
           ))}
         </div>

--- a/src/components/category-filter.tsx
+++ b/src/components/category-filter.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback } from "react";
+
+interface Category {
+  id: string;
+  name: string;
+  slug: string;
+}
+
+export function CategoryFilter({ categories }: { categories: Category[] }) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  
+  const selectedCategories = searchParams.getAll("category");
+
+  const toggleCategory = useCallback((slug: string) => {
+    const newParams = new URLSearchParams(searchParams.toString());
+    const current = newParams.getAll("category");
+    
+    newParams.delete("category");
+    
+    if (current.includes(slug)) {
+      const next = current.filter(c => c !== slug);
+      next.forEach(c => newParams.append("category", c));
+    } else {
+      current.forEach(c => newParams.append("category", c));
+      newParams.append("category", slug);
+    }
+    
+    router.push("/?" + newParams.toString(), { scroll: false });
+  }, [router, searchParams]);
+
+  const clearCategories = useCallback(() => {
+    const newParams = new URLSearchParams(searchParams.toString());
+    newParams.delete("category");
+    router.push("/?" + newParams.toString(), { scroll: false });
+  }, [router, searchParams]);
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      <button
+        type="button"
+        onClick={clearCategories}
+        className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+          selectedCategories.length === 0
+            ? "bg-blue-600 text-white"
+            : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+        }`}
+      >
+        All
+      </button>
+      {categories.map((c) => {
+        const isSelected = selectedCategories.includes(c.slug);
+        return (
+          <button
+            key={c.id}
+            type="button"
+            onClick={() => toggleCategory(c.slug)}
+            className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+              isSelected
+                ? "bg-blue-600 text-white"
+                : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+            }`}
+          >
+            {c.name}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/vote-button.tsx
+++ b/src/components/vote-button.tsx
@@ -43,9 +43,33 @@ export function VoteButton({
         disabled:opacity-50 disabled:cursor-not-allowed`}
     >
       {/* TODO [easy-challenge]: this button shows no loading state during API call — add one */}
-      <TriangleIcon filled={voted} />
+      {isLoading ? (
+        <Loader2Icon className="animate-spin text-current" />
+      ) : (
+        <TriangleIcon filled={voted} />
+      )}
       {count}
     </button>
+  );
+}
+
+function Loader2Icon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      xmlns="http://www.w3.org/2000/svg"
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+    </svg>
   );
 }
 

--- a/src/hooks/use-optimistic-vote.ts
+++ b/src/hooks/use-optimistic-vote.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useRef, useEffect } from "react";
 
 interface UseOptimisticVoteOptions {
   moduleId: string;
@@ -43,7 +43,15 @@ export function useOptimisticVote({
   // BUG: this ref is never reset when the component unmounts and remounts
   // with the same moduleId (e.g. navigating away and back in the same session).
   // The stale `isMounted` from the previous render is reused.
+  // FIX: Added a useEffect cleanup to properly track mounted state.
   const isMounted = useRef(true);
+
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
 
   const toggle = useCallback(async () => {
     if (isLoading) return;


### PR DESCRIPTION
## What does this PR do?

1. **Category Filter Multi-select:** Implement category filter in the `/` browse page using `useRouter` and `useSearchParams`. Upgraded the original requirement to support **Multi-select (OR logic)** for better UX, allowing users to select multiple overlapping categories (e.g., `?category=slug1&category=slug2`).
2. **Vote Loading State (Issue #6):** Integrated `Loader2Icon` into the `VoteButton` to show a spinning loading state during the optimistic API call.
3. **Optimistic Vote Memory Leak FIX:** Identified and patched the intentional stale-state trap within `useOptimisticVote.ts` hook. Added unmount `useEffect` cleanup (`isMounted.current = false`) to prevent state rollbacks from crashing when a user quickly navigates away before the API request completes.

## Related Issue

Closes #28
Closes #6

## How to test

1. Visit `/` home page.
2. Click on multiple category pills on top. The URL will update dynamically without a full-page reload, and the modules grid will adjust accurately (using Prisma `in` operator filtering).
3. Click a module to go to its detail page. Click the Upvote button. Observe the loading spinner until the API resolves.
4. Try to click Upvote and instantly hit regular "back" page routing — no memory leak or stale state crash will occur in the console.

## Screenshots / recordings (if UI change)
*(Tested fully on local branch)*

## Checklist

- [x] I read the relevant code **before** writing my own
- [x] My code follows the existing patterns in the codebase
- [x] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
- [x] I added or updated tests where applicable
- [x] I can explain every line of code I wrote (reviewer will ask)
- [x] I kept the PR focused — no unrelated changes

## Notes for reviewer

Regarding the ambiguity in the acceptance criteria: I opted for **Multi-select (OR logic)** instead of Single-select. Allowing users to filter `React` OR `Nextjs` mini-apps provides a robust UX mimicking modern e-commerce filtering flows. Also, proactively resolved the `isMounted` ref trap in the hook for safer optimistic updates.
