### PR TITLE
feat(modules): add cursor-based pagination with load more button

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 import { db } from "@/lib/db";
 import { auth } from "@/lib/auth";
-import { ModuleCard } from "@/components/module-card";
+import { ModuleList } from "@/components/module-list";
 
 // TODO [medium-challenge]: Add category filter with URL query params (state persists on refresh)
 // See: ISSUES.md for full acceptance criteria
@@ -32,8 +32,12 @@ export default async function HomePage({
       author: { select: { id: true, name: true, image: true } },
     },
     orderBy: { voteCount: "desc" },
-    take: 12,
+    take: 13,
   });
+
+  const hasMore = modules.length > 12;
+  const items = hasMore ? modules.slice(0, 12) : modules;
+  const nextCursor = hasMore ? items[items.length - 1].id : null;
 
   // Fetch which modules the current user has voted on
   let votedIds = new Set<string>();
@@ -41,7 +45,7 @@ export default async function HomePage({
     const votes = await db.vote.findMany({
       where: {
         userId: session.user.id,
-        moduleId: { in: modules.map((m) => m.id) },
+        moduleId: { in: items.map((m) => m.id) },
       },
       select: { moduleId: true },
     });
@@ -103,7 +107,7 @@ export default async function HomePage({
         ))}
       </div>
 
-      {modules.length === 0 ? (
+      {items.length === 0 ? (
         <div className="rounded-xl border border-dashed border-gray-300 p-12 text-center">
           <p className="text-gray-500">No modules found.</p>
           {q && (
@@ -113,15 +117,14 @@ export default async function HomePage({
           )}
         </div>
       ) : (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {modules.map((module) => (
-            <ModuleCard
-              key={module.id}
-              module={module}
-              hasVoted={votedIds.has(module.id)}
-            />
-          ))}
-        </div>
+        <ModuleList
+          key={`${q}-${category}`}
+          initialModules={items}
+          initialNextCursor={nextCursor}
+          votedIds={[...votedIds]}
+          q={q}
+          category={category}
+        />
       )}
     </div>
   );

--- a/src/components/module-list.tsx
+++ b/src/components/module-list.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState } from "react";
+import { ModuleCard } from "@/components/module-card";
+import type { Module } from "@/types";
+
+interface ModuleListProps {
+  initialModules: Module[];
+  initialNextCursor: string | null;
+  votedIds: string[];
+  q?: string;
+  category?: string;
+}
+
+export function ModuleList({
+  initialModules,
+  initialNextCursor,
+  votedIds,
+  q,
+  category,
+}: ModuleListProps) {
+  const [modules, setModules] = useState(initialModules);
+  const [nextCursor, setNextCursor] = useState(initialNextCursor);
+  const [isLoading, setIsLoading] = useState(false);
+
+  async function loadMore() {
+    if (!nextCursor || isLoading) return;
+    setIsLoading(true);
+
+    try {
+      const params = new URLSearchParams();
+      params.set("cursor", nextCursor);
+      if (q) params.set("q", q);
+      if (category) params.set("category", category);
+
+      const res = await fetch(`/api/modules?${params.toString()}`);
+      const data = await res.json();
+
+      setModules((prev) => [...prev, ...data.items]);
+      setNextCursor(data.nextCursor);
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  const votedSet = new Set(votedIds);
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {modules.map((module) => (
+          <ModuleCard
+            key={module.id}
+            module={module}
+            hasVoted={votedSet.has(module.id)}
+          />
+        ))}
+      </div>
+
+      {nextCursor && (
+        <div className="flex justify-center">
+          <button
+            onClick={loadMore}
+            disabled={isLoading}
+            className="rounded-lg border border-gray-300 px-5 py-2 text-sm font-medium text-gray-600 hover:bg-gray-50 disabled:opacity-50"
+          >
+            {isLoading ? "Loading…" : "Load more"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## What does this PR do?

Implements cursor-based pagination on the browse page. Previously the page hardcoded `take: 12` with no way to see more modules. This PR adds a "Load more" button that appends the next page of results in-place without a full page reload, using the `nextCursor` already supported by `GET /api/modules`.

## Related Issue

Closes #18

## How to test

1. Run the project with `pnpm dev`
2. Go to `http://localhost:3000` — if there are more than 12 approved modules, a **Load more** button appears below the grid
3. Click **Load more** — next 12 modules append to the list, button shows "Loading…" while fetching
4. When no more modules remain, the button disappears
5. Search with `?q=` active, then click **Load more** — search filter is preserved across pages
6. Filter by category, then click **Load more** — category filter is preserved across pages

## Checklist

- Ran `pnpm lint` and `pnpm typecheck` successfully
- TypeScript types are correct
- I understand why I made each change

## How I used AI

Used AI for guidance on:
- Structuring the `ModuleList` client component to manage accumulated results in local state
