### PR TITLE
feat: add back to top button

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist } from "next/font/google";
 import "./globals.css";
 import { Navbar } from "@/components/navbar";
 import { AuthSessionProvider } from "@/components/session-provider";
+import { BackToTop } from "@/components/back-to-top";
 
 const geist = Geist({ subsets: ["latin"], variable: "--font-geist" });
 
@@ -22,6 +23,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             {children}
           </main>
         </AuthSessionProvider>
+
+        <BackToTop />
       </body>
     </html>
   );

--- a/src/components/back-to-top.tsx
+++ b/src/components/back-to-top.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function BackToTop() {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      if (window.scrollY > 300) {
+        setIsVisible(true);
+      } else {
+        setIsVisible(false);
+      }
+    };
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
+  };
+
+  return (
+    <button
+      onClick={scrollToTop}
+      aria-label="Back to top"
+      className={`fixed bottom-8 right-8 z-50 flex h-12 w-12 items-center justify-center rounded-full bg-slate-900 text-white shadow-lg outline-none ring-slate-900 ring-offset-2 transition-all duration-300 hover:bg-slate-800 focus-visible:ring-2 ${
+        isVisible
+          ? "pointer-events-auto scale-100 opacity-100"
+          : "pointer-events-none scale-90 opacity-0"
+      }`}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <path d="m18 15-6-6-6 6" />
+      </svg>
+    </button>
+  );
+}


### PR DESCRIPTION
## What does this PR do?
Adds a smooth, accessible "Back to Top" floating button component using React hooks and Tailwind CSS. The button fades in seamlessly after scrolling 300px and smoothly auto-scrolls to top upon click.

## Related Issue
Closes #37

## How to test
1. Scroll down the main page.
2. Verify that at 300px, a grey floating button with an up-arrow appears smoothly without layout shifts.
3. Click it and enjoy the smooth slide back to top.

## Screenshots / recordings (if UI change)
*(Tested fully on local branch)*

## Checklist

- [x] I read the relevant code **before** writing my own
- [x] My code follows the existing patterns in the codebase
- [x] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
- [x] I added or updated tests where applicable
- [x] I can explain every line of code I wrote (reviewer will ask)
- [x] I kept the PR focused — no unrelated changes

## Notes for reviewer
Designed purely with React Hooks and Tailwind CSS to strictly respect the `No new dependencies introduced` requirement, while still retaining a premium interactive micro-animation.
