### PR TITLE
feat: add leaderboard page to rank top contributors

### DIFF
--- a/__tests__/leaderboard.test.ts
+++ b/__tests__/leaderboard.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { db } from '@/lib/db';
+import LeaderboardPage, { revalidate } from '@/app/leaderboard/page';
+
+// Mock the DB to prevent real queries
+vi.mock('@/lib/db', () => ({
+  db: {
+    miniApp: {
+      groupBy: vi.fn().mockResolvedValue([]),
+    },
+    user: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+  },
+}));
+
+describe('Leaderboard Edge Case: 1st of the month at 00:01 UTC', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('should query for submissions starting from 1st of the CURRENT month', async () => {
+    // REQUIREMENT: What happens on the 1st of a new month at 00:01 UTC?
+    // ACTUALLY: Because of Next.js ISR (\`revalidate = 600\`), if a request hits at 00:01 UTC, 
+    // it will return the cached page from the previous month. Once the 10 min cache expires, 
+    // it executes this component. Let's verify what happens when it DOES execute.
+
+    // Arrange: Set time to May 1st at 00:01 UTC
+    const mockDate = new Date('2026-05-01T00:01:00Z');
+    vi.setSystemTime(mockDate);
+
+    // Act: Render the page component (as a normal async function call)
+    await LeaderboardPage();
+
+    // Assert: Check if Prisma was called with the correct \`createdAt.gte\`
+    const expectedStartOfMonth = new Date('2026-05-01T00:00:00Z');
+
+    expect(db.miniApp.groupBy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: 'APPROVED',
+          createdAt: {
+            gte: expectedStartOfMonth,
+          },
+        }),
+      })
+    );
+  });
+
+  it('should query for submissions from the SAME month if it is the last day at 23:59 UTC', async () => {
+    // Arrange: Set time to April 30th at 23:59 UTC
+    const mockDate = new Date('2026-04-30T23:59:00Z');
+    vi.setSystemTime(mockDate);
+
+    // Act
+    await LeaderboardPage();
+
+    // Assert: Start of month should be April 1st
+    const expectedStartOfMonth = new Date('2026-04-01T00:00:00Z');
+
+    expect(db.miniApp.groupBy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: 'APPROVED',
+          createdAt: {
+            gte: expectedStartOfMonth,
+          },
+        }),
+      })
+    );
+  });
+});
+
+describe('Leaderboard Page Configuration', () => {
+  it('should export revalidate configured to 600 seconds (10 minutes) for ISR', () => {
+    expect(revalidate).toBe(600);
+  });
+});

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -106,6 +106,7 @@ model MiniApp {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  @@index([status, createdAt])
   @@map("mini_apps")
 }
 

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -1,0 +1,123 @@
+import { db } from "@/lib/db";
+
+export const revalidate = 600;
+
+export default async function LeaderboardPage() {
+  const now = new Date();
+  const startOfMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+
+  const topAuthors = await db.miniApp.groupBy({
+    by: ["authorId"],
+    where: {
+      status: "APPROVED",
+      createdAt: { gte: startOfMonth },
+    },
+    _count: {
+      id: true,
+    },
+    orderBy: {
+      _count: {
+        id: "desc",
+      },
+    },
+    take: 10,
+  });
+
+  const users = await db.user.findMany({
+    where: { id: { in: topAuthors.map((a) => a.authorId) } },
+  });
+
+  // Map user data back to the grouped stats to keep the ordered array
+  const leaderboard = topAuthors.map((authorData, index) => {
+    const user = users.find((u) => u.id === authorData.authorId);
+    return {
+      rank: index + 1,
+      id: user?.id,
+      name: user?.name || "Unknown",
+      image: user?.image,
+      approvedCount: authorData._count.id,
+    };
+  });
+
+  return (
+    <div className="space-y-8 max-w-3xl mx-auto py-12 px-4">
+      <div className="text-center space-y-3">
+        <h1 className="text-4xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-blue-600 to-purple-600">
+          Top Contributors
+        </h1>
+        <p className="text-lg text-gray-500 max-w-xl mx-auto">
+          Honoring our most active community members with the highest number of approved module submissions this month.
+        </p>
+      </div>
+
+      <div className="bg-white rounded-2xl shadow-xl shadow-blue-900/5 border border-gray-100 overflow-hidden">
+        <div className="grid grid-cols-[80px_1fr_120px] items-center p-5 border-b border-gray-100 bg-gray-50/80 text-xs tracking-wider uppercase font-bold text-gray-500">
+          <div className="text-center">Rank</div>
+          <div>Contributor</div>
+          <div className="text-right">Approved</div>
+        </div>
+
+        {leaderboard.length === 0 && (
+          <div className="p-12 text-center">
+            <div className="text-4xl mb-4">🏆</div>
+            <h3 className="text-lg font-bold text-gray-900 mb-1">No submissions yet</h3>
+            <p className="text-gray-500">Be the first to get a module approved this month!</p>
+          </div>
+        )}
+
+        <div className="divide-y divide-gray-50">
+          {leaderboard.map((entry) => (
+            <div
+              key={entry.id || entry.rank}
+              className="grid grid-cols-[80px_1fr_120px] items-center p-5 hover:bg-gray-50 transition duration-150 ease-in-out group"
+            >
+              <div className="text-center">
+                {entry.rank === 1 ? (
+                  <span className="inline-flex items-center justify-center w-8 h-8 rounded-full bg-yellow-100 text-yellow-700 font-bold text-sm shadow-sm border border-yellow-200">1</span>
+                ) : entry.rank === 2 ? (
+                  <span className="inline-flex items-center justify-center w-8 h-8 rounded-full bg-gray-100 text-gray-600 font-bold text-sm shadow-sm border border-gray-200">2</span>
+                ) : entry.rank === 3 ? (
+                  <span className="inline-flex items-center justify-center w-8 h-8 rounded-full bg-amber-100/50 text-amber-700 font-bold text-sm shadow-sm border border-amber-200/50">3</span>
+                ) : (
+                  <span className="font-mono font-semibold text-gray-400 text-lg group-hover:text-gray-600 transition-colors">
+                    #{entry.rank}
+                  </span>
+                )}
+              </div>
+
+              <div className="flex items-center gap-4">
+                {entry.image ? (
+                  <img
+                    src={entry.image}
+                    alt={entry.name}
+                    className="h-12 w-12 rounded-full border-2 border-white shadow-sm object-cover"
+                  />
+                ) : (
+                  <div className="h-12 w-12 rounded-full bg-gradient-to-br from-blue-100 to-blue-200 text-blue-700 flex items-center justify-center font-bold shadow-sm border-2 border-white">
+                    {entry.name.charAt(0).toUpperCase()}
+                  </div>
+                )}
+                <div>
+                  <div className="font-bold text-gray-900 leading-tight group-hover:text-blue-600 transition-colors">
+                    {entry.name}
+                  </div>
+                  {entry.rank === 1 && (
+                    <div className="text-xs font-semibold text-yellow-600 mt-0.5 tracking-wide uppercase">
+                      Top Contributor
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              <div className="text-right pr-2">
+                <span className="inline-flex items-center justify-center bg-blue-50 text-blue-700 px-3 py-1.5 rounded-lg font-bold">
+                  {entry.approvedCount}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What does this PR do?

Introduces a public `/leaderboard` page to reward active community contributors with visibility. It displays the top 10 users with the most approved module submissions for the current UTC calendar month. This page is heavily optimized using Incremental Static Regeneration (10-minute cache) and a fast Prisma grouping query to prevent database strain.

## Related Issue

Closes #30 

## How to test

<!-- Exact steps for the reviewer to verify your change works -->

1. Run `pnpm build && pnpm start` to run the active production server with proper Next.js caching enabled.

2. Navigate to `http://localhost:3000/leaderboard` as an unauthenticated (public) user.

3. Open `pnpm db:studio` in a separate terminal. Manually insert an "APPROVED" `MiniApp` submission for a user.

4. Verify that the leaderboard UI refuses to update immediately. Wait 10 minutes (or temporarily alter `export const revalidate = 600;` to something lower in [page.tsx](cci:7://file:///d:/WORKSPACE/PROJECT%20JAVA/intern-community/src/app/page.tsx:0:0-0:0) and rebuild) to observe the ISR cache flawlessly kicking in.

5. Run `pnpm test` to verify our edge-case time mock tests are succeeding.
## Screenshots / recordings (if UI change)

<!-- Drag and drop a screenshot or screen recording here -->
![issue30_showtop10](https://github.com/user-attachments/assets/4a045f91-8911-46c9-a6a3-e4a564e917ab)

![issue30_test](https://github.com/user-attachments/assets/bdf2c887-5ac4-44e7-8460-54c505d1dfad)

## Checklist

- [ x ] I read the relevant code **before** writing my own
- [ x ] My code follows the existing patterns in the codebase
- [ x ] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
- [ x ] I added or updated tests where applicable
- [ x ] I can explain every line of code I wrote (reviewer will ask)
- [ x ] I kept the PR focused — no unrelated changes

## Notes for reviewer

- **Performance & N+1 Check:** To fetch the leaderboard safely, I utilized a Prisma `groupBy` to count the active submissions and then passed the top 10 `authorId`s into a single batch `User.findMany` query to populate their avatars and names. I also appended an `@@index([status, createdAt])` to the `MiniApp` database schema to eliminate full table scans.
- **Question: What happens to the leaderboard on the 1st of a new month at 00:01 UTC?**  
Because we are utilizing standard Next.js ISR caching (`revalidate: 600`), the production environment will safely continue to serve the stale cached data from the previous month for exactly that 10-minute buffer window. Once the first request triggers generation *after* 00:10 UTC, the system drops the staleness and runs the query, correctly pulling the absolute empty current month. The boundary calculation has been backed entirely by our `__tests__/leaderboard.test.ts` where we strictly test the `Date.UTC` timezone rollovers!
