### PR TITLE
feat: add back to top button with smooth scroll and fade effect

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist } from "next/font/google";
 import "./globals.css";
 import { Navbar } from "@/components/navbar";
 import { AuthSessionProvider } from "@/components/session-provider";
+import BackToTop from "@/components/backto-top";
 
 const geist = Geist({ subsets: ["latin"], variable: "--font-geist" });
 
@@ -15,6 +16,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className={`${geist.variable} h-full antialiased`}>
+      
       <body className="flex min-h-full flex-col bg-gray-50 font-sans">
         <AuthSessionProvider>
           <Navbar />
@@ -22,6 +24,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             {children}
           </main>
         </AuthSessionProvider>
+        <BackToTop />
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -58,6 +58,7 @@ export default async function HomePage({
           <p className="text-sm text-gray-500">
             Discover mini-apps built by the Intern developer community.
           </p>
+          
         </div>
 
         <form className="flex gap-2">

--- a/src/components/backto-top.tsx
+++ b/src/components/backto-top.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export default function BackToTop() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setVisible(window.scrollY > 300);
+    };
+
+    window.addEventListener("scroll", handleScroll);
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
+  };
+
+  return (
+    <button
+      onClick={scrollToTop}
+      aria-label="Back to top"
+      className={`
+        fixed bottom-6 right-6
+        bg-blue-600 text-white
+        px-4 py-2 rounded-full shadow
+        transition-opacity duration-300
+        hover:bg-blue-700
+        ${visible ? "opacity-100" : "opacity-0 pointer-events-none"}
+      `}
+    >
+      ↑
+    </button>
+  );
+}


### PR DESCRIPTION
## What does this PR do?

This PR adds a "Back to top" button to improve navigation on long pages.
When users scroll down more than 300px, a floating button appears that allows them to quickly and smoothly return to the top of the page.

---

## Related Issue

Closes #37

---

## How to test

1. Run the project:

   ```bash
   pnpm dev
   ```

2. Open `http://localhost:3000`

3. Scroll down the page:

   * The "Back to top" button should appear after ~300px

4. Click the button:

   * The page should smoothly scroll back to the top

5. Scroll back to the top:

   * The button should disappear

---

## Screenshots / recordings (if UI change)

(Optional)
The button appears at the bottom-right corner with a smooth fade-in/out effect.

---

## Checklist

* [x] I read the relevant code **before** writing my own
* [x] My code follows the existing patterns in the codebase
* [x] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
* [x] I added or updated tests where applicable (not required for this UI change)
* [x] I can explain every line of code I wrote (reviewer will ask)
* [x] I kept the PR focused — no unrelated changes

---


AI was used as a supporting tool for implementation suggestions, but all code was reviewed and adjusted to match the project's conventions.
