### PR TITLE
feat: add redis-backed rate limiting for vote and module

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,5 @@ AUTH_SECRET="change-me-in-production-use-openssl-rand-base64-32"
 # Callback URL: http://localhost:3000/api/auth/callback/github
 AUTH_GITHUB_ID=""
 AUTH_GITHUB_SECRET=""
+UPSTASH_REDIS_REST_URL=""
+UPSTASH_REDIS_REST_TOKEN=""

--- a/__tests__/rate-limit.test.ts
+++ b/__tests__/rate-limit.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const authMock = vi.fn();
+const voteLimitMock = vi.fn();
+const moduleLimitMock = vi.fn();
+
+const dbMock = {
+  vote: {
+    findUnique: vi.fn(),
+    delete: vi.fn(),
+    create: vi.fn(),
+  },
+  miniApp: {
+    update: vi.fn(),
+    findMany: vi.fn(),
+    create: vi.fn(),
+  },
+  $transaction: vi.fn(),
+};
+
+vi.mock("@/lib/auth", () => ({
+  auth: authMock,
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: dbMock,
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  voteRateLimit: {
+    limit: voteLimitMock,
+  },
+  moduleRateLimit: {
+    limit: moduleLimitMock,
+  },
+}));
+
+function createRequest(body: unknown) {
+  return {
+    json: vi.fn().mockResolvedValue(body),
+  } as never;
+}
+
+describe("rate-limited routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authMock.mockResolvedValue({
+      user: { id: "user-1", isAdmin: false, name: "Test User" },
+    });
+  });
+
+  it("returns 429 for votes when the rate limit is exceeded", async () => {
+    voteLimitMock.mockResolvedValue({ success: false });
+
+    const { POST } = await import("@/app/api/votes/route");
+    const response = await POST(createRequest({ moduleId: "module-1" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(429);
+    expect(body).toEqual({ error: "Too many votes. Please wait a moment." });
+    expect(voteLimitMock).toHaveBeenCalledWith("user-1");
+    expect(dbMock.vote.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("returns 429 for module submissions when the rate limit is exceeded", async () => {
+    moduleLimitMock.mockResolvedValue({ success: false });
+
+    const { POST } = await import("@/app/api/modules/route");
+    const response = await POST(
+      createRequest({
+        name: "Budget Buddy",
+        description: "A budgeting helper for personal spending insights.",
+        categoryId: "ckqexamplecategoryid1234567",
+        repoUrl: "https://github.com/example/budget-buddy",
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(429);
+    expect(body).toEqual({ error: "Too many submissions. Please wait a moment." });
+    expect(moduleLimitMock).toHaveBeenCalledWith("user-1");
+    expect(dbMock.miniApp.findMany).not.toHaveBeenCalled();
+    expect(dbMock.miniApp.create).not.toHaveBeenCalled();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "@auth/prisma-adapter": "^2.11.1",
     "@prisma/adapter-pg": "^7.6.0",
     "@prisma/client": "^7.6.0",
+    "@upstash/ratelimit": "^2.0.8",
+    "@upstash/redis": "^1.37.0",
     "clsx": "^2.1.1",
     "dotenv": "^17.3.1",
     "next": "16.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,12 @@ importers:
       '@prisma/client':
         specifier: ^7.6.0
         version: 7.6.0(prisma@7.6.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
+      '@upstash/ratelimit':
+        specifier: ^2.0.8
+        version: 2.0.8(@upstash/redis@1.37.0)
+      '@upstash/redis':
+        specifier: ^1.37.0
+        version: 1.37.0
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -1236,6 +1242,18 @@ packages:
     resolution: {integrity: sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==}
     cpu: [x64]
     os: [win32]
+
+  '@upstash/core-analytics@0.0.10':
+    resolution: {integrity: sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==}
+    engines: {node: '>=16.0.0'}
+
+  '@upstash/ratelimit@2.0.8':
+    resolution: {integrity: sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==}
+    peerDependencies:
+      '@upstash/redis': ^1.34.3
+
+  '@upstash/redis@1.37.0':
+    resolution: {integrity: sha512-LqOJ3+XWPLSZ2rGSed5DYG3ixybxb8EhZu3yQqF7MdZX1wLBG/FRcI6xcUZXHy/SS7mmXWyadrud0HJHkOc+uw==}
 
   '@vitejs/plugin-react@6.0.1':
     resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
@@ -2882,6 +2900,9 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
+  uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
@@ -3994,6 +4015,19 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
+
+  '@upstash/core-analytics@0.0.10':
+    dependencies:
+      '@upstash/redis': 1.37.0
+
+  '@upstash/ratelimit@2.0.8(@upstash/redis@1.37.0)':
+    dependencies:
+      '@upstash/core-analytics': 0.0.10
+      '@upstash/redis': 1.37.0
+
+  '@upstash/redis@1.37.0':
+    dependencies:
+      uncrypto: 0.1.3
 
   '@vitejs/plugin-react@6.0.1(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@20.19.37)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0))':
     dependencies:
@@ -5883,6 +5917,8 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
+
+  uncrypto@0.1.3: {}
 
   undici-types@6.21.0: {}
 

--- a/src/app/api/modules/route.ts
+++ b/src/app/api/modules/route.ts
@@ -73,7 +73,7 @@ export async function POST(req: NextRequest) {
     .then((r) => r.map((m) => m.slug));
   const slug = makeUniqueSlug(baseSlug, existingSlugs);
 
-  const module = await db.miniApp.create({
+  const miniApp = await db.miniApp.create({
     data: {
       slug,
       name,
@@ -86,5 +86,5 @@ export async function POST(req: NextRequest) {
     },
   });
 
-  return NextResponse.json(module, { status: 201 });
+  return NextResponse.json(miniApp, { status: 201 });
 }

--- a/src/app/api/modules/route.ts
+++ b/src/app/api/modules/route.ts
@@ -3,7 +3,7 @@ import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { submitModuleSchema } from "@/lib/validations";
 import { generateSlug, makeUniqueSlug } from "@/lib/utils";
-
+import { moduleRateLimit } from "@/lib/rate-limit";
 // GET /api/modules — list approved modules (with optional category filter + search)
 export async function GET(req: NextRequest) {
   const { searchParams } = req.nextUrl;
@@ -49,7 +49,13 @@ export async function POST(req: NextRequest) {
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
-
+  const { success } = await moduleRateLimit.limit(session.user.id);
+  if (!success) {
+    return NextResponse.json(
+      { error: "Too many submissions. Please wait a moment." },
+      { status: 429 }
+    );
+  }
   const body = await req.json();
   const parsed = submitModuleSchema.safeParse(body);
   if (!parsed.success) {

--- a/src/app/api/votes/route.ts
+++ b/src/app/api/votes/route.ts
@@ -2,12 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { voteRateLimit } from "@/lib/rate-limit";
-// Simple in-memory rate limit: max 10 votes per minute per user.
-// In production, replace with Redis-backed sliding window (e.g. Upstash).
-// TODO [medium-challenge]: Replace this with a proper rate limiter
 async function checkRateLimit(userId: string): Promise<boolean> {
   const { success } = await voteRateLimit.limit(userId);
-  return success
+  return success;
 }
 
 
@@ -18,7 +15,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  if (!( await checkRateLimit(session.user.id))) {
+  if (!(await checkRateLimit(session.user.id))) {
     return NextResponse.json(
       { error: "Too many votes. Please wait a moment." },
       { status: 429 }

--- a/src/app/api/votes/route.ts
+++ b/src/app/api/votes/route.ts
@@ -1,23 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
-
+import { voteRateLimit } from "@/lib/rate-limit";
 // Simple in-memory rate limit: max 10 votes per minute per user.
 // In production, replace with Redis-backed sliding window (e.g. Upstash).
 // TODO [medium-challenge]: Replace this with a proper rate limiter
-const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
-
-function checkRateLimit(userId: string): boolean {
-  const now = Date.now();
-  const entry = rateLimitMap.get(userId);
-  if (!entry || entry.resetAt < now) {
-    rateLimitMap.set(userId, { count: 1, resetAt: now + 60_000 });
-    return true;
-  }
-  if (entry.count >= 10) return false;
-  entry.count++;
-  return true;
+async function checkRateLimit(userId: string): Promise<boolean> {
+  const { success } = await voteRateLimit.limit(userId);
+  return success
 }
+
 
 // POST /api/votes — toggle vote on a module
 export async function POST(req: NextRequest) {
@@ -26,7 +18,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  if (!checkRateLimit(session.user.id)) {
+  if (!( await checkRateLimit(session.user.id))) {
     return NextResponse.json(
       { error: "Too many votes. Please wait a moment." },
       { status: 429 }

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,17 @@
+import { Redis } from '@upstash/redis'
+import { Ratelimit } from "@upstash/ratelimit"
+const redis = Redis.fromEnv()
+
+export const voteRateLimit = new Ratelimit({
+  redis,
+  limiter: Ratelimit.slidingWindow(10, "60 s"),
+  analytics: true,
+  prefix: "rate-limit:votes"
+})
+
+export const moduleRateLimit = new Ratelimit({
+  redis,
+  limiter: Ratelimit.slidingWindow(5, "10 m"),
+  analytics: true,
+  prefix: "rate-limit:modules"
+})

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,17 +1,18 @@
-import { Redis } from '@upstash/redis'
-import { Ratelimit } from "@upstash/ratelimit"
-const redis = Redis.fromEnv()
+import { Ratelimit } from "@upstash/ratelimit";
+import { Redis } from "@upstash/redis";
+
+const redis = Redis.fromEnv();
 
 export const voteRateLimit = new Ratelimit({
   redis,
   limiter: Ratelimit.slidingWindow(10, "60 s"),
   analytics: true,
-  prefix: "rate-limit:votes"
-})
+  prefix: "rate-limit:votes",
+});
 
 export const moduleRateLimit = new Ratelimit({
   redis,
   limiter: Ratelimit.slidingWindow(5, "10 m"),
   analytics: true,
-  prefix: "rate-limit:modules"
-})
+  prefix: "rate-limit:modules",
+});


### PR DESCRIPTION
## What does this PR do?

This PR replaces the in-memory vote rate limiter with a Redis-backed rate limiter using Upstash. It also applies the same protection pattern to module submissions so write-heavy endpoints are no longer limited only by process memory.

## Related Issue

Closes #67

## How to test

1. Add the required Redis environment variables to `.env`:
   ```bash
   UPSTASH_REDIS_REST_URL=...
   UPSTASH_REDIS_REST_TOKEN=...
   ```
2. Run:
   ```bash
   pnpm install
   pnpm dev
   ```
3. Sign in with a test account.
4. Send votes to the same or different modules more than 10 times within 60 seconds.
5. Confirm the API starts returning HTTP `429` with the vote rate limit message.
6. Submit modules more than 5 times within 10 minutes.
7. Confirm the API starts returning HTTP `429` with the submission rate limit message.
8. Restart the app and verify the limits still depend on Redis-backed state rather than in-process memory.



## Checklist

- [x] I read the relevant code **before** writing my own
- [x] My code follows the existing patterns in the codebase
- [ ] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
- [x] I added or updated tests where applicable
- [x] I can explain every line of code I wrote (reviewer will ask)
- [x] I kept the PR focused — no unrelated changes

## Notes for reviewer

- I replaced the previous in-memory `Map`-based limiter in `POST /api/votes` with Upstash Redis + `@upstash/ratelimit`.
- I extracted the limiter configuration into a shared helper so the same pattern can be reused for both votes and module submissions.
- Vote limit is configured as `10 requests / 60 seconds` using a sliding window.
- Module submission limit is configured as `5 requests / 10 minutes`.
- I added the required Redis environment variables to `.env.example`.
- `pnpm lint` may still report pre-existing baseline issues outside this PR’s scope if they have not been cleaned up separately.
