### PR TITLE
feat: add delete button for pending submissions

### DIFF
--- a/src/app/my-submissions/page.tsx
+++ b/src/app/my-submissions/page.tsx
@@ -2,12 +2,7 @@ import { redirect } from "next/navigation";
 import Link from "next/link";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
-
-const statusStyles: Record<string, string> = {
-  PENDING: "bg-yellow-50 text-yellow-700 border-yellow-200",
-  APPROVED: "bg-green-50 text-green-700 border-green-200",
-  REJECTED: "bg-red-50 text-red-700 border-red-200",
-};
+import { SubmissionsList } from "./submissions-list"; // 👈 thêm dòng này
 
 export default async function MySubmissionsPage() {
   const session = await auth();
@@ -31,46 +26,7 @@ export default async function MySubmissionsPage() {
         </Link>
       </div>
 
-      {submissions.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-gray-300 p-12 text-center">
-          <p className="text-gray-500">No submissions yet.</p>
-          <Link
-            href="/submit"
-            className="mt-2 block text-sm text-blue-600 hover:underline"
-          >
-            Submit your first module →
-          </Link>
-        </div>
-      ) : (
-        <div className="space-y-3">
-          {submissions.map((sub) => (
-            <div
-              key={sub.id}
-              className="flex items-start justify-between rounded-xl border border-gray-200 bg-white p-4"
-            >
-              <div className="space-y-1">
-                <p className="font-medium text-gray-900">{sub.name}</p>
-                <p className="text-xs text-gray-400">
-                  {sub.category.name} ·{" "}
-                  {new Date(sub.createdAt).toLocaleDateString()}
-                </p>
-                {sub.feedback && (
-                  <p className="mt-1 rounded-md bg-gray-50 px-2 py-1 text-xs text-gray-600">
-                    Feedback: {sub.feedback}
-                  </p>
-                )}
-              </div>
-              <span
-                className={`shrink-0 rounded-full border px-2 py-0.5 text-xs font-medium ${
-                  statusStyles[sub.status]
-                }`}
-              >
-                {sub.status}
-              </span>
-            </div>
-          ))}
-        </div>
-      )}
+      <SubmissionsList submissions={submissions} /> 
     </div>
   );
 }

--- a/src/app/my-submissions/submissions-list.tsx
+++ b/src/app/my-submissions/submissions-list.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import type { MiniApp, Category } from "@prisma/client";
+
+type Submission = MiniApp & { category: Category };
+
+const statusStyles: Record<string, string> = {
+  PENDING: "bg-yellow-50 text-yellow-700 border-yellow-200",
+  APPROVED: "bg-green-50 text-green-700 border-green-200",
+  REJECTED: "bg-red-50 text-red-700 border-red-200",
+};
+
+export function SubmissionsList({ submissions }: { submissions: Submission[] }) {
+  const router = useRouter();
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  async function handleDelete(id: string, name: string) {
+    const confirmed = confirm(`Are you sure you want to delete "${name}"?`);
+    if (!confirmed) return;
+
+    setDeletingId(id);
+    try {
+      const res = await fetch(`/api/modules/${id}`, { method: "DELETE" });
+      if (!res.ok) {
+        alert("Failed to delete. Please try again.");
+        return;
+      }
+      router.refresh();
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
+  if (submissions.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed border-gray-300 p-12 text-center">
+        <p className="text-gray-500">No submissions yet.</p>
+        <a href="/submit" className="mt-2 block text-sm text-blue-600 hover:underline">
+          Submit your first module →
+        </a>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {submissions.map((sub) => (
+        <div
+          key={sub.id}
+          className="flex items-start justify-between rounded-xl border border-gray-200 bg-white p-4"
+        >
+          <div className="space-y-1">
+            <p className="font-medium text-gray-900">{sub.name}</p>
+            <p className="text-xs text-gray-400">
+              {sub.category.name} ·{" "}
+              {new Date(sub.createdAt).toLocaleDateString()}
+            </p>
+            {sub.feedback && (
+              <p className="mt-1 rounded-md bg-gray-50 px-2 py-1 text-xs text-gray-600">
+                Feedback: {sub.feedback}
+              </p>
+            )}
+          </div>
+
+          <div className="flex shrink-0 items-center gap-3">
+            <span
+              className={`rounded-full border px-2 py-0.5 text-xs font-medium ${statusStyles[sub.status]}`}
+            >
+              {sub.status}
+            </span>
+
+            {sub.status === "PENDING" && (
+              <button
+                onClick={() => handleDelete(sub.id, sub.name)}
+                disabled={deletingId === sub.id}
+                className="rounded-lg border border-red-200 px-2 py-0.5 text-xs font-medium text-red-600 hover:bg-red-50 disabled:opacity-50"
+              >
+                {deletingId === sub.id ? "Deleting…" : "Delete"}
+              </button>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## What does this PR do?
Adds a delete button on the My Submissions page so users can remove their own PENDING submissions if they change their mind.

## Changes
- Created `src/app/my-submissions/submissions-list.tsx` — new Client Component that handles the list display and delete logic
- Updated `src/app/my-submissions/page.tsx` — minimal change, imports and renders `SubmissionsList`

## How to test
1. Sign in with GitHub
2. Submit a module (it will be PENDING)
3. Go to My Submissions page
4. Click "Delete" on the pending submission
5. Confirm the dialog → submission is removed, list updates without full page reload
6. APPROVED and REJECTED submissions do not show the Delete button

## Why this approach?
- Kept `page.tsx` as a Server Component for data fetching, extracted interactivity into a separate Client Component — follows the pattern used in the codebase
- Used `confirm()` for confirmation dialog as suggested in the issue
- Used `router.refresh()` to revalidate server data after delete without full page reload

Closes #29