### PR TITLE
Feat/issue 14 contributor leaderboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,6 @@ AUTH_SECRET="change-me-in-production-use-openssl-rand-base64-32"
 # Callback URL: http://localhost:3000/api/auth/callback/github
 AUTH_GITHUB_ID=""
 AUTH_GITHUB_SECRET=""
+
+# Secret used to secure revalidation API requests
+REVALIDATE_SECRET=""

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -46,38 +46,47 @@ export async function GET(req: NextRequest) {
   const { year, month } = parsed;
 
   try {
-    const startOfMonth = new Date(Date.UTC(year, month - 1, 1));
-    const endOfMonth = new Date(Date.UTC(year, month, 1));
-
-    // Get list leaderboard
-    const leaderboard = await db.miniApp.groupBy({
-      by: ["authorId"],
-      where: {
-        status: "APPROVED",
-        createdAt: { gte: startOfMonth, lt: endOfMonth },
-      },
-      _count: { id: true },
-      orderBy: { _count: { id: "desc" } },
-      take: limitResult.data,
-    });
-    // Get leaderboard users
-    const authorIds = leaderboard.map((entry) => entry.authorId);
-    const users = await db.user.findMany({
-      where: { id: { in: authorIds } },
-      select: { id: true, name: true, image: true },
-    });
-
-    // Map result
-    const userMap = new Map(users.map((u) => [u.id, u]));
-    const result = leaderboard.map((entry, index) => ({
-      rank: index + 1,
-      count: entry._count.id,
-      user: userMap.get(entry.authorId) ?? null,
-    }));
-
+    const result = await loadLeaderboard(year, month, limitResult.data);
     return NextResponse.json(result);
   } catch (err) {
     console.error(err);
     return NextResponse.json({ error: "Failed" }, { status: 500 });
   }
 }
+
+export const loadLeaderboard = async (
+  year: number,
+  month: number,
+  limit: number,
+) => {
+  const startOfMonth = new Date(Date.UTC(year, month - 1, 1));
+  const endOfMonth = new Date(Date.UTC(year, month, 1));
+
+  // Get list leaderboard
+  const leaderboard = await db.miniApp.groupBy({
+    by: ["authorId"],
+    where: {
+      status: "APPROVED",
+      createdAt: { gte: startOfMonth, lt: endOfMonth },
+    },
+    _count: { id: true },
+    orderBy: { _count: { id: "desc" } },
+    take: limit,
+  });
+  // Get leaderboard users
+  const authorIds = leaderboard.map((entry) => entry.authorId);
+  const users = await db.user.findMany({
+    where: { id: { in: authorIds } },
+    select: { id: true, name: true, image: true },
+  });
+
+  // Map result
+  const userMap = new Map(users.map((u) => [u.id, u]));
+  const result = leaderboard.map((entry, index) => ({
+    rank: index + 1,
+    count: entry._count.id,
+    user: userMap.get(entry.authorId) ?? null,
+  }));
+
+  return result;
+};

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -1,0 +1,83 @@
+import { ModuleStatus } from "./../../../types/index";
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { limitSchema, periodSchema } from "@/lib/validations";
+
+// validate year-month
+export function parseAndValidatePeriod(periodParam: string | null) {
+  const now = new Date();
+
+  if (!periodParam) {
+    return { year: now.getUTCFullYear(), month: now.getUTCMonth() + 1 };
+  }
+
+  try {
+    // Validate with Zod
+    const validated = periodSchema.parse(periodParam ?? undefined);
+
+    const [yearStr, monthStr] = validated.split("-");
+
+    return { year: Number(yearStr), month: Number(monthStr) };
+  } catch (err) {
+    return null;
+  }
+}
+// GET /api/leaderboard?period=2026-04&limit=10 — list
+export async function GET(req: NextRequest) {
+  const url = req.nextUrl;
+  //
+  const limitResult = limitSchema.safeParse(
+    url.searchParams.get("limit") ?? undefined,
+  );
+  if (!limitResult.success) {
+    return NextResponse.json(
+      { error: limitResult.error.issues[0].message },
+      { status: 400 },
+    );
+  }
+  const parsed = parseAndValidatePeriod(url.searchParams.get("period"));
+  if (!parsed) {
+    return NextResponse.json(
+      { error: "Invalid period, expected format: YYYY-MM" },
+      { status: 400 },
+    );
+  }
+
+  const { year, month } = parsed;
+
+  try {
+    const startOfMonth = new Date(Date.UTC(year, month - 1, 1));
+    const endOfMonth = new Date(Date.UTC(year, month, 1));
+
+    // Get list leaderboard
+    const leaderboard = await db.miniApp.groupBy({
+      by: ["authorId"],
+      where: {
+        status: "APPROVED",
+        createdAt: { gte: startOfMonth, lt: endOfMonth },
+      },
+      _count: { id: true },
+      orderBy: { _count: { id: "desc" } },
+      take: limitResult.data,
+    });
+    // Get leaderboard users
+    const authorIds = leaderboard.map((entry) => entry.authorId);
+    const users = await db.user.findMany({
+      where: { id: { in: authorIds } },
+      select: { id: true, name: true, image: true },
+    });
+
+    // Map result
+    const userMap = new Map(users.map((u) => [u.id, u]));
+    const result = leaderboard.map((entry, index) => ({
+      rank: index + 1,
+      count: entry._count.id,
+      user: userMap.get(entry.authorId) ?? null,
+    }));
+
+    return NextResponse.json(result);
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: "Failed" }, { status: 500 });
+  }
+}

--- a/src/app/api/modules/[id]/route.ts
+++ b/src/app/api/modules/[id]/route.ts
@@ -8,7 +8,7 @@ type Params = { params: Promise<{ id: string }> };
 // GET /api/modules/[id]
 export async function GET(_req: NextRequest, { params }: Params) {
   const { id } = await params;
-  const module = await db.miniApp.findUnique({
+  const moduleData = await db.miniApp.findUnique({
     where: { id },
     include: {
       category: true,
@@ -16,8 +16,9 @@ export async function GET(_req: NextRequest, { params }: Params) {
       _count: { select: { votes: true } },
     },
   });
-  if (!module) return NextResponse.json({ error: "Not found" }, { status: 404 });
-  return NextResponse.json(module);
+  if (!moduleData)
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  return NextResponse.json(moduleData);
 }
 
 // PATCH /api/modules/[id] — admin approve/reject
@@ -31,7 +32,10 @@ export async function PATCH(req: NextRequest, { params }: Params) {
   const body = await req.json();
   const parsed = adminReviewSchema.safeParse(body);
   if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.flatten() }, { status: 422 });
+    return NextResponse.json(
+      { error: parsed.error.flatten() },
+      { status: 422 },
+    );
   }
 
   const updated = await db.miniApp.update({
@@ -53,10 +57,11 @@ export async function DELETE(_req: NextRequest, { params }: Params) {
   }
 
   const { id } = await params;
-  const module = await db.miniApp.findUnique({ where: { id } });
-  if (!module) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  const moduleData = await db.miniApp.findUnique({ where: { id } });
+  if (!moduleData)
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
 
-  if (module.authorId !== session.user.id && !session.user.isAdmin) {
+  if (moduleData.authorId !== session.user.id && !session.user.isAdmin) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/src/app/api/modules/route.ts
+++ b/src/app/api/modules/route.ts
@@ -55,7 +55,7 @@ export async function POST(req: NextRequest) {
   if (!parsed.success) {
     return NextResponse.json(
       { error: parsed.error.flatten() },
-      { status: 422 }
+      { status: 422 },
     );
   }
 
@@ -63,11 +63,14 @@ export async function POST(req: NextRequest) {
 
   const baseSlug = generateSlug(name);
   const existingSlugs = await db.miniApp
-    .findMany({ where: { slug: { startsWith: baseSlug } }, select: { slug: true } })
+    .findMany({
+      where: { slug: { startsWith: baseSlug } },
+      select: { slug: true },
+    })
     .then((r) => r.map((m) => m.slug));
   const slug = makeUniqueSlug(baseSlug, existingSlugs);
 
-  const module = await db.miniApp.create({
+  const moduleData = await db.miniApp.create({
     data: {
       slug,
       name,
@@ -80,5 +83,5 @@ export async function POST(req: NextRequest) {
     },
   });
 
-  return NextResponse.json(module, { status: 201 });
+  return NextResponse.json(moduleData, { status: 201 });
 }

--- a/src/app/api/revalidate/leaderboard/route.ts
+++ b/src/app/api/revalidate/leaderboard/route.ts
@@ -1,0 +1,14 @@
+import { revalidatePath } from "next/cache";
+
+// POST /api/revalidate/leaderboard  - revalidate leaderboard
+export async function POST(req: Request) {
+  const secret = req.headers.get("x-secret");
+
+  if (secret !== process.env.REVALIDATE_SECRET) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  revalidatePath("/leaderboard");
+
+  return Response.json({ revalidated: true });
+}

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -1,0 +1,206 @@
+import { loadLeaderboard } from "../api/leaderboard/route";
+
+export const revalidate = 600;
+
+const AVATAR_COLORS = [
+  "bg-amber-100 text-amber-800",
+  "bg-blue-100 text-blue-800",
+  "bg-teal-100 text-teal-800",
+  "bg-pink-100 text-pink-800",
+  "bg-purple-100 text-purple-800",
+  "bg-orange-100 text-orange-800",
+];
+
+function getInitials(name?: string | null) {
+  if (!name) return "?";
+  return name
+    .trim()
+    .split(" ")
+    .filter(Boolean)
+    .slice(-2)
+    .map((w) => w[0])
+    .join("")
+    .toUpperCase();
+}
+
+function Avatar({
+  user,
+  size = "md",
+  colorIdx = 0,
+}: {
+  user?: { name?: string | null; image?: string | null } | null;
+  size?: "sm" | "md" | "lg";
+  colorIdx?: number;
+}) {
+  const sizeClass = {
+    sm: "w-8 h-8 text-xs",
+    md: "w-10 h-10 text-sm",
+    lg: "w-14 h-14 text-base",
+  }[size];
+
+  const color = AVATAR_COLORS[colorIdx % AVATAR_COLORS.length];
+
+  if (user?.image) {
+    return (
+      <img
+        src={user.image}
+        alt={user.name ?? ""}
+        className={`${sizeClass} rounded-full object-cover flex-shrink-0`}
+      />
+    );
+  }
+
+  return (
+    <div
+      className={`${sizeClass} ${color} rounded-full flex items-center justify-center font-medium flex-shrink-0`}
+    >
+      {getInitials(user?.name)}
+    </div>
+  );
+}
+
+const RING_CLASS = [
+  "ring-2 ring-amber-400",
+  "ring-2 ring-blue-300",
+  "ring-1 ring-gray-300",
+];
+
+const CHIP_CLASS = [
+  "bg-amber-50 text-amber-800 border border-amber-300",
+  "bg-blue-50 text-blue-800 border border-blue-200",
+  "bg-gray-100 text-gray-600 border border-gray-200",
+];
+
+const POD_BORDER = [
+  "border border-amber-300",
+  "border border-blue-200",
+  "border border-gray-200",
+];
+
+export default async function LeaderboardPage() {
+  const now = new Date();
+
+  const result = await loadLeaderboard(
+    now.getUTCFullYear(),
+    now.getUTCMonth() + 1,
+    10,
+  );
+
+  const top3 = result.slice(0, 3);
+  const rest = result.slice(3);
+
+  // Podium order: 2nd | 1st | 3rd
+  const podiumOrder = top3.length === 3 ? [top3[1], top3[0], top3[2]] : top3;
+
+  const podiumMeta = [
+    {
+      chipCls: CHIP_CLASS[1],
+      ringCls: RING_CLASS[1],
+      borderCls: POD_BORDER[1],
+      marginTop: "mt-5",
+    },
+    {
+      chipCls: CHIP_CLASS[0],
+      ringCls: RING_CLASS[0],
+      borderCls: POD_BORDER[0],
+      marginTop: "",
+    },
+    {
+      chipCls: CHIP_CLASS[2],
+      ringCls: RING_CLASS[2],
+      borderCls: POD_BORDER[2],
+      marginTop: "mt-9",
+    },
+  ];
+
+  return (
+    <div className="max-w-xl mx-auto px-4 py-10 space-y-8">
+      {/* Header */}
+      <div className="text-center space-y-2">
+        <span className="inline-block text-xs font-medium tracking-widest text-gray-400 uppercase border border-gray-200 rounded-full px-3 py-1">
+          {now.toLocaleDateString("vi-VN", { month: "long", year: "numeric" })}
+        </span>
+        <h1 className="text-2xl font-serif font-normal text-gray-900 tracking-tight">
+          Contributor Leaderboard
+        </h1>
+      </div>
+
+      {/* Podium */}
+      {top3.length > 0 && (
+        <div className="grid grid-cols-3 gap-2 items-end">
+          {podiumOrder.map((entry, i) => {
+            const meta = podiumMeta[i];
+            return (
+              <div
+                key={entry?.user?.id ?? i}
+                className={`flex flex-col items-center ${meta.borderCls} bg-white rounded-2xl px-3 py-5 relative ${meta.marginTop}`}
+              >
+                {/* Rank chip */}
+                <div
+                  className={`absolute -top-3 left-1/2 -translate-x-1/2 text-xs font-semibold px-2.5 py-0.5 rounded-full ${meta.chipCls}`}
+                >
+                  #{entry?.rank}
+                </div>
+
+                {/* Avatar with ring */}
+                <div
+                  className={`rounded-full ${meta.ringCls} ring-offset-2 mb-3`}
+                >
+                  <Avatar
+                    user={entry?.user}
+                    size="lg"
+                    colorIdx={(entry?.rank ?? 1) - 1}
+                  />
+                </div>
+
+                <p className="text-sm font-medium text-gray-900 text-center truncate w-full">
+                  {entry?.user?.name ?? "Unknown"}
+                </p>
+                <p className="text-xl font-semibold text-gray-900 mt-1 leading-none">
+                  {entry?.count}
+                </p>
+                <p className="text-xs text-gray-400 mt-0.5">modules</p>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Divider */}
+      <div className="flex items-center gap-3">
+        <div className="flex-1 h-px bg-gray-100" />
+        <span className="text-xs text-gray-400 font-medium tracking-wide">
+          Hạng 4 – 10
+        </span>
+        <div className="flex-1 h-px bg-gray-100" />
+      </div>
+
+      {/* Rest list */}
+      <div className="flex flex-col gap-1.5">
+        {rest.map((entry) => (
+          <div
+            key={entry.user?.id ?? entry.rank}
+            className="flex items-center gap-3 px-4 py-2.5 rounded-xl border border-gray-100 bg-white hover:bg-gray-50 transition-colors"
+          >
+            <span className="text-xs font-medium text-gray-400 w-4 text-center flex-shrink-0">
+              {entry.rank}
+            </span>
+
+            <Avatar user={entry.user} size="sm" colorIdx={entry.rank - 1} />
+
+            <span className="text-sm font-medium text-gray-900 flex-1 truncate">
+              {entry.user?.name ?? "Unknown"}
+            </span>
+
+            <span className="text-sm font-semibold text-gray-700 tabular-nums">
+              {entry.count}
+              <span className="text-xs font-normal text-gray-400 ml-1">
+                modules
+              </span>
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/modules/[slug]/page.tsx
+++ b/src/app/modules/[slug]/page.tsx
@@ -8,15 +8,19 @@ type Props = { params: Promise<{ slug: string }> };
 
 export async function generateMetadata({ params }: Props) {
   const { slug } = await params;
-  const module = await db.miniApp.findUnique({ where: { slug } });
-  return { title: module ? `${module.name} — Intern Community Hub` : "Not Found" };
+  const moduleData = await db.miniApp.findUnique({ where: { slug } });
+  return {
+    title: moduleData
+      ? `${moduleData.name} — Intern Community Hub`
+      : "Not Found",
+  };
 }
 
 export default async function ModuleDetailPage({ params }: Props) {
   const { slug } = await params;
   const session = await auth();
 
-  const module = await db.miniApp.findUnique({
+  const moduleData = await db.miniApp.findUnique({
     where: { slug, status: "APPROVED" },
     include: {
       category: true,
@@ -24,13 +28,13 @@ export default async function ModuleDetailPage({ params }: Props) {
     },
   });
 
-  if (!module) notFound();
+  if (!moduleData) notFound();
 
   let hasVoted = false;
   if (session?.user) {
     const vote = await db.vote.findUnique({
       where: {
-        userId_moduleId: { userId: session.user.id, moduleId: module.id },
+        userId_moduleId: { userId: session.user.id, moduleId: moduleData.id },
       },
     });
     hasVoted = !!vote;
@@ -44,38 +48,40 @@ export default async function ModuleDetailPage({ params }: Props) {
 
       <div className="space-y-2">
         <div className="flex items-start justify-between gap-4">
-          <h1 className="text-2xl font-bold text-gray-900">{module.name}</h1>
+          <h1 className="text-2xl font-bold text-gray-900">
+            {moduleData.name}
+          </h1>
           <VoteButton
-            moduleId={module.id}
+            moduleId={moduleData.id}
             initialVoted={hasVoted}
-            initialCount={module.voteCount}
+            initialCount={moduleData.voteCount}
           />
         </div>
         <p className="text-sm text-gray-500">
-          by {module.author.name} · {module.category.name}
+          by {moduleData.author.name} · {moduleData.category.name}
         </p>
       </div>
 
-      <p className="text-gray-700">{module.description}</p>
+      <p className="text-gray-700">{moduleData.description}</p>
 
       <div className="flex gap-3">
-        <a
-          href={module.repoUrl}
+        <Link
+          href={moduleData.repoUrl}
           target="_blank"
           rel="noopener noreferrer"
           className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
         >
           View on GitHub
-        </a>
-        {module.demoUrl && (
-          <a
-            href={module.demoUrl}
+        </Link>
+        {moduleData.demoUrl && (
+          <Link
+            href={moduleData.demoUrl}
             target="_blank"
             rel="noopener noreferrer"
             className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
           >
             Live Demo
-          </a>
+          </Link>
         )}
       </div>
 
@@ -86,10 +92,13 @@ export default async function ModuleDetailPage({ params }: Props) {
           - Add Content-Security-Policy header for the iframe origin
           - Show a loading skeleton while the iframe loads
           See: ISSUES.md for full acceptance criteria */}
-      {module.demoUrl && (
+      {moduleData.demoUrl && (
         <div className="rounded-xl border border-dashed border-gray-300 p-8 text-center text-sm text-gray-400">
           Sandboxed preview coming soon. Contribute this feature! See{" "}
-          <Link href="https://github.com" className="text-blue-600 hover:underline">
+          <Link
+            href="https://github.com"
+            className="text-blue-600 hover:underline"
+          >
             ISSUES.md
           </Link>
         </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { db } from "@/lib/db";
 import { auth } from "@/lib/auth";
 import { ModuleCard } from "@/components/module-card";
+import Link from "next/link";
 
 // TODO [medium-challenge]: Add category filter with URL query params (state persists on refresh)
 // See: ISSUES.md for full acceptance criteria
@@ -54,7 +55,9 @@ export default async function HomePage({
     <div className="space-y-6">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Community Modules</h1>
+          <h1 className="text-2xl font-bold text-gray-900">
+            Community Modules
+          </h1>
           <p className="text-sm text-gray-500">
             Discover mini-apps built by the Intern developer community.
           </p>
@@ -78,7 +81,7 @@ export default async function HomePage({
 
       {/* Category filter placeholder — see TODO above */}
       <div className="flex flex-wrap gap-2">
-        <a
+        <Link
           href="/"
           className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
             !category
@@ -87,7 +90,7 @@ export default async function HomePage({
           }`}
         >
           All
-        </a>
+        </Link>
         {categories.map((c) => (
           <a
             key={c.id}
@@ -107,9 +110,12 @@ export default async function HomePage({
         <div className="rounded-xl border border-dashed border-gray-300 p-12 text-center">
           <p className="text-gray-500">No modules found.</p>
           {q && (
-            <a href="/" className="mt-2 block text-sm text-blue-600 hover:underline">
+            <Link
+              href="/"
+              className="mt-2 block text-sm text-blue-600 hover:underline"
+            >
               Clear search
-            </a>
+            </Link>
           )}
         </div>
       ) : (

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -14,16 +14,31 @@ export function Navbar() {
         </Link>
 
         <div className="flex items-center gap-4">
+          <Link
+            href="/leaderboard"
+            className="text-sm text-gray-600 hover:text-gray-900"
+          >
+            Leaderboard
+          </Link>
           {session ? (
             <>
-              <Link href="/submit" className="text-sm text-gray-600 hover:text-gray-900">
+              <Link
+                href="/submit"
+                className="text-sm text-gray-600 hover:text-gray-900"
+              >
                 Submit Module
               </Link>
-              <Link href="/my-submissions" className="text-sm text-gray-600 hover:text-gray-900">
+              <Link
+                href="/my-submissions"
+                className="text-sm text-gray-600 hover:text-gray-900"
+              >
                 My Submissions
               </Link>
               {session.user.isAdmin && (
-                <Link href="/admin" className="text-sm font-medium text-orange-600 hover:text-orange-700">
+                <Link
+                  href="/admin"
+                  className="text-sm font-medium text-orange-600 hover:text-orange-700"
+                >
                   Admin
                 </Link>
               )}

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -14,7 +14,7 @@ export const submitModuleSchema = z.object({
     .url("Must be a valid URL")
     .refine(
       (url) => url.startsWith("https://github.com/"),
-      "Must be a GitHub repository URL"
+      "Must be a GitHub repository URL",
     ),
   demoUrl: z
     .url("Must be a valid URL")
@@ -26,6 +26,33 @@ export const adminReviewSchema = z.object({
   status: z.enum(["APPROVED", "REJECTED"]),
   feedback: z.string().max(500).optional(),
 });
+
+export const periodSchema = z
+  .string()
+  .regex(/^\d{4}-\d{2}$/, "Invalid period format, expected YYYY-MM")
+  .refine(
+    (val) => {
+      const [yearStr, monthStr] = val.split("-");
+      const year = Number(yearStr);
+      const month = Number(monthStr);
+      return (
+        !isNaN(year) &&
+        !isNaN(month) &&
+        month >= 1 &&
+        month <= 12 &&
+        year >= 2000 &&
+        year <= new Date().getUTCFullYear()
+      );
+    },
+    { message: "Month must be between 01-12 and year valid" },
+  );
+export const limitSchema = z
+  .string()
+  .optional()
+  .transform((val) => (val ? Number(val) : 10))
+  .refine((val) => !isNaN(val) && val > 0 && val <= 100, {
+    message: `Limit must be a number between 1 and ${100}`,
+  });
 
 export type SubmitModuleInput = z.infer<typeof submitModuleSchema>;
 export type AdminReviewInput = z.infer<typeof adminReviewSchema>;


### PR DESCRIPTION
## What does this PR do?

Build an API to fetch the top contributors based on approved contributions for a specified month and year, and develop a leaderboard page displaying the top 10 contributors of approved contributions for the current month.

## Related Issue

Closes #14 

## How to test

<!-- Exact steps for the reviewer to verify your change works -->

1. Clone the repository to your local machine.

2. Run pnpm build and pnpm run start.

3. Access the URL http://localhost:3000/api/leaderboard?period=YYYY-MM&limit=10 to fetch the list of top approved contributors, where limit must be a number between 0 and 100, and year must not be greater than the current year or less than 2000 (UTC).

4. Open the /leaderboard page via the navbar to display the top 10 approved contributors for the current month.

5. Add new approved module data, then revisit the /leaderboard page and notice that the page does not update immediately due to the 10-minute ISR cache.

6. Use Postman to send a POST request to http://localhost:3000/api/revalidate/leaderboard with the header { x-secret: REVALIDATE_SECRET }, where REVALIDATE_SECRET is set in the .env file.

7. Reload the /leaderboard page and see that the data updates immediately without waiting for 10 minutes.

## Screenshots / recordings (if UI change)

<img width="1918" height="966" alt="leaderboardPage" src="https://github.com/user-attachments/assets/1f183080-7ddd-412e-b999-29dd4323f251" />

<!-- Drag and drop a screenshot or screen recording here -->

## Checklist

- [X] I read the relevant code **before** writing my own
- [X] My code follows the existing patterns in the codebase
- [X] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
- [X] I added or updated tests where applicable
- [X] I can explain every line of code I wrote (reviewer will ask)
- [X] I kept the PR focused — no unrelated changes

## Notes for reviewer
- Prisma does not support groupBy combined with include. To avoid N+1 queries, the process should be done in two steps: first, fetch the list of authorIds with the highest number of approved contributions for the month; second, retrieve the detailed user information for these authorIds.

- The leaderboard page uses a 10-minute ISR. On access, the server component gets the current date, determines the month and year, calls loadLeaderboard to fetch fresh data, and caches the result for 10 minutes.

- At 00:01 UTC on the first day of a new month, the leaderboard data may still be cached, so updating to the latest data can be delayed until 00:10. The /api/revalidate/leaderboard API is used to clear the cache, ensuring that the next access fetches fresh data. Vercel Cron Jobs can be used to call this API automatically, so users receive the latest data immediately at the start of the new month.

### ASK:
- Since Server Components are used, the time is calculated based on the server’s UTC. If the client’s time zone differs from the server’s, the data displayed may not reflect the correct time frame.

- Solution: To ensure the data aligns with the user’s actual time frame, switch to using Client Components, avoid ISR, and implement caching on the API server using Redis. Additionally, adjust the time-handling logic in the GET /api/leaderboard API to calculate based on each user’s time zone.

- Would this solution be effective, or is there a better approach?
 
<!-- Anything you want to highlight, trade-offs you made, or questions you have -->
