### PR TITLE
feat: add URL-synced category filter without full page reload

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,7 @@
 import { db } from "@/lib/db";
 import { auth } from "@/lib/auth";
 import { ModuleCard } from "@/components/module-card";
-
-// TODO [medium-challenge]: Add category filter with URL query params (state persists on refresh)
-// See: ISSUES.md for full acceptance criteria
+import { CategoryFilter } from "@/components/category-filter";
 
 export default async function HomePage({
   searchParams,
@@ -67,6 +65,7 @@ export default async function HomePage({
             placeholder="Search modules…"
             className="rounded-lg border border-gray-300 px-3 py-2 text-sm outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
           />
+          {category ? <input type="hidden" name="category" value={category} /> : null}
           <button
             type="submit"
             className="rounded-lg bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700"
@@ -76,38 +75,16 @@ export default async function HomePage({
         </form>
       </div>
 
-      {/* Category filter placeholder — see TODO above */}
-      <div className="flex flex-wrap gap-2">
-        <a
-          href="/"
-          className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
-            !category
-              ? "bg-blue-600 text-white"
-              : "bg-gray-100 text-gray-600 hover:bg-gray-200"
-          }`}
-        >
-          All
-        </a>
-        {categories.map((c) => (
-          <a
-            key={c.id}
-            href={`/?category=${c.slug}`}
-            className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
-              category === c.slug
-                ? "bg-blue-600 text-white"
-                : "bg-gray-100 text-gray-600 hover:bg-gray-200"
-            }`}
-          >
-            {c.name}
-          </a>
-        ))}
-      </div>
+      <CategoryFilter categories={categories} activeCategory={category} />
 
       {modules.length === 0 ? (
         <div className="rounded-xl border border-dashed border-gray-300 p-12 text-center">
           <p className="text-gray-500">No modules found.</p>
           {q && (
-            <a href="/" className="mt-2 block text-sm text-blue-600 hover:underline">
+            <a
+              href={category ? `/?category=${category}` : "/"}
+              className="mt-2 block text-sm text-blue-600 hover:underline"
+            >
               Clear search
             </a>
           )}

--- a/src/components/category-filter.tsx
+++ b/src/components/category-filter.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import type { Category } from "@/types";
+
+interface CategoryFilterProps {
+  categories: Category[];
+  activeCategory?: string;
+}
+
+export function CategoryFilter({
+  categories,
+  activeCategory,
+}: CategoryFilterProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  function setCategory(nextCategory?: string) {
+    const params = new URLSearchParams(searchParams.toString());
+
+    if (!nextCategory) {
+      params.delete("category");
+    } else {
+      params.set("category", nextCategory);
+    }
+
+    const query = params.toString();
+    router.push(query ? `${pathname}?${query}` : pathname, { scroll: false });
+  }
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      <button
+        type="button"
+        onClick={() => setCategory(undefined)}
+        aria-pressed={!activeCategory}
+        className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+          !activeCategory
+            ? "bg-blue-600 text-white"
+            : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+        }`}
+      >
+        All
+      </button>
+
+      {categories.map((category) => {
+        const isActive = activeCategory === category.slug;
+        return (
+          <button
+            key={category.id}
+            type="button"
+            onClick={() => setCategory(category.slug)}
+            aria-pressed={isActive}
+            className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+              isActive
+                ? "bg-blue-600 text-white"
+                : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+            }`}
+          >
+            {category.name}
+          </button>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## What does this PR do?

This PR implements the medium challenge for category filtering by syncing the selected category with URL query params using Next.js App Router navigation.
It removes full-page reload behavior when changing categories and preserves combined filtering with both `q` (search) and `category`.

## Related Issue

Related to medium challenge: category filter with URL query params

## How to test

1. Run the app locally and open `/`.
2. Click a category pill and verify:
   - URL updates with `?category=<slug>`
   - Module list is filtered correctly.
3. Refresh the page and verify selected category persists.
4. Enter a search query and submit; verify both `q` and `category` exist in URL.
5. Change categories and verify `q` is preserved.
6. Click `All` and verify `category` is removed while `q` remains.
7. Use browser back/forward and verify UI + data stay in sync.

### Verification commands

- `pnpm typecheck` ✅
- `pnpm test` ✅
- `pnpm build` ✅

## Screenshots / recordings (if UI change)

<img width="1917" height="1027" alt="image" src="https://github.com/user-attachments/assets/6471173c-bf36-4eb1-95d9-d04cf73f9e9d" />

## Checklist

- [x] I read the relevant code **before** writing my own
- [x] My code follows the existing patterns in the codebase
- [ ] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
- [x] I added or updated tests where applicable
- [x] I can explain every line of code I wrote (reviewer will ask)
- [x] I kept the PR focused — no unrelated changes

## Notes for reviewer

- Scope is intentionally limited to the medium challenge category-filter behavior.
- Implementation uses a hybrid approach:
  - Server-side filtering remains in `src/app/page.tsx`
  - Client-side URL updates are handled in new `src/components/category-filter.tsx`.
- Search/category interoperability was improved by preserving `category` on search submit and preserving active category context in clear-search behavior.
- `pnpm lint` currently reports pre-existing repo issues outside this PR scope; no new lint issues were introduced in modified files.
- AI usage: I used AI to compare App Router URL-state implementation options and edge cases, then implemented and verified manually against acceptance criteria.