### PR TITLE
test: add unit tests for generateSlug

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -22,14 +22,21 @@ describe("generateSlug", () => {
     expect(generateSlug("a   b   c")).toBe("a-b-c");
   });
 
-  // TODO [easy-challenge]: Add test cases for the following:
-  // 1. A name that is already a valid slug (no changes needed)
-  // 2. A name with numbers (numbers should be preserved)
-  // 3. An empty string (what should the output be? Check the implementation)
-  // 4. A name with leading/trailing hyphens after special char removal
-  //
-  // Hint: read `src/lib/utils.ts` to understand the exact transformation rules
-  // before writing your assertions.
+  it("keeps an already valid slug unchanged", () => {
+    expect(generateSlug("already-valid-slug")).toBe("already-valid-slug");
+  });
+
+  it("preserves numbers in the slug", () => {
+    expect(generateSlug("Top 10 App 2026")).toBe("top-10-app-2026");
+  });
+
+  it("returns an empty string for empty input", () => {
+    expect(generateSlug("")).toBe("");
+  });
+
+  it("removes leading and trailing hyphens after special character cleanup", () => {
+    expect(generateSlug("!!! Hello World ???")).toBe("hello-world");
+  });
 });
 
 // ============================================================


### PR DESCRIPTION
## Goal

Improve confidence in the existing `generateSlug()` behavior by covering the missing edge cases noted in the test file.

Closes #3

## Implementation

I added unit tests for the following cases:
- input that is already a valid slug
- input containing numbers
- empty string input
- input that results in leading/trailing hyphens after special character cleanup

I kept the implementation unchanged and only expanded test coverage based on the current behavior in `src/lib/utils.ts`.

## How to test

1. Run `pnpm test __tests__/utils.test.ts`
2. Verify the `generateSlug` test cases pass
3. Run `pnpm lint`
4. Run `pnpm typecheck`

## Screenshots / recordings (if UI change)

N/A

## Checklist

- [x] I read the relevant code **before** writing my own
- [x] My code follows the existing patterns in the codebase
- [x] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
- [x] I added or updated tests where applicable
- [x] I can explain every line of code I wrote (reviewer will ask)
- [x] I kept the PR focused — no unrelated changes

## Notes for reviewer

I kept this PR intentionally small and limited it to test coverage for `generateSlug()` only.

## AI usage

I used AI as a supporting tool to help structure the test plan, but I verified the implementation directly from `src/lib/utils.ts` before writing the assertions.
