### PR TITLE
feat: Google login, admin dashboard, comment threads with admin repli…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,9 @@ AUTH_SECRET="change-me-in-production-use-openssl-rand-base64-32"
 # Callback URL: http://localhost:3000/api/auth/callback/github
 AUTH_GITHUB_ID=""
 AUTH_GITHUB_SECRET=""
+
+AUTH_GOOGLE_ID=""
+
+AUTH_GOOGLE_SECRET=""
+
+DISCORD_WEBHOOK_URL=""

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -204,7 +204,8 @@ The My Submissions page exists but is basic. It shows a list of submissions but 
 **Files:** New files + `src/app/api/`, `prisma/schema.prisma`
 
 **Context:**  
-When a maintainer approves or rejects a submission, the author currently has no way to know other than checking "My Submissions". We want to notify authors in-app.
+Khi admin approve/reject một submission, tác giả cần được báo trong-app ngoài việc tự xem "My Submissions".
+Hiện dự án đã có UI bell/toast tạm thời, nhưng notification cần được lưu bền (DB), có unread badge và khả năng mark-as-read.
 
 **Task description:**  
 Design and implement an in-app notification system that alerts module authors when their submission status changes.

--- a/package.json
+++ b/package.json
@@ -49,5 +49,6 @@
     "tsx": "^4.21.0",
     "typescript": "^5",
     "vitest": "^4.1.2"
-  }
+  },
+  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -64,6 +64,8 @@ model User {
   sessions    Session[]
   submissions MiniApp[]
   votes       Vote[]
+  comments    ModuleComment[]
+  notifications Notification[]
 
   createdAt DateTime @default(now())
 
@@ -99,6 +101,8 @@ model MiniApp {
   authorId String
 
   votes     Vote[]
+  comments  ModuleComment[]
+  notifications Notification[]
   // Denormalized for read performance on the browse page.
   // DO NOT remove this field and replace with COUNT(*) without running EXPLAIN ANALYZE first.
   voteCount Int    @default(0)
@@ -122,6 +126,41 @@ model Vote {
 
   @@unique([userId, moduleId])
   @@map("votes")
+}
+
+model ModuleComment {
+  id        String   @id @default(cuid())
+  module    MiniApp  @relation(fields: [moduleId], references: [id])
+  moduleId  String
+  author    User     @relation(fields: [authorId], references: [id])
+  authorId  String
+  content   String
+  isAdmin   Boolean  @default(false)
+  parentId  String?
+  parent    ModuleComment? @relation("CommentReplies", fields: [parentId], references: [id])
+  replies   ModuleComment[] @relation("CommentReplies")
+  createdAt DateTime @default(now())
+
+  @@index([moduleId, createdAt])
+  @@index([parentId])
+  @@map("comments")
+}
+
+model Notification {
+  id        String   @id @default(cuid())
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId    String
+
+  module    MiniApp? @relation(fields: [moduleId], references: [id], onDelete: SetNull)
+  moduleId  String?
+
+  message   String
+  isRead    Boolean  @default(false)
+  createdAt DateTime @default(now())
+  readAt    DateTime?
+
+  @@index([userId, isRead, createdAt])
+  @@map("notifications")
 }
 
 enum SubmissionStatus {

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -5,7 +5,12 @@ import { AdminReviewCard } from "@/components/admin-review-card";
 
 export default async function AdminPage() {
   const session = await auth();
-  if (!session?.user?.isAdmin) redirect("/");
+  if (!session?.user) {
+    redirect("/api/auth/signin?callbackUrl=/admin");
+  }
+  if (!session.user.isAdmin) {
+    redirect("/");
+  }
 
   const pending = await db.miniApp.findMany({
     where: { status: "PENDING" },
@@ -27,46 +32,88 @@ export default async function AdminPage() {
   });
 
   return (
-    <div className="space-y-8">
-      <h1 className="text-2xl font-bold text-gray-900">Admin — Module Review</h1>
-
-      <section className="space-y-4">
-        <h2 className="text-lg font-semibold text-gray-700">
-          Pending ({pending.length})
-        </h2>
-        {pending.length === 0 ? (
-          <p className="text-sm text-gray-400">No pending submissions. 🎉</p>
-        ) : (
-          <div className="grid gap-4 sm:grid-cols-2">
-            {pending.map((module) => (
-              <AdminReviewCard key={module.id} module={module} />
-            ))}
-          </div>
-        )}
-      </section>
-
-      <section className="space-y-4">
-        <h2 className="text-lg font-semibold text-gray-700">Recently Reviewed</h2>
-        <div className="space-y-2">
-          {recentlyReviewed.map((module) => (
-            <div
-              key={module.id}
-              className="flex items-center justify-between rounded-lg border border-gray-200 bg-white px-4 py-3"
-            >
-              <span className="text-sm font-medium text-gray-800">{module.name}</span>
-              <span
-                className={`rounded-full px-2 py-0.5 text-xs font-medium ${
-                  module.status === "APPROVED"
-                    ? "bg-green-50 text-green-700"
-                    : "bg-red-50 text-red-700"
-                }`}
-              >
-                {module.status}
-              </span>
-            </div>
-          ))}
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Admin Dashboard</h1>
+          <p className="mt-1 text-sm text-gray-500">Review community modules and manage feedback.</p>
         </div>
-      </section>
+        <div className="flex gap-2">
+          <div className="rounded-xl border border-gray-200 bg-white px-4 py-2">
+            <p className="text-xs text-gray-500">Pending</p>
+            <p className="text-lg font-semibold text-gray-900">{pending.length}</p>
+          </div>
+          <div className="rounded-xl border border-gray-200 bg-white px-4 py-2">
+            <p className="text-xs text-gray-500">Reviewed</p>
+            <p className="text-lg font-semibold text-gray-900">{recentlyReviewed.length}</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        <section className="space-y-4 lg:col-span-2">
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-gray-800">Pending Queue</h2>
+            <span className="rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-700">
+              {pending.length} items
+            </span>
+          </div>
+
+          {pending.length === 0 ? (
+            <div className="rounded-xl border border-dashed border-gray-300 bg-white p-10 text-center">
+              <p className="text-sm text-gray-500">No pending submissions. 🎉</p>
+            </div>
+          ) : (
+            <div className="max-h-[70vh] overflow-y-auto rounded-xl border border-gray-200 bg-white p-4">
+              <div className="grid gap-4 sm:grid-cols-2">
+                {pending.map((module) => (
+                  <AdminReviewCard key={module.id} module={module} />
+                ))}
+              </div>
+            </div>
+          )}
+        </section>
+
+        <aside className="space-y-4 lg:col-span-1">
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-gray-800">Recently Reviewed</h2>
+          </div>
+
+          <div className="rounded-xl border border-gray-200 bg-white p-4">
+            {recentlyReviewed.length === 0 ? (
+              <p className="text-sm text-gray-400">No reviewed modules yet.</p>
+            ) : (
+              <div className="space-y-2">
+                {recentlyReviewed.map((module) => (
+                  <div
+                    key={module.id}
+                    className="flex items-center justify-between rounded-lg border border-gray-200 bg-white px-4 py-3"
+                  >
+                    <span className="text-sm font-medium text-gray-800 truncate pr-3">
+                      {module.name}
+                    </span>
+                    <span
+                      className={`shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${module.status === "APPROVED"
+                          ? "bg-green-50 text-green-700"
+                          : "bg-red-50 text-red-700"
+                        }`}
+                    >
+                      {module.status}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div className="rounded-xl border border-gray-200 bg-white p-4">
+            <h3 className="text-sm font-semibold text-gray-900">Tip</h3>
+            <p className="mt-1 text-sm text-gray-600">
+              Approve modules only when the repo + demo work as expected. Use the feedback box to guide the author.
+            </p>
+          </div>
+        </aside>
+      </div>
     </div>
   );
 }

--- a/src/app/api/modules/[id]/comments/route.ts
+++ b/src/app/api/modules/[id]/comments/route.ts
@@ -1,0 +1,104 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+
+
+const lastPostAt = new Map<string, number>();
+
+function canPost(userId: string, moduleId: string) {
+    const key = `${userId}:${moduleId}`;
+    const now = Date.now();
+    const last = lastPostAt.get(key) ?? 0;
+    if (now - last < 5000) return false;
+    lastPostAt.set(key, now);
+    return true;
+}
+
+export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+    try {
+        const { id: moduleId } = await params;
+
+        const prisma = db as any;
+        const comments = await prisma.moduleComment.findMany({
+            where: { moduleId, parentId: null },
+            orderBy: { createdAt: "desc" },
+            take: 10,
+            include: {
+                author: { select: { id: true, name: true, image: true } },
+                replies: {
+                    orderBy: { createdAt: "asc" },
+                    include: { author: { select: { id: true, name: true, image: true } } },
+                },
+            },
+        });
+
+        return NextResponse.json(comments);
+    } catch (err) {
+        console.error("GET /comments error:", err);
+        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+    }
+}
+
+
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+    try {
+        const session = await auth();
+        if (!session?.user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+        const { id: moduleId } = await params;
+        const { content, parentId } = await req.json();
+
+        const text = (content ?? "").trim();
+        if (text.length < 2) return NextResponse.json({ error: "Too short" }, { status: 400 });
+        if (text.length > 1000) return NextResponse.json({ error: "Too long" }, { status: 400 });
+        if (!canPost(session.user.id, moduleId)) {
+            return NextResponse.json({ error: "Too fast" }, { status: 429 });
+        }
+
+        const exists = await db.miniApp.findFirst({ where: { id: moduleId, status: "APPROVED" } });
+        if (!exists) return NextResponse.json({ error: "Module not found" }, { status: 404 });
+
+        // If replying, only admin can create admin replies.
+        if (parentId) {
+            if (!session.user.isAdmin) {
+                return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+            }
+
+            const prisma = db as any;
+            const parent = await prisma.moduleComment.findUnique({ where: { id: parentId }, select: { moduleId: true } });
+            if (!parent || parent.moduleId !== moduleId) {
+                return NextResponse.json({ error: "Invalid parent comment" }, { status: 400 });
+            }
+        }
+
+        const prisma = db as any;
+        const created = await prisma.moduleComment.create({
+            data: {
+                moduleId,
+                authorId: session.user.id,
+                content: text,
+                parentId: parentId ?? null,
+                isAdmin: !!session.user.isAdmin,
+            },
+            include: { author: { select: { id: true, name: true, image: true } } },
+        });
+
+        // Fire-and-forget Discord webhook notification if configured
+        const webhook = process.env.DISCORD_WEBHOOK_URL;
+        if (webhook) {
+            // Best-effort, do not block response
+            fetch(webhook, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    content: `💬 New comment on module ${moduleId} by ${created.author.name ?? "User"}:\n> ${text}`,
+                }),
+            }).catch(() => { });
+        }
+
+        return NextResponse.json(created, { status: 201 });
+    } catch (err) {
+        console.error("POST /comments error:", err);
+        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+    }
+}

--- a/src/app/api/modules/[id]/route.ts
+++ b/src/app/api/modules/[id]/route.ts
@@ -34,6 +34,12 @@ export async function PATCH(req: NextRequest, { params }: Params) {
     return NextResponse.json({ error: parsed.error.flatten() }, { status: 422 });
   }
 
+  const existing = await db.miniApp.findUnique({
+    where: { id },
+    select: { id: true, authorId: true, name: true },
+  });
+  if (!existing) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
   const updated = await db.miniApp.update({
     where: { id },
     data: {
@@ -41,6 +47,18 @@ export async function PATCH(req: NextRequest, { params }: Params) {
       feedback: parsed.data.feedback,
     },
   });
+
+  if (parsed.data.status === "APPROVED" || parsed.data.status === "REJECTED") {
+    const when = new Date().toISOString();
+    const decision = parsed.data.status === "APPROVED" ? "approved" : "rejected";
+    await db.notification.create({
+      data: {
+        userId: existing.authorId,
+        moduleId: existing.id,
+        message: `${existing.name} was ${decision} — ${when}`,
+      },
+    });
+  }
 
   return NextResponse.json(updated);
 }

--- a/src/app/api/notifications/[id]/route.ts
+++ b/src/app/api/notifications/[id]/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+
+type Params = { params: Promise<{ id: string }> };
+
+// Mark a single notification as read
+export async function PATCH(_req: NextRequest, { params }: Params) {
+  const session = await auth();
+  if (!session?.user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { id } = await params;
+  const userId = session.user.id;
+
+  await db.notification.updateMany({
+    where: { id, userId, isRead: false },
+    data: { isRead: true, readAt: new Date() },
+  });
+
+  const unreadCount = await db.notification.count({ where: { userId, isRead: false } });
+  return NextResponse.json({ unreadCount });
+}
+

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+
+export async function GET(_req: NextRequest) {
+  const session = await auth();
+  if (!session?.user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const take = 20;
+  const userId = session.user.id;
+
+  const [unreadCount, items] = await Promise.all([
+    db.notification.count({ where: { userId, isRead: false } }),
+    db.notification.findMany({
+      where: { userId },
+      orderBy: { createdAt: "desc" },
+      take,
+    }),
+  ]);
+
+  return NextResponse.json({ unreadCount, items });
+}
+
+// Mark all notifications as read
+export async function PATCH(_req: NextRequest) {
+  const session = await auth();
+  if (!session?.user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const userId = session.user.id;
+  await db.notification.updateMany({
+    where: { userId, isRead: false },
+    data: { isRead: true, readAt: new Date() },
+  });
+
+  const unreadCount = await db.notification.count({ where: { userId, isRead: false } });
+  return NextResponse.json({ unreadCount });
+}
+

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist } from "next/font/google";
 import "./globals.css";
 import { Navbar } from "@/components/navbar";
 import { AuthSessionProvider } from "@/components/session-provider";
+import { NotifyBannerHost } from "@/components/notify-banner";
 
 const geist = Geist({ subsets: ["latin"], variable: "--font-geist" });
 
@@ -18,6 +19,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body className="flex min-h-full flex-col bg-gray-50 font-sans">
         <AuthSessionProvider>
           <Navbar />
+          <NotifyBannerHost />
           <main className="mx-auto w-full max-w-5xl flex-1 px-4 py-8">
             {children}
           </main>

--- a/src/app/modules/[slug]/page.tsx
+++ b/src/app/modules/[slug]/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { db } from "@/lib/db";
 import { auth } from "@/lib/auth";
 import { VoteButton } from "@/components/vote-button";
+import { Comments } from "@/components/comments";
 
 type Props = { params: Promise<{ slug: string }> };
 
@@ -94,6 +95,8 @@ export default async function ModuleDetailPage({ params }: Props) {
           </Link>
         </div>
       )}
+
+      <Comments moduleId={module.id} />
     </div>
   );
 }

--- a/src/app/my-submissions/page.tsx
+++ b/src/app/my-submissions/page.tsx
@@ -12,6 +12,7 @@ const statusStyles: Record<string, string> = {
 export default async function MySubmissionsPage() {
   const session = await auth();
   if (!session?.user) redirect("/api/auth/signin");
+  if (session.user.isAdmin) redirect("/admin");
 
   const submissions = await db.miniApp.findMany({
     where: { authorId: session.user.id },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,11 +19,11 @@ export default async function HomePage({
       ...(category ? { category: { slug: category } } : {}),
       ...(q
         ? {
-            OR: [
-              { name: { contains: q, mode: "insensitive" } },
-              { description: { contains: q, mode: "insensitive" } },
-            ],
-          }
+          OR: [
+            { name: { contains: q, mode: "insensitive" } },
+            { description: { contains: q, mode: "insensitive" } },
+          ],
+        }
         : {}),
     },
     // DO NOT remove include — avoids N+1 on category/author fields.
@@ -80,11 +80,10 @@ export default async function HomePage({
       <div className="flex flex-wrap gap-2">
         <a
           href="/"
-          className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
-            !category
+          className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${!category
               ? "bg-blue-600 text-white"
               : "bg-gray-100 text-gray-600 hover:bg-gray-200"
-          }`}
+            }`}
         >
           All
         </a>
@@ -92,11 +91,10 @@ export default async function HomePage({
           <a
             key={c.id}
             href={`/?category=${c.slug}`}
-            className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
-              category === c.slug
+            className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${category === c.slug
                 ? "bg-blue-600 text-white"
                 : "bg-gray-100 text-gray-600 hover:bg-gray-200"
-            }`}
+              }`}
           >
             {c.name}
           </a>

--- a/src/app/submit/page.tsx
+++ b/src/app/submit/page.tsx
@@ -6,6 +6,7 @@ import { SubmitForm } from "@/components/submit-form";
 export default async function SubmitPage() {
   const session = await auth();
   if (!session?.user) redirect("/api/auth/signin");
+  if (session.user.isAdmin) redirect("/admin");
 
   const categories = await db.category.findMany({ orderBy: { name: "asc" } });
 

--- a/src/components/comments.tsx
+++ b/src/components/comments.tsx
@@ -1,0 +1,265 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSession } from "next-auth/react";
+import { notifyBell } from "@/components/notification-bell";
+
+interface Comment {
+    id: string;
+    content: string;
+    createdAt: string;
+    isAdmin?: boolean;
+    replies?: Comment[];
+    author: {
+        id: string;
+        name: string | null;
+        image: string | null;
+    };
+}
+
+export function Comments({ moduleId }: { moduleId: string }) {
+    const { data: session } = useSession();
+    const [items, setItems] = useState<Comment[]>([]);
+    const [nextCursor, setNextCursor] = useState<string | null>(null);
+    const [loading, setLoading] = useState(false);
+    const [content, setContent] = useState("");
+    const [error, setError] = useState<string | null>(null);
+    const [success, setSuccess] = useState<string | null>(null);
+
+    async function load(initial = false) {
+        if (loading) return;
+        setLoading(true);
+        const url = new URL(`/api/modules/${moduleId}/comments`, window.location.origin);
+        if (!initial && nextCursor) url.searchParams.set("cursor", nextCursor);
+        const res = await fetch(url.toString());
+        if (!res.ok) {
+            const body = await res.json().catch(() => ({}));
+            setError(body.error || "Failed to load comments.");
+            setLoading(false);
+            return;
+        }
+        const data = await res.json();
+        if (Array.isArray(data)) {
+
+            if (initial) setItems(data);
+            else setItems((prev) => [...prev, ...data]);
+            setNextCursor(null);
+        } else {
+
+            if (initial) setItems(data.items);
+            else setItems((prev) => [...prev, ...data.items]);
+            setNextCursor(data.nextCursor);
+        }
+        setLoading(false);
+    }
+
+    useEffect(() => {
+        load(true);
+
+    }, [moduleId]);
+
+    async function submit(e: React.FormEvent, parentId?: string) {
+        e.preventDefault();
+        setError(null);
+        setSuccess(null);
+        const text = content.trim();
+        if (text.length < 2) {
+            setError("Comment must be at least 2 characters.");
+            return;
+        }
+        const res = await fetch(`/api/modules/${moduleId}/comments`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ content: text, parentId }),
+        });
+        if (!res.ok) {
+            const body = await res.json().catch(() => ({}));
+            setError(body.error || "Failed to post comment.");
+            notifyBell({ message: body.error || "Failed to post comment.", type: "error" });
+            return;
+        }
+        const created: Comment = await res.json();
+        if (parentId) {
+            setItems((prev) =>
+                prev.map((c) =>
+                    c.id === parentId
+                        ? { ...c, replies: [created, ...(c.replies ?? [])] }
+                        : c
+                )
+            );
+        } else {
+            setItems((prev) => [created, ...prev]);
+        }
+        setContent("");
+        setSuccess("Comment posted successfully");
+        setTimeout(() => setSuccess(null), 2000);
+        // Show toast under the bell without moving layout
+        notifyBell({ message: "Comment posted successfully", type: "success" });
+    }
+
+    async function submitReply(parentId: string, text: string) {
+        setError(null);
+        const body = { content: text, parentId };
+        const res = await fetch(`/api/modules/${moduleId}/comments`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(body),
+        });
+        if (!res.ok) {
+            const b = await res.json().catch(() => ({}));
+            setError(b.error || "Failed to reply.");
+            notifyBell({ message: b.error || "Failed to reply.", type: "error" });
+            return;
+        }
+        const created: Comment = await res.json();
+        setItems((prev) =>
+            prev.map((c) =>
+                c.id === parentId ? { ...c, replies: [created, ...(c.replies ?? [])] } : c
+            )
+        );
+        notifyBell({ message: "Reply sent successfully", type: "success" });
+    }
+
+    return (
+        <div className="space-y-3">
+            <h2 className="text-lg font-semibold text-gray-900">Comments</h2>
+
+            {session ? (
+                <form onSubmit={(e) => submit(e)} className="space-y-2">
+                    <textarea
+                        value={content}
+                        onChange={(e) => setContent(e.target.value)}
+                        placeholder="Write a comment…"
+                        className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+                        rows={3}
+                    />
+                    {error && <p className="text-sm text-red-600">{error}</p>}
+                    {success && <p className="text-sm text-green-600">{success}</p>}
+                    <div className="flex justify-end">
+                        <button
+                            type="submit"
+                            className="rounded-lg bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+                            disabled={content.trim().length < 2}
+                        >
+                            Post
+                        </button>
+                    </div>
+                </form>
+            ) : (
+                <p className="text-sm text-gray-500">Sign in to write a comment.</p>
+            )}
+
+            <div className="space-y-3">
+                {items.length === 0 ? (
+                    <p className="text-sm text-gray-400">No comments yet.</p>
+                ) : (
+                    items.map((c) => (
+                        <div key={c.id} className="rounded-lg border border-gray-200 bg-white p-3">
+                            <div className="mb-1 flex items-center gap-2">
+                                {c.author.image && (
+
+                                    <img
+                                        src={c.author.image}
+                                        alt=""
+                                        className="h-5 w-5 rounded-full"
+                                        loading="lazy"
+                                    />
+                                )}
+                                <span className="text-sm font-medium text-gray-900">
+                                    {c.author.name ?? "User"} {c.isAdmin ? <em className="text-xs text-orange-600">(admin)</em> : null}
+                                </span>
+                                <span className="text-xs text-gray-400">
+                                    {new Date(c.createdAt).toLocaleString()}
+                                </span>
+                            </div>
+                            <p className="text-sm text-gray-700 whitespace-pre-wrap">{c.content}</p>
+                            {session?.user?.isAdmin && (
+                                <div className="mt-2 flex justify-end">
+                                    <details>
+                                        <summary className="cursor-pointer text-xs text-blue-600 hover:underline">
+                                            Reply
+                                        </summary>
+                                        <div className="mt-2 ml-auto w-full max-w-xl">
+                                            <AdminReplyForm onSubmit={(e, text) => {
+                                                e.preventDefault();
+                                                const t = text.trim();
+                                                if (!t) return;
+                                                submitReply(c.id, t);
+                                            }} />
+                                        </div>
+                                    </details>
+                                </div>
+                            )}
+                            {(c.replies ?? []).length > 0 && (
+                                <div className="mt-2 space-y-2 border-l-2 border-gray-100 pl-3">
+                                    {(c.replies ?? []).map((r) => (
+                                        <div key={r.id}>
+                                            <div className="mb-0.5 flex items-center gap-2">
+                                                {r.author?.image && (
+                                                    // eslint-disable-next-line @next/next/no-img-element
+                                                    <img src={r.author.image} alt="" className="h-4 w-4 rounded-full" loading="lazy" />
+                                                )}
+                                                <span className="text-xs font-medium text-gray-900">
+                                                    {r.author?.name ?? "User"} {r.isAdmin ? <em className="text-[10px] text-orange-600">(admin)</em> : null}
+                                                </span>
+                                                <span className="text-[10px] text-gray-400">
+                                                    {new Date(r.createdAt).toLocaleString()}
+                                                </span>
+                                            </div>
+                                            <p className="text-sm text-gray-700 whitespace-pre-wrap">{r.content}</p>
+                                        </div>
+                                    ))}
+                                </div>
+                            )}
+                        </div>
+                    ))
+                )}
+            </div>
+
+            {nextCursor && (
+                <div className="flex justify-center">
+                    <button
+                        onClick={() => load(false)}
+                        className="rounded-lg border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
+                        disabled={loading}
+                    >
+                        {loading ? "Loading…" : "Load more"}
+                    </button>
+                </div>
+            )}
+        </div>
+    );
+}
+
+function AdminReplyForm({ onSubmit }: { onSubmit: (e: React.FormEvent, text: string) => void }) {
+    const [value, setValue] = useState("");
+    return (
+        <form
+            onSubmit={(e) => {
+                e.preventDefault();
+                const text = value.trim();
+                if (!text) return;
+                onSubmit(e, text);
+                setValue("");
+            }}
+            className="mt-2 space-y-2"
+        >
+            <textarea
+                value={value}
+                onChange={(e) => setValue(e.target.value)}
+                placeholder="Reply as admin…"
+                className="w-full min-h-[120px] rounded-lg border border-gray-300 px-3 py-2 text-sm outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+                rows={4}
+            />
+            <div className="flex justify-end">
+                <button
+                    type="submit"
+                    className="rounded-lg bg-orange-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-orange-700 disabled:opacity-50"
+                    disabled={value.trim().length < 1}
+                >
+                    Reply
+                </button>
+            </div>
+        </form>
+    );
+}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useSession, signIn, signOut } from "next-auth/react";
+import { NotificationBell } from "@/components/notification-bell";
 
 export function Navbar() {
   const { data: session } = useSession();
@@ -16,17 +17,22 @@ export function Navbar() {
         <div className="flex items-center gap-4">
           {session ? (
             <>
-              <Link href="/submit" className="text-sm text-gray-600 hover:text-gray-900">
-                Submit Module
-              </Link>
-              <Link href="/my-submissions" className="text-sm text-gray-600 hover:text-gray-900">
-                My Submissions
-              </Link>
               {session.user.isAdmin && (
                 <Link href="/admin" className="text-sm font-medium text-orange-600 hover:text-orange-700">
                   Admin
                 </Link>
               )}
+              {!session.user.isAdmin && (
+                <>
+                  <Link href="/submit" className="text-sm text-gray-600 hover:text-gray-900">
+                    Submit Module
+                  </Link>
+                  <Link href="/my-submissions" className="text-sm text-gray-600 hover:text-gray-900">
+                    My Submissions
+                  </Link>
+                </>
+              )}
+              <NotificationBell />
               <button
                 onClick={() => signOut()}
                 className="text-sm text-gray-400 hover:text-gray-600"
@@ -36,12 +42,20 @@ export function Navbar() {
               <span className="text-sm text-gray-700">{session.user.name}</span>
             </>
           ) : (
-            <button
-              onClick={() => signIn("github")}
-              className="rounded-lg bg-gray-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-gray-700"
-            >
-              Sign in with GitHub
-            </button>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => signIn("github")}
+                className="rounded-lg bg-gray-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-gray-700"
+              >
+                Sign in with GitHub
+              </button>
+              <button
+                onClick={() => signIn("google")}
+                className="rounded-lg bg-red-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-700"
+              >
+                Sign in with Google
+              </button>
+            </div>
           )}
         </div>
       </div>

--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+type NoticeType = "success" | "error" | "info";
+
+interface NotificationItem {
+    id: string;
+    message: string;
+    createdAt: string;
+    isRead: boolean;
+}
+
+export function NotificationBell() {
+    const [open, setOpen] = useState(false);
+    const [notifications, setNotifications] = useState<NotificationItem[]>([]);
+    const [unreadCount, setUnreadCount] = useState(0);
+    const panelRef = useRef<HTMLDivElement | null>(null);
+    const [toast, setToast] = useState<{ message: string; type: NoticeType } | null>(null);
+
+    function pushClientNotification(params: { message: string }) {
+        setNotifications((prev) => [
+            {
+                id: crypto.randomUUID(),
+                message: params.message,
+                createdAt: new Date().toISOString(),
+                isRead: false,
+            },
+            ...prev,
+        ].slice(0, 20));
+        setUnreadCount((c) => c + 1);
+    }
+
+    async function loadNotifications() {
+        const res = await fetch("/api/notifications");
+        if (!res.ok) return;
+        const data = await res.json();
+        setUnreadCount(data.unreadCount ?? 0);
+        setNotifications(data.items ?? []);
+    }
+
+    async function markAllRead() {
+        const res = await fetch("/api/notifications", { method: "PATCH" });
+        if (!res.ok) return;
+        // Mark current client-only items as read too, then refresh from DB.
+        setNotifications((prev) => prev.map((n) => ({ ...n, isRead: true })));
+        setUnreadCount(0);
+        await loadNotifications();
+    }
+
+    useEffect(() => {
+        function onNotify(e: Event) {
+            const d = (e as CustomEvent).detail as { message: string; type?: NoticeType };
+            setToast({ message: d.message, type: d.type ?? "info" });
+            pushClientNotification({ message: d.message });
+            const t = setTimeout(() => setToast(null), 2500);
+            return () => clearTimeout(t);
+        }
+        function onNotifyBell(e: Event) {
+            const d = (e as CustomEvent).detail as { message: string; type?: NoticeType };
+            setToast({ message: d.message, type: d.type ?? "info" });
+            pushClientNotification({ message: d.message });
+            const t = setTimeout(() => setToast(null), 2500);
+            return () => clearTimeout(t);
+        }
+        function onDocClick(ev: MouseEvent) {
+            if (!panelRef.current) return;
+            if (!panelRef.current.contains(ev.target as Node)) setOpen(false);
+        }
+        window.addEventListener("app:notify", onNotify as EventListener);
+        window.addEventListener("app:notify:bell", onNotifyBell as EventListener);
+        document.addEventListener("click", onDocClick);
+        return () => {
+            window.removeEventListener("app:notify", onNotify as EventListener);
+            window.removeEventListener("app:notify:bell", onNotifyBell as EventListener);
+            document.removeEventListener("click", onDocClick);
+        };
+    }, []);
+
+    useEffect(() => {
+        if (!open) return;
+        void (async () => {
+            await markAllRead();
+        })();
+    }, [open]);
+
+    useEffect(() => {
+        void loadNotifications();
+    }, []);
+
+    return (
+        <div className="relative" ref={panelRef}>
+            <button
+                aria-label="Notifications"
+                onClick={(e) => {
+                    e.stopPropagation();
+                    setOpen((v) => !v);
+                }}
+                className="relative rounded-full p-2 text-gray-500 hover:bg-gray-100 hover:text-gray-700"
+            >
+                <BellIcon />
+                {unreadCount > 0 && (
+                    <span className="absolute right-0 top-0 inline-flex min-w-4 items-center justify-center rounded-full bg-red-500 px-1.5 text-[10px] font-semibold text-white">
+                        {unreadCount}
+                    </span>
+                )}
+            </button>
+
+            {toast && (
+                <div
+                    className={`absolute right-0 z-50 mt-2 max-w-[320px] rounded-lg px-4 py-2 text-sm shadow-lg whitespace-nowrap overflow-hidden text-ellipsis text-left ${toast.type === "success"
+                        ? "bg-green-600 text-white"
+                        : toast.type === "error"
+                            ? "bg-red-600 text-white"
+                            : "bg-blue-600 text-white"
+                        }`}
+                >
+                    {toast.message}
+                </div>
+            )}
+
+            {open && (
+                <div className="absolute right-0 z-40 mt-2 w-80 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-lg">
+                    <div className="flex items-center justify-between border-b border-gray-100 px-3 py-2">
+                        <span className="text-sm font-medium text-gray-800">Notifications</span>
+                        <button
+                            onClick={() => void markAllRead()}
+                            disabled={unreadCount === 0}
+                            className="text-xs text-gray-400 hover:text-gray-600 disabled:opacity-50"
+                        >
+                            Mark all read
+                        </button>
+                    </div>
+                    <div className="max-h-80 overflow-y-auto">
+                        {notifications.length === 0 ? (
+                            <div className="px-4 py-6 text-center text-sm text-gray-400">No notifications</div>
+                        ) : (
+                            notifications.map((n) => (
+                                <button
+                                    key={n.id}
+                                    type="button"
+                                    onClick={async () => {
+                                        const res = await fetch(`/api/notifications/${n.id}`, { method: "PATCH" });
+                                        if (res.ok) {
+                                            setNotifications((prev) =>
+                                                prev.map((x) => (x.id === n.id ? { ...x, isRead: true } : x))
+                                            );
+                                            setUnreadCount((c) => Math.max(0, c - (n.isRead ? 0 : 1)));
+                                        }
+                                    }}
+                                    className="w-full border-b border-gray-50 px-4 py-3 text-left last:border-0 hover:bg-gray-50 disabled:cursor-pointer"
+                                >
+                                    <span className={`mr-2 inline-block h-2 w-2 rounded-full ${n.isRead ? "bg-gray-300" : "bg-blue-500"}`} />
+                                    <span className={`text-sm ${n.isRead ? "text-gray-600" : "font-semibold text-gray-800"}`}>
+                                        {n.message}
+                                    </span>
+                                    <div className="mt-0.5 text-[11px] text-gray-400">
+                                        {new Date(n.createdAt).toLocaleString()}
+                                    </div>
+                                </button>
+                            ))
+                        )}
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}
+
+function BellIcon() {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            className="h-5 w-5"
+            aria-hidden="true"
+        >
+            <path d="M12 22a2 2 0 0 0 2-2H10a2 2 0 0 0 2 2Z" />
+            <path d="M18 8a6 6 0 1 0-12 0c0 7-3 7-3 9h18c0-2-3-2-3-9Z" />
+        </svg>
+    );
+}
+
+export function notifyBell(params: { message: string; type?: NoticeType }) {
+    if (typeof window === "undefined") return;
+    window.dispatchEvent(new CustomEvent("app:notify:bell", { detail: params }));
+}

--- a/src/components/notify-banner.tsx
+++ b/src/components/notify-banner.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type BannerType = "success" | "error" | "info";
+
+export function NotifyBannerHost() {
+    const [message, setMessage] = useState<string | null>(null);
+    const [type, setType] = useState<BannerType>("info");
+
+    useEffect(() => {
+        function onNotify(e: Event) {
+            const detail = (e as CustomEvent).detail as { type?: BannerType; message: string; durationMs?: number };
+            setType(detail.type ?? "info");
+            setMessage(detail.message);
+            const timeout = setTimeout(() => setMessage(null), detail.durationMs ?? 2500);
+            return () => clearTimeout(timeout);
+        }
+        window.addEventListener("app:notify", onNotify as EventListener);
+        return () => window.removeEventListener("app:notify", onNotify as EventListener);
+    }, []);
+
+    if (!message) return null;
+
+    const color =
+        type === "success"
+            ? "bg-green-600 text-white"
+            : type === "error"
+                ? "bg-red-600 text-white"
+                : "bg-blue-600 text-white";
+
+    return (
+        <div className="pointer-events-none fixed inset-x-0 top-14 z-50 flex justify-center px-4">
+            <div className={`pointer-events-auto rounded-full ${color} px-3 py-1.5 text-xs shadow-lg`}>
+                {message}
+            </div>
+        </div>
+    );
+}
+
+export function notifyBanner(params: { message: string; type?: BannerType; durationMs?: number }) {
+    if (typeof window === "undefined") return;
+    window.dispatchEvent(new CustomEvent("app:notify", { detail: params }));
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,5 +1,6 @@
 import NextAuth from "next-auth";
 import GitHub from "next-auth/providers/github";
+import Google from "next-auth/providers/google";
 import { PrismaAdapter } from "@auth/prisma-adapter";
 import { db } from "@/lib/db";
 
@@ -9,6 +10,11 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     GitHub({
       clientId: process.env.AUTH_GITHUB_ID,
       clientSecret: process.env.AUTH_GITHUB_SECRET,
+    }),
+    Google({
+      clientId: process.env.AUTH_GOOGLE_ID,
+      clientSecret: process.env.AUTH_GOOGLE_SECRET,
+      allowDangerousEmailAccountLinking: true,
     }),
   ],
   callbacks: {


### PR DESCRIPTION

"feat: Google login, admin dashboard, comment threads with admin replies, and DB notifications" `
"feat(auth): add Google provider (keep GitHub) + admin guard redirects" `
"feat(admin): rework /admin into a dashboard layout; hide user submission links for admin" ` 
"feat(comments): add module comments with admin reply threads (parentId) + UI reply form" `
"feat(notifications): persist approve/reject notifications in DB + unread badge + mark-as-read APIs" `
"fix(ui): notification toast/dropdown styling (no awkward circle, no wrap) + success messages"
