### PR TITLE
fix: show loading state on vote button

### DIFF
--- a/src/components/vote-button.tsx
+++ b/src/components/vote-button.tsx
@@ -34,7 +34,14 @@ export function VoteButton({
     <button
       onClick={toggle}
       disabled={isLoading}
-      aria-label={voted ? "Remove vote" : "Upvote this module"}
+      aria-label={
+        isLoading
+          ? "Updating vote"
+          : voted
+            ? "Remove vote"
+            : "Upvote this module"
+      }
+      aria-busy={isLoading}
       className={`inline-flex items-center gap-1 rounded-md px-2 py-1 text-sm font-medium transition-colors
         ${voted
           ? "bg-orange-100 text-orange-600 hover:bg-orange-200"
@@ -43,7 +50,7 @@ export function VoteButton({
         disabled:opacity-50 disabled:cursor-not-allowed`}
     >
       {/* TODO [easy-challenge]: this button shows no loading state during API call — add one */}
-      <TriangleIcon filled={voted} />
+      {isLoading ? <SpinnerIcon /> : <TriangleIcon filled={voted} />}
       {count}
     </button>
   );
@@ -61,6 +68,35 @@ function TriangleIcon({ filled = false }: { filled?: boolean }) {
       aria-hidden="true"
     >
       <path d="M6 1 L11 10 L1 10 Z" />
+    </svg>
+  );
+}
+
+function SpinnerIcon() {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      className="animate-spin"
+      aria-hidden="true"
+    >
+      <circle
+        cx="6"
+        cy="6"
+        r="4.5"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeOpacity="0.25"
+      />
+      <path
+        d="M6 1.5a4.5 4.5 0 0 1 4.5 4.5"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
     </svg>
   );
 }


### PR DESCRIPTION
## Goal

Improve the vote interaction by showing a visible loading state while the vote request is in progress.

Closes #7

## Implementation

I updated the vote button UI to:
- show a spinner while the request is loading
- expose `aria-busy` during the loading state
- adjust the `aria-label` while the button is updating

I intentionally kept the change scoped to `src/components/vote-button.tsx` and did not modify the optimistic vote hook logic.

## How to test

1. Run `pnpm dev`
2. Sign in with GitHub
3. Open the home page or a module detail page
4. Click the vote button
5. Verify the button shows a loading spinner while the request is in progress
6. Run `pnpm lint src/components/vote-button.tsx`
7. Run `pnpm typecheck`

## Screenshots / recordings (if UI change)

N/A

## Checklist

- [x] I read the relevant code **before** writing my own
- [x] My code follows the existing patterns in the codebase
- [x] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
- [x] I added or updated tests where applicable
- [x] I can explain every line of code I wrote (reviewer will ask)
- [x] I kept the PR focused — no unrelated changes

## Notes for reviewer

I kept the change limited to the button presentation layer so the existing optimistic vote behavior remains unchanged.

## AI usage

I used AI as a supporting tool to help structure the UI change, but I reviewed the existing vote flow first and intentionally kept the implementation limited to the button component.
