### PR TITLE
fix: show loading state on vote button

### DIFF
--- a/src/components/vote-button.tsx
+++ b/src/components/vote-button.tsx
@@ -36,16 +36,41 @@ export function VoteButton({
       disabled={isLoading}
       aria-label={voted ? "Remove vote" : "Upvote this module"}
       className={`inline-flex items-center gap-1 rounded-md px-2 py-1 text-sm font-medium transition-colors
-        ${voted
-          ? "bg-orange-100 text-orange-600 hover:bg-orange-200"
-          : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+        ${
+          voted
+            ? "bg-orange-100 text-orange-600 hover:bg-orange-200"
+            : "bg-gray-100 text-gray-600 hover:bg-gray-200"
         }
         disabled:opacity-50 disabled:cursor-not-allowed`}
     >
       {/* TODO [easy-challenge]: this button shows no loading state during API call — add one */}
-      <TriangleIcon filled={voted} />
+      {isLoading ? <SpinnerIcon /> : <TriangleIcon filled={voted} />}
       {count}
     </button>
+  );
+}
+
+function SpinnerIcon() {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      className="animate-spin"
+      aria-hidden="true"
+    >
+      <circle
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="blue"
+        strokeWidth="3"
+        fill="none"
+        strokeDasharray="60"
+        strokeDashoffset="20"
+        strokeLinecap="round"
+      />
+    </svg>
   );
 }
 


### PR DESCRIPTION
## What does this PR do?

This PR adds a loading state to the vote button.
When a user clicks the button, a visual indicator (spinner) is displayed to show that the action is being processed.

## Related Issue

Closes #81 

## How to test

1. Start the app with pnpm dev
2. Login with Github
3. Click the vote button
4. Observe that a loading indicator appears while the request is in progress
5. Verify that the button returns to normal state after the request completes (success or failure)

## Screenshots / recordings (if UI change)

<!-- Drag and drop a screenshot or screen recording here -->

## Checklist

- [ x ] I read the relevant code **before** writing my own
- [ x ] My code follows the existing patterns in the codebase
- [ x ] I ran and `pnpm typecheck` locally — no errors
- [ x ] I added or updated tests where applicable
- [ x ] I can explain every line of code I wrote (reviewer will ask)
- [ x ] I kept the PR focused — no unrelated changes

## Notes for reviewer

During local development, I ran pnpm lint and noticed some errors in unrelated files that were already present in the codebase.
These issues were outside the scope of this PR, so I focused only on implementing the loading state for the vote button.
