### PR TITLE
Feat/build contributor leaderboard

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 ignoredBuiltDependencies:
+  - esbuild
   - sharp
   - unrs-resolver
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -95,6 +95,128 @@ async function main() {
       authorId: contributor.id,
       voteCount: 41,
     },
+
+    {
+      slug: "2048-game-productivity",
+      name: "2048 Game Productivity",
+      description:
+        "Classic 2048 puzzle game. Keyboard and touch support. Saves high score to localStorage.",
+      repoUrl: "https://github.com/example/2048",
+      demoUrl: "https://2048.example.com",
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "productivity")!.id,
+      authorId: contributor.id,
+      voteCount: 45,
+    },
+
+    {
+      slug: "2048-game-social",
+      name: "2048 Game Social",
+      description:
+        "Classic 2048 puzzle game. Keyboard and touch support. Saves high score to localStorage.",
+      repoUrl: "https://github.com/example/2048",
+      demoUrl: "https://2048.example.com",
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "social")!.id,
+      authorId: contributor.id,
+      voteCount: 1,
+    },
+    {
+      slug: "2048-game-utility",
+      name: "2048 Game Utility",
+      description:
+        "Classic 2048 puzzle game. Keyboard and touch support. Saves high score to localStorage.",
+      repoUrl: "https://github.com/example/2048",
+      demoUrl: "https://2048.example.com",
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "utility")!.id,
+      authorId: contributor.id,
+      voteCount: 2,
+    },
+    {
+      slug: "2048-game-finance",
+      name: "2048 Game Finance",
+      description:
+        "Classic 2048 puzzle game. Keyboard and touch support. Saves high score to localStorage.",
+      repoUrl: "https://github.com/example/2048",
+      demoUrl: "https://2048.example.com",
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "finance")!.id,
+      authorId: contributor.id,
+      voteCount: 41,
+    },
+    {
+      slug: "chat-app",
+      name: "Chat App",
+      description:
+        "Classic 2048 puzzle game. Keyboard and touch support. Saves high score to localStorage.",
+      repoUrl: "https://github.com/example/2048",
+      demoUrl: "https://2048.example.com",
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "utility")!.id,
+      authorId: contributor.id,
+      voteCount: 41,
+    },
+    {
+      slug: "mental-health-app",
+      name: "Mental Health App",
+      description:
+        "Classic 2048 puzzle game. Keyboard and touch support. Saves high score to localStorage.",
+      repoUrl: "https://github.com/example/2048",
+      demoUrl: "https://2048.example.com",
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "productivity")!.id,
+      authorId: contributor.id,
+      voteCount: 41,
+    },
+    {
+      slug: "surfway-surfer",
+      name: "Surfway Surfer",
+      description:
+        "Classic 2048 puzzle game. Keyboard and touch support. Saves high score to localStorage.",
+      repoUrl: "https://github.com/example/2048",
+      demoUrl: "https://2048.example.com",
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "game")!.id,
+      authorId: contributor.id,
+      voteCount: 41,
+    },
+    {
+      slug: "bank-app",
+      name: "Bank App",
+      description:
+        "Classic 2048 puzzle game. Keyboard and touch support. Saves high score to localStorage.",
+      repoUrl: "https://github.com/example/2048",
+      demoUrl: "https://2048.example.com",
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "finance")!.id,
+      authorId: contributor.id,
+      voteCount: 16,
+    },
+    {
+      slug: "mario-game",
+      name: "Mario Game",
+      description:
+        "Classic 2048 puzzle game. Keyboard and touch support. Saves high score to localStorage.",
+      repoUrl: "https://github.com/example/2048",
+      demoUrl: "https://2048.example.com",
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "game")!.id,
+      authorId: contributor.id,
+      voteCount: 13,
+    },
+    {
+      slug: "knight-game",
+      name: "Knight Game",
+      description:
+        "Classic 2048 puzzle game. Keyboard and touch support. Saves high score to localStorage.",
+      repoUrl: "https://github.com/example/2048",
+      demoUrl: "https://2048.example.com",
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "game")!.id,
+      authorId: contributor.id,
+      voteCount: 12,
+    },
   ];
 
   for (const mod of approvedModules) {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -35,7 +35,7 @@ async function main() {
     }),
   ]);
 
-  // Seed demo admin user
+  //Seed demo admin user
   const admin = await prisma.user.upsert({
     where: { email: "admin@td.com" },
     update: {},
@@ -53,6 +53,16 @@ async function main() {
     create: {
       name: "Demo Dev",
       email: "dev@example.com",
+      isAdmin: false,
+    },
+  });
+
+  const contributor2 = await prisma.user.upsert({
+    where: { email: "[EMAIL_ADDRESS]" },
+    update: {},
+    create: {
+      name: "Irisus",
+      email: "[EMAIL_ADDRESS]",
       isAdmin: false,
     },
   });
@@ -105,7 +115,7 @@ async function main() {
       demoUrl: "https://2048.example.com",
       status: SubmissionStatus.APPROVED,
       categoryId: categories.find((c) => c.slug === "productivity")!.id,
-      authorId: contributor.id,
+      authorId: contributor2.id,
       voteCount: 45,
     },
 
@@ -142,7 +152,7 @@ async function main() {
       demoUrl: "https://2048.example.com",
       status: SubmissionStatus.APPROVED,
       categoryId: categories.find((c) => c.slug === "finance")!.id,
-      authorId: contributor.id,
+      authorId: contributor2.id,
       voteCount: 41,
     },
     {
@@ -178,7 +188,7 @@ async function main() {
       demoUrl: "https://2048.example.com",
       status: SubmissionStatus.APPROVED,
       categoryId: categories.find((c) => c.slug === "game")!.id,
-      authorId: contributor.id,
+      authorId: contributor2.id,
       voteCount: 41,
     },
     {
@@ -202,7 +212,7 @@ async function main() {
       demoUrl: "https://2048.example.com",
       status: SubmissionStatus.APPROVED,
       categoryId: categories.find((c) => c.slug === "game")!.id,
-      authorId: contributor.id,
+      authorId: contributor2.id,
       voteCount: 13,
     },
     {

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -1,0 +1,80 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+
+function getCurrentUtcMonthRange() {
+    const now = new Date();
+
+    const start = new Date(
+        Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)
+    );
+
+    const end = new Date(
+        Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1)
+    );
+
+    return { start, end };
+}
+
+export async function GET() {
+    try {
+        const { start, end } = getCurrentUtcMonthRange();
+
+        const grouped = await db.miniApp.groupBy({
+            by: ["authorId"],
+            where: {
+                status: "APPROVED",
+                createdAt: {
+                    gte: start,
+                    lt: end,
+                },
+            },
+            _count: {
+                authorId: true,
+            },
+            orderBy: {
+                _count: {
+                    authorId: "desc",
+                },
+            },
+            take: 10,
+        });
+
+        const users = await db.user.findMany({
+            where: {
+                id: {
+                    in: grouped.map((item) => item.authorId),
+                },
+            },
+            select: {
+                id: true,
+                name: true,
+                image: true,
+            },
+        });
+
+        const userMap = new Map(users.map((user) => [user.id, user]));
+
+        const items = grouped.map((item, index) => ({
+            rank: index + 1,
+            approvedCount: item._count.authorId,
+            user: userMap.get(item.authorId) ?? {
+                id: item.authorId,
+                name: "Unknown user",
+                image: null,
+            },
+        }));
+
+        return NextResponse.json({
+            monthStartUtc: start.toISOString(),
+            monthEndUtc: end.toISOString(),
+            items,
+        });
+    } catch (error) {
+        console.error("GET /api/leaderboard error:", error);
+
+        return NextResponse.json(
+            { error: "Failed to load leaderboard" },
+            { status: 500 }
+        );
+    }
+}

--- a/src/app/api/modules/[id]/route.ts
+++ b/src/app/api/modules/[id]/route.ts
@@ -63,3 +63,4 @@ export async function DELETE(_req: NextRequest, { params }: Params) {
   await db.miniApp.delete({ where: { id } });
   return new NextResponse(null, { status: 204 });
 }
+

--- a/src/app/api/modules/route.ts
+++ b/src/app/api/modules/route.ts
@@ -6,6 +6,7 @@ import { generateSlug, makeUniqueSlug } from "@/lib/utils";
 
 // GET /api/modules — list approved modules (with optional category filter + search)
 export async function GET(req: NextRequest) {
+  const session = await auth();
   const { searchParams } = req.nextUrl;
   const category = searchParams.get("category");
   const search = searchParams.get("q");
@@ -18,11 +19,11 @@ export async function GET(req: NextRequest) {
       ...(category ? { category: { slug: category } } : {}),
       ...(search
         ? {
-            OR: [
-              { name: { contains: search, mode: "insensitive" } },
-              { description: { contains: search, mode: "insensitive" } },
-            ],
-          }
+          OR: [
+            { name: { contains: search, mode: "insensitive" } },
+            { description: { contains: search, mode: "insensitive" } },
+          ],
+        }
         : {}),
     },
     // NOTE: Always include category and author to avoid N+1 on listing pages.
@@ -40,7 +41,24 @@ export async function GET(req: NextRequest) {
   const items = hasMore ? modules.slice(0, limit) : modules;
   const nextCursor = hasMore ? items[items.length - 1].id : null;
 
-  return NextResponse.json({ items, nextCursor });
+  let votedIds = new Set<string>();
+  if (session?.user) {
+    const votes = await db.vote.findMany({
+      where: {
+        userId: session.user.id,
+        moduleId: { in: items.map((m) => m.id) },
+      },
+      select: { moduleId: true },
+    });
+    votedIds = new Set(votes.map((v) => v.moduleId));
+  }
+
+  const itemsWithVoteState = items.map((item) => ({
+    ...item,
+    hasVoted: votedIds.has(item.id),
+  }));
+
+  return NextResponse.json({ items: itemsWithVoteState, nextCursor });
 }
 
 // POST /api/modules — submit a new module (authenticated)

--- a/src/app/api/my-submissions/[id]/route.ts
+++ b/src/app/api/my-submissions/[id]/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { submitModuleSchema } from "@/lib/validations";
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function PATCH(req: NextRequest, { params }: Params) {
+    try {
+        const session = await auth();
+
+        if (!session?.user?.id) {
+            return NextResponse.json(
+                { error: { _: ["Unauthorized"] } },
+                { status: 401 }
+            );
+        }
+
+        const { id } = await params;
+        const body = await req.json();
+
+        const parsed = submitModuleSchema.safeParse(body);
+
+        if (!parsed.success) {
+            return NextResponse.json(
+                { error: parsed.error.flatten().fieldErrors },
+                { status: 422 }
+            );
+        }
+
+        const existingSubmission = await db.miniApp.findFirst({
+            where: {
+                id,
+                authorId: session.user.id,
+            },
+        });
+
+        if (!existingSubmission) {
+            return NextResponse.json(
+                { error: { _: ["Submission not found"] } },
+                { status: 404 }
+            );
+        }
+
+        if (existingSubmission.status !== "PENDING") {
+            return NextResponse.json(
+                { error: { _: ["Only pending submissions can be edited"] } },
+                { status: 403 }
+            );
+        }
+
+        const { name, description, categoryId, repoUrl, demoUrl } = parsed.data;
+
+        const updatedSubmission = await db.miniApp.update({
+            where: { id },
+            data: {
+                name,
+                description,
+                categoryId,
+                repoUrl,
+                demoUrl: demoUrl || null,
+            },
+        });
+
+        return NextResponse.json(updatedSubmission);
+    } catch (error) {
+        console.error("PATCH /api/my-submissions/[id] error:", error);
+        return NextResponse.json(
+            { error: { _: ["Failed to update submission"] } },
+            { status: 500 }
+        );
+    }
+}

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -1,0 +1,102 @@
+import Link from "next/link";
+
+export const revalidate = 600;
+
+interface LeaderboardItem {
+    rank: number;
+    approvedCount: number;
+    user: {
+        id: string;
+        name: string | null;
+        image: string | null;
+    };
+}
+
+async function getLeaderboard(): Promise<LeaderboardItem[]> {
+    const baseUrl = "http://localhost:3000";
+
+    const res = await fetch(`${baseUrl}/api/leaderboard`, {
+        next: { revalidate: 600 },
+    });
+
+    if (!res.ok) {
+        throw new Error("Failed to fetch leaderboard");
+    }
+
+    const data = await res.json();
+    return data.items;
+}
+
+export default async function LeaderboardPage() {
+    const items = await getLeaderboard();
+
+    return (
+        <div className="mx-auto max-w-3xl space-y-6">
+            <div className="space-y-1">
+                <h1 className="text-2xl font-bold text-gray-900">
+                    Contributor Leaderboard
+                </h1>
+                <p className="text-sm text-gray-500">
+                    Top contributors by approved module submissions this month.
+                </p>
+            </div>
+
+            {items.length === 0 ? (
+                <div className="rounded-xl border border-dashed border-gray-300 p-10 text-center">
+                    <p className="text-gray-500">
+                        No approved submissions yet this month.
+                    </p>
+                    <Link
+                        href="/"
+                        className="mt-2 block text-sm text-blue-600 hover:underline"
+                    >
+                        Browse modules
+                    </Link>
+                </div>
+            ) : (
+                <div className="overflow-hidden rounded-xl border border-gray-200 bg-white">
+                    <div className="grid grid-cols-[80px_1fr_120px] gap-4 border-b border-gray-200 bg-gray-50 px-4 py-3 text-sm font-medium text-gray-600">
+                        <span>Rank</span>
+                        <span>Contributor</span>
+                        <span className="text-right">Approved</span>
+                    </div>
+
+                    <div>
+                        {items.map((item) => (
+                            <div
+                                key={item.user.id}
+                                className="grid grid-cols-[80px_1fr_120px] items-center gap-4 border-b border-gray-100 px-4 py-4 last:border-b-0"
+                            >
+                                <span className="text-sm font-semibold text-gray-900">
+                                    #{item.rank}
+                                </span>
+
+                                <div className="flex items-center gap-3">
+                                    {item.user.image ? (
+                                        <img
+                                            src={item.user.image}
+                                            alt={item.user.name ?? "Contributor avatar"}
+                                            className="h-10 w-10 rounded-full border border-gray-200 object-cover"
+                                        />
+                                    ) : (
+                                        <div className="flex h-10 w-10 items-center justify-center rounded-full bg-gray-100 text-sm font-medium text-gray-500">
+                                            {(item.user.name ?? "?").charAt(0).toUpperCase()}
+                                        </div>
+                                    )}
+
+                                    <p className="font-medium text-gray-900">
+                                        {item.user.name ?? "Unknown user"}
+                                    </p>
+                                </div>
+
+                                <span className="text-right text-sm font-semibold text-blue-600">
+                                    {item.approvedCount}
+                                </span>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/app/my-submissions/page.tsx
+++ b/src/app/my-submissions/page.tsx
@@ -52,7 +52,11 @@ export default async function MySubmissionsPage() {
                 <p className="font-medium text-gray-900">{sub.name}</p>
                 <p className="text-xs text-gray-400">
                   {sub.category.name} ·{" "}
-                  {new Date(sub.createdAt).toLocaleDateString()}
+                  {new Date(sub.createdAt).toLocaleDateString("vi-VN", {
+                    day: "2-digit",
+                    month: "2-digit",
+                    year: "numeric",
+                  })}
                 </p>
                 {sub.feedback && (
                   <p className="mt-1 rounded-md bg-gray-50 px-2 py-1 text-xs text-gray-600">
@@ -60,13 +64,23 @@ export default async function MySubmissionsPage() {
                   </p>
                 )}
               </div>
-              <span
-                className={`shrink-0 rounded-full border px-2 py-0.5 text-xs font-medium ${
-                  statusStyles[sub.status]
-                }`}
-              >
-                {sub.status}
-              </span>
+              <div className="flex items-center gap-2">
+                <span
+                  className={`shrink-0 rounded-full border px-2 py-0.5 text-xs font-medium ${statusStyles[sub.status]
+                    }`}
+                >
+                  {sub.status}
+                </span>
+
+                {sub.status === "PENDING" && (
+                  <Link
+                    href={`/submit?editId=${sub.id}`}
+                    className="rounded-lg border border-blue-200 px-3 py-1.5 text-xs font-medium text-blue-600 hover:bg-blue-50"
+                  >
+                    Edit
+                  </Link>
+                )}
+              </div>
             </div>
           ))}
         </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { db } from "@/lib/db";
 import { auth } from "@/lib/auth";
-import { ModuleCard } from "@/components/module-card";
+// import { ModuleCard } from "@/components/module-card";
+import { ModuleList } from "@/components/module-list";
 
 // TODO [medium-challenge]: Add category filter with URL query params (state persists on refresh)
 // See: ISSUES.md for full acceptance criteria
@@ -12,18 +13,19 @@ export default async function HomePage({
 }) {
   const { q, category } = await searchParams;
   const session = await auth();
+  const limit = 12
 
-  const modules = await db.miniApp.findMany({
+  const fetchedModules = await db.miniApp.findMany({
     where: {
       status: "APPROVED",
       ...(category ? { category: { slug: category } } : {}),
       ...(q
         ? {
-            OR: [
-              { name: { contains: q, mode: "insensitive" } },
-              { description: { contains: q, mode: "insensitive" } },
-            ],
-          }
+          OR: [
+            { name: { contains: q, mode: "insensitive" } },
+            { description: { contains: q, mode: "insensitive" } },
+          ],
+        }
         : {}),
     },
     // DO NOT remove include — avoids N+1 on category/author fields.
@@ -32,8 +34,12 @@ export default async function HomePage({
       author: { select: { id: true, name: true, image: true } },
     },
     orderBy: { voteCount: "desc" },
-    take: 12,
+    take: limit + 1,
   });
+
+  const hasMore = fetchedModules.length > limit;
+  const modules = hasMore ? fetchedModules.slice(0, limit) : fetchedModules;
+  const nextCursor = hasMore ? modules[modules.length - 1].id : null;
 
   // Fetch which modules the current user has voted on
   let votedIds = new Set<string>();
@@ -49,6 +55,11 @@ export default async function HomePage({
   }
 
   const categories = await db.category.findMany({ orderBy: { name: "asc" } });
+
+  const initialModules = modules.map((module) => ({
+    ...module,
+    hasVoted: votedIds.has(module.id),
+  }));
 
   return (
     <div className="space-y-6">
@@ -80,11 +91,10 @@ export default async function HomePage({
       <div className="flex flex-wrap gap-2">
         <a
           href="/"
-          className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
-            !category
-              ? "bg-blue-600 text-white"
-              : "bg-gray-100 text-gray-600 hover:bg-gray-200"
-          }`}
+          className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${!category
+            ? "bg-blue-600 text-white"
+            : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+            }`}
         >
           All
         </a>
@@ -92,18 +102,17 @@ export default async function HomePage({
           <a
             key={c.id}
             href={`/?category=${c.slug}`}
-            className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
-              category === c.slug
-                ? "bg-blue-600 text-white"
-                : "bg-gray-100 text-gray-600 hover:bg-gray-200"
-            }`}
+            className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${category === c.slug
+              ? "bg-blue-600 text-white"
+              : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+              }`}
           >
             {c.name}
           </a>
         ))}
       </div>
 
-      {modules.length === 0 ? (
+      {initialModules.length === 0 ? (
         <div className="rounded-xl border border-dashed border-gray-300 p-12 text-center">
           <p className="text-gray-500">No modules found.</p>
           {q && (
@@ -113,15 +122,13 @@ export default async function HomePage({
           )}
         </div>
       ) : (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {modules.map((module) => (
-            <ModuleCard
-              key={module.id}
-              module={module}
-              hasVoted={votedIds.has(module.id)}
-            />
-          ))}
-        </div>
+
+        <ModuleList
+          initialModules={initialModules}
+          initialNextCursor={nextCursor}
+          q={q}
+          category={category}
+        />
       )}
     </div>
   );

--- a/src/app/submit/page.tsx
+++ b/src/app/submit/page.tsx
@@ -1,24 +1,57 @@
-import { redirect } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { SubmitForm } from "@/components/submit-form";
 
-export default async function SubmitPage() {
+export default async function SubmitPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ editId?: string }>;
+}) {
   const session = await auth();
   if (!session?.user) redirect("/api/auth/signin");
 
+  const { editId } = await searchParams;
+
   const categories = await db.category.findMany({ orderBy: { name: "asc" } });
+
+  let initialData = null;
+
+  if (editId) {
+    const submission = await db.miniApp.findFirst({
+      where: {
+        id: editId,
+        authorId: session.user.id,
+      },
+    });
+
+    if (!submission) notFound();
+
+    if (submission.status !== "PENDING") {
+      redirect("/my-submissions");
+    }
+
+    initialData = {
+      id: submission.id,
+      name: submission.name,
+      description: submission.description,
+      categoryId: submission.categoryId,
+      repoUrl: submission.repoUrl,
+      demoUrl: submission.demoUrl ?? "",
+    };
+  }
 
   return (
     <div className="mx-auto max-w-lg space-y-6">
       <div>
-        <h1 className="text-2xl font-bold text-gray-900">Submit a Module</h1>
+        <h1 className="text-2xl font-bold text-gray-900">{initialData ? "Edit Submission" : "Submit a Module"}</h1>
         <p className="mt-1 text-sm text-gray-500">
-          Share your mini-app with the TD community. Submissions are reviewed by
-          maintainers before being listed publicly.
+          {initialData
+            ? "Update your pending submission before it is reviewed."
+            : "Share your mini-app with the TD community. Submissions are reviewed by maintainers before being listed publicly."}
         </p>
       </div>
-      <SubmitForm categories={categories} />
+      <SubmitForm categories={categories} initialData={initialData} />
     </div>
   );
 }

--- a/src/components/module-list.tsx
+++ b/src/components/module-list.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useState } from "react";
+import { ModuleCard } from "@/components/module-card";
+import type { Module } from "@/types";
+
+type ModuleWithVoteState = Module & {
+    hasVoted?: boolean;
+};
+
+interface ModuleListProps {
+    initialModules: ModuleWithVoteState[];
+    initialNextCursor: string | null;
+    q?: string;
+    category?: string;
+}
+
+export function ModuleList({
+    initialModules,
+    initialNextCursor,
+    q,
+    category,
+}: ModuleListProps) {
+    const [modules, setModules] = useState(initialModules);
+    const [nextCursor, setNextCursor] = useState<string | null>(initialNextCursor);
+    const [isLoadingMore, setIsLoadingMore] = useState(false);
+
+    async function loadMore() {
+        if (!nextCursor || isLoadingMore) return;
+
+        setIsLoadingMore(true);
+        try {
+            const params = new URLSearchParams();
+            params.set("cursor", nextCursor);
+            if (q) params.set("q", q);
+            if (category) params.set("category", category);
+
+            const res = await fetch(`/api/modules?${params.toString()}`);
+            if (!res.ok) throw new Error("Failed to load more modules");
+
+            const data = await res.json();
+
+            setModules((prev) => [...prev, ...data.items]);
+            setNextCursor(data.nextCursor);
+        } finally {
+            setIsLoadingMore(false);
+        }
+    }
+
+    return (
+        <div className="space-y-6">
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                {modules.map((module) => (
+                    <ModuleCard
+                        key={module.id}
+                        module={module}
+                        hasVoted={module.hasVoted}
+                    />
+                ))}
+            </div>
+
+            {nextCursor && (
+                <div className="flex justify-center">
+                    <button
+                        onClick={loadMore}
+                        disabled={isLoadingMore}
+                        className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                        {isLoadingMore ? "Loading..." : "Load more"}
+                    </button>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -14,8 +14,15 @@ export function Navbar() {
         </Link>
 
         <div className="flex items-center gap-4">
+          <Link
+            href="/leaderboard"
+            className="text-sm text-gray-600 hover:text-gray-900"
+          >
+            Leaderboard
+          </Link>
           {session ? (
             <>
+
               <Link href="/submit" className="text-sm text-gray-600 hover:text-gray-900">
                 Submit Module
               </Link>

--- a/src/components/submit-form.tsx
+++ b/src/components/submit-form.tsx
@@ -7,12 +7,22 @@ import type { Category } from "@/types";
 
 interface SubmitFormProps {
   categories: Category[];
+  initialData?: {
+    id: string;
+    name: string;
+    description: string;
+    categoryId: string;
+    repoUrl: string;
+    demoUrl: string;
+  } | null;
 }
 
-export function SubmitForm({ categories }: SubmitFormProps) {
+export function SubmitForm({ categories, initialData = null }: SubmitFormProps) {
   const router = useRouter();
   const [error, setError] = useState<Record<string, string[]>>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const isEditMode = Boolean(initialData);
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -28,8 +38,14 @@ export function SubmitForm({ categories }: SubmitFormProps) {
 
     setIsSubmitting(true);
     try {
-      const res = await fetch("/api/modules", {
-        method: "POST",
+      const url = isEditMode
+        ? `/api/my-submissions/${initialData?.id}`
+        : "/api/modules";
+
+      const method = isEditMode ? "PATCH" : "POST";
+
+      const res = await fetch(url, {
+        method,
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(parsed.data),
       });
@@ -56,6 +72,7 @@ export function SubmitForm({ categories }: SubmitFormProps) {
           placeholder="e.g. Pomodoro Timer"
           maxLength={60}
           className={inputClass}
+          defaultValue={initialData?.name ?? ""}
         />
       </Field>
 
@@ -67,11 +84,12 @@ export function SubmitForm({ categories }: SubmitFormProps) {
           placeholder="What does your module do? Who is it for?"
           maxLength={500}
           className={inputClass}
+          defaultValue={initialData?.description ?? ""}
         />
       </Field>
 
       <Field label="Category" name="categoryId" error={error.categoryId}>
-        <select name="categoryId" className={inputClass} defaultValue="">
+        <select name="categoryId" className={inputClass} defaultValue={initialData?.categoryId ?? ""}>
           <option value="" disabled>Select a category</option>
           {categories.map((c) => (
             <option key={c.id} value={c.id}>{c.name}</option>
@@ -85,6 +103,7 @@ export function SubmitForm({ categories }: SubmitFormProps) {
           type="url"
           placeholder="https://github.com/your-username/your-repo"
           className={inputClass}
+          defaultValue={initialData?.repoUrl ?? ""}
         />
       </Field>
 
@@ -94,6 +113,7 @@ export function SubmitForm({ categories }: SubmitFormProps) {
           type="url"
           placeholder="https://your-demo.vercel.app"
           className={inputClass}
+          defaultValue={initialData?.demoUrl ?? ""}
         />
       </Field>
 
@@ -106,7 +126,13 @@ export function SubmitForm({ categories }: SubmitFormProps) {
         disabled={isSubmitting}
         className="w-full rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
       >
-        {isSubmitting ? "Submitting…" : "Submit Module"}
+        {isSubmitting
+          ? isEditMode
+            ? "Saving…"
+            : "Submitting…"
+          : isEditMode
+            ? "Save Changes"
+            : "Submit Module"}
       </button>
     </form>
   );


### PR DESCRIPTION
## What does this PR do?

This PR adds a public `/leaderboard` page that shows the top 10 contributors for the current UTC calendar month, ranked by the number of approved module submissions. It also adds an API route to fetch leaderboard data.

## Related Issue

Closes #62 

## How to test

1. Start the app and open `/leaderboard`
2. Verify the page is publicly accessible without login
3. Confirm the list shows at most 10 contributors
4. Verify each row shows rank, avatar, name, and approved submission count
5. Confirm contributors are ordered from highest to lowest approved count
6. Verify users with no approved submissions in the current month do not appear
7. If there is no leaderboard data for the current month, confirm the empty state is shown

## Screenshots / recordings (if UI change)

<img width="1234" height="479" alt="image" src="https://github.com/user-attachments/assets/e8986d31-1710-4fb7-a951-383a6232c404" />

## Checklist

- [x] I read the relevant code **before** writing my own
- [x] My code follows the existing patterns in the codebase
- [x] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
- [ ] I added or updated tests where applicable
- [x] I can explain every line of code I wrote (reviewer will ask)
- [x] I kept the PR focused — no unrelated changes

## Notes for reviewer

The leaderboard uses the current month in UTC, based on `createdAt`, and only counts submissions with `APPROVED` status. The page uses `revalidate = 600` so data is refreshed periodically without client-side polling.