### PR TITLE
fix: add aria-label to external link button in ModuleCard

### DIFF
--- a/src/components/module-card.tsx
+++ b/src/components/module-card.tsx
@@ -23,6 +23,7 @@ export function ModuleCard({ module, hasVoted = false }: ModuleCardProps) {
             href={module.demoUrl}
             target="_blank"
             rel="noopener noreferrer"
+            aria-label={`Open demo for ${module.name}`}
             className="shrink-0 text-gray-400 hover:text-gray-600"
           >
             <ExternalLinkIcon />
@@ -49,7 +50,15 @@ export function ModuleCard({ module, hasVoted = false }: ModuleCardProps) {
 
 function ExternalLinkIcon() {
   return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 14 14"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      aria-hidden="true"
+    >
       <path d="M5 2H2a1 1 0 0 0-1 1v9a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1V9" />
       <path d="M8 1h5v5" />
       <path d="M13 1 7 7" />


### PR DESCRIPTION
## What does this PR do?
Adds an `aria-label` to the icon-only external link button in the ModuleCard component to improve accessibility for screen readers.

## Related Issue
Closes #96

## How to test
1. Run the app with `pnpm dev`
2. Open the homepage and locate a module card with a demo link
3. Inspect the external link button in DevTools
4. Verify that the `<a>` element has an `aria-label` like "Open demo for {module name}"
5. Ensure the `<svg>` still has `aria-hidden="true"`

## Notes
- No visual changes were introduced
- This update only improves accessibility