### PR TITLE
Feat/issue 81 vote loading

### DIFF
--- a/src/components/module-card.tsx
+++ b/src/components/module-card.tsx
@@ -23,6 +23,7 @@ export function ModuleCard({ module, hasVoted = false }: ModuleCardProps) {
             href={module.demoUrl}
             target="_blank"
             rel="noopener noreferrer"
+            aria-label={`Open demo for ${module.name}`}
             className="shrink-0 text-gray-400 hover:text-gray-600"
           >
             <ExternalLinkIcon />
@@ -49,7 +50,15 @@ export function ModuleCard({ module, hasVoted = false }: ModuleCardProps) {
 
 function ExternalLinkIcon() {
   return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 14 14"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      aria-hidden="true"
+    >
       <path d="M5 2H2a1 1 0 0 0-1 1v9a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1V9" />
       <path d="M8 1h5v5" />
       <path d="M13 1 7 7" />

--- a/src/components/vote-button.tsx
+++ b/src/components/vote-button.tsx
@@ -34,16 +34,26 @@ export function VoteButton({
     <button
       onClick={toggle}
       disabled={isLoading}
-      aria-label={voted ? "Remove vote" : "Upvote this module"}
+      aria-label={
+        isLoading
+          ? "Updating vote"
+          : voted
+            ? "Remove vote"
+            : "Upvote this module"
+      }
       className={`inline-flex items-center gap-1 rounded-md px-2 py-1 text-sm font-medium transition-colors
-        ${voted
-          ? "bg-orange-100 text-orange-600 hover:bg-orange-200"
-          : "bg-gray-100 text-gray-600 hover:bg-gray-200"
-        }
-        disabled:opacity-50 disabled:cursor-not-allowed`}
+    ${
+      voted
+        ? "bg-orange-100 text-orange-600 hover:bg-orange-200"
+        : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+    }
+    disabled:opacity-50 disabled:cursor-not-allowed`}
     >
-      {/* TODO [easy-challenge]: this button shows no loading state during API call — add one */}
-      <TriangleIcon filled={voted} />
+      {isLoading ? (
+        <span className="animate-pulse">...</span>
+      ) : (
+        <TriangleIcon filled={voted} />
+      )}
       {count}
     </button>
   );


### PR DESCRIPTION
## What does this PR do?

Adds a loading state to the vote button so users receive visual feedback while a vote request is being processed. This also prevents repeated clicks during the API call.

## Related Issue

Closes #81

## How to test

1. Run the app with `pnpm dev`
2. Sign in with GitHub
3. Open the homepage and find any module card
4. Click the vote button
5. Verify that the button becomes disabled while the request is in progress
6. Verify that a loading indicator appears temporarily
7. Confirm that the vote count still updates correctly after the request finishes

## Screenshots / recordings (if UI change)

Added a temporary loading indicator to the vote button while the API request is in progress.

## Checklist

- [x] I read the relevant code **before** writing my own
- [x] My code follows the existing patterns in the codebase
- [x] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
- [ ] I added or updated tests where applicable
- [x] I can explain every line of code I wrote (reviewer will ask)
- [x] I kept the PR focused — no unrelated changes

## Notes for reviewer

This change reuses the existing `isLoading` state from `useOptimisticVote` instead of introducing separate local loading logic. The goal was to keep the fix minimal and consistent with the current code structure.