### PR TITLE
fix: PATCH lacks "semantic", better to use PUT

### DIFF
--- a/src/app/api/modules/[id]/route.ts
+++ b/src/app/api/modules/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
-import { adminReviewSchema } from "@/lib/validations";
+import { adminPatchSchema } from "@/lib/validations";
 
 type Params = { params: Promise<{ id: string }> };
 
@@ -20,28 +20,48 @@ export async function GET(_req: NextRequest, { params }: Params) {
   return NextResponse.json(module);
 }
 
-// PATCH /api/modules/[id] — admin approve/reject
+// PATCH /api/modules/[id] — admin approve/reject (RFC 6902 JSON Patch)
+//
+// Content-Type: application/json-patch+json
+//
+// Supported operations:
+//   { "op": "replace", "path": "/status",   "value": "APPROVED" | "REJECTED" }
+//   { "op": "replace", "path": "/feedback", "value": "<string max 500>" }
+//   { "op": "remove",  "path": "/feedback" }
 export async function PATCH(req: NextRequest, { params }: Params) {
   const session = await auth();
   if (!session?.user?.isAdmin) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
+  const contentType = req.headers.get("content-type") ?? "";
+  if (!contentType.includes("application/json-patch+json")) {
+    return NextResponse.json(
+      { error: "Content-Type must be application/json-patch+json" },
+      { status: 415 },
+    );
+  }
+
   const { id } = await params;
   const body = await req.json();
-  const parsed = adminReviewSchema.safeParse(body);
+  const parsed = adminPatchSchema.safeParse(body);
   if (!parsed.success) {
     return NextResponse.json({ error: parsed.error.flatten() }, { status: 422 });
   }
 
-  const updated = await db.miniApp.update({
-    where: { id },
-    data: {
-      status: parsed.data.status,
-      feedback: parsed.data.feedback,
-    },
-  });
+  // Reduce the patch operations into a Prisma update payload.
+  const data: { status?: "APPROVED" | "REJECTED"; feedback?: string | null } = {};
+  for (const op of parsed.data) {
+    if (op.path === "/status" && op.op === "replace") {
+      data.status = op.value;
+    } else if (op.path === "/feedback" && op.op === "replace") {
+      data.feedback = op.value;
+    } else if (op.path === "/feedback" && op.op === "remove") {
+      data.feedback = null;
+    }
+  }
 
+  const updated = await db.miniApp.update({ where: { id }, data });
   return NextResponse.json(updated);
 }
 

--- a/src/components/admin-review-card.tsx
+++ b/src/components/admin-review-card.tsx
@@ -16,10 +16,21 @@ export function AdminReviewCard({ module }: AdminReviewCardProps) {
   async function review(status: "APPROVED" | "REJECTED") {
     setIsLoading(true);
     try {
+      // Build an RFC 6902 JSON Patch document.
+      type PatchOp =
+        | { op: "replace"; path: string; value: string }
+        | { op: "remove"; path: string };
+
+      const ops: PatchOp[] = [{ op: "replace", path: "/status", value: status }];
+
+      if (feedback) {
+        ops.push({ op: "replace", path: "/feedback", value: feedback });
+      }
+
       await fetch(`/api/modules/${module.id}`, {
         method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ status, feedback: feedback || undefined }),
+        headers: { "Content-Type": "application/json-patch+json" },
+        body: JSON.stringify(ops),
       });
       router.refresh();
     } finally {

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -27,5 +27,41 @@ export const adminReviewSchema = z.object({
   feedback: z.string().max(500).optional(),
 });
 
+/**
+ * RFC 6902 JSON Patch schema for admin review.
+ *
+ * Allowed operations:
+ *   { "op": "replace", "path": "/status",   "value": "APPROVED" | "REJECTED" }
+ *   { "op": "replace", "path": "/feedback", "value": "<string max 500>" }
+ *   { "op": "remove",  "path": "/feedback" }
+ *
+ * Example request body:
+ * [
+ *   { "op": "replace", "path": "/status",   "value": "REJECTED" },
+ *   { "op": "replace", "path": "/feedback", "value": "Please add a demo link." }
+ * ]
+ */
+const adminPatchOpSchema = z.union([
+  z.object({
+    op: z.literal("replace"),
+    path: z.literal("/status"),
+    value: z.enum(["APPROVED", "REJECTED"]),
+  }),
+  z.object({
+    op: z.literal("replace"),
+    path: z.literal("/feedback"),
+    value: z.string().max(500),
+  }),
+  z.object({
+    op: z.literal("remove"),
+    path: z.literal("/feedback"),
+  }),
+]);
+
+export const adminPatchSchema = z
+  .array(adminPatchOpSchema)
+  .min(1, "At least one patch operation is required");
+
 export type SubmitModuleInput = z.infer<typeof submitModuleSchema>;
 export type AdminReviewInput = z.infer<typeof adminReviewSchema>;
+export type AdminPatchInput = z.infer<typeof adminPatchSchema>;


### PR DESCRIPTION
## What does this PR do?

Your PATCH api look like a "replacement", it looks like more a PUT
- if it's a PUT it is better return 204 bc client already the content it wants to replace.
- If it's intent is a PATCH, your PATCH lacks the semantic "what to do with each field, for example null field meaning delete or leave it", my recommendation is to follow JSON Patch (RFC 6902).

## Related Issue

Closes #

## How to test
Don't run anything due to security issues. The code the generated by claude.
## Screenshots / recordings (if UI change)

<!-- Drag and drop a screenshot or screen recording here -->

## Checklist

- [ ] I read the relevant code **before** writing my own
- [ ] My code follows the existing patterns in the codebase
- [ ] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
- [ ] I added or updated tests where applicable
- [ ] I can explain every line of code I wrote (reviewer will ask)
- [ ] I kept the PR focused — no unrelated changes

## Notes for reviewer

<!-- Anything you want to highlight, trade-offs you made, or questions you have -->
