### PR TITLE
feat: allow deleting pending submissions

### DIFF
--- a/src/app/api/modules/[id]/route.ts
+++ b/src/app/api/modules/[id]/route.ts
@@ -60,6 +60,13 @@ export async function DELETE(_req: NextRequest, { params }: Params) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
+  if (module.authorId === session.user.id && !session.user.isAdmin && module.status !== "PENDING") {
+    return NextResponse.json(
+      { error: "Only pending submissions can be deleted by the author." },
+      { status: 403 }
+    );
+  }
+
   await db.miniApp.delete({ where: { id } });
   return new NextResponse(null, { status: 204 });
 }

--- a/src/app/my-submissions/page.tsx
+++ b/src/app/my-submissions/page.tsx
@@ -2,12 +2,7 @@ import { redirect } from "next/navigation";
 import Link from "next/link";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
-
-const statusStyles: Record<string, string> = {
-  PENDING: "bg-yellow-50 text-yellow-700 border-yellow-200",
-  APPROVED: "bg-green-50 text-green-700 border-green-200",
-  REJECTED: "bg-red-50 text-red-700 border-red-200",
-};
+import { SubmissionList } from "@/components/submission-list";
 
 export default async function MySubmissionsPage() {
   const session = await auth();
@@ -42,34 +37,12 @@ export default async function MySubmissionsPage() {
           </Link>
         </div>
       ) : (
-        <div className="space-y-3">
-          {submissions.map((sub) => (
-            <div
-              key={sub.id}
-              className="flex items-start justify-between rounded-xl border border-gray-200 bg-white p-4"
-            >
-              <div className="space-y-1">
-                <p className="font-medium text-gray-900">{sub.name}</p>
-                <p className="text-xs text-gray-400">
-                  {sub.category.name} ·{" "}
-                  {new Date(sub.createdAt).toLocaleDateString()}
-                </p>
-                {sub.feedback && (
-                  <p className="mt-1 rounded-md bg-gray-50 px-2 py-1 text-xs text-gray-600">
-                    Feedback: {sub.feedback}
-                  </p>
-                )}
-              </div>
-              <span
-                className={`shrink-0 rounded-full border px-2 py-0.5 text-xs font-medium ${
-                  statusStyles[sub.status]
-                }`}
-              >
-                {sub.status}
-              </span>
-            </div>
-          ))}
-        </div>
+        <SubmissionList
+          initialSubmissions={submissions.map((submission) => ({
+            ...submission,
+            createdAt: submission.createdAt.toISOString(),
+          }))}
+        />
       )}
     </div>
   );

--- a/src/components/submission-list.tsx
+++ b/src/components/submission-list.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useState, startTransition } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+
+type Submission = {
+  id: string;
+  name: string;
+  feedback: string | null;
+  status: "PENDING" | "APPROVED" | "REJECTED";
+  createdAt: string;
+  category: {
+    name: string;
+  };
+};
+
+const statusStyles: Record<Submission["status"], string> = {
+  PENDING: "bg-yellow-50 text-yellow-700 border-yellow-200",
+  APPROVED: "bg-green-50 text-green-700 border-green-200",
+  REJECTED: "bg-red-50 text-red-700 border-red-200",
+};
+
+export function SubmissionList({
+  initialSubmissions,
+}: {
+  initialSubmissions: Submission[];
+}) {
+  const router = useRouter();
+  const [submissions, setSubmissions] = useState(initialSubmissions);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleDelete(id: string, name: string) {
+    const confirmed = window.confirm(`Delete "${name}"? This cannot be undone.`);
+    if (!confirmed) return;
+
+    setDeletingId(id);
+    setError(null);
+
+    try {
+      const res = await fetch(`/api/modules/${id}`, { method: "DELETE" });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        setError(body?.error ?? "Failed to delete submission.");
+        return;
+      }
+
+      setSubmissions((current) => current.filter((submission) => submission.id !== id));
+      startTransition(() => {
+        router.refresh();
+      });
+    } catch {
+      setError("Failed to delete submission.");
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
+  if (submissions.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed border-gray-300 p-12 text-center">
+        <p className="text-gray-500">No submissions yet.</p>
+        <Link href="/submit" className="mt-2 block text-sm text-blue-600 hover:underline">
+          Submit your first module →
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {error && <p className="text-sm text-red-600">{error}</p>}
+
+      {submissions.map((sub) => {
+        const isDeleting = deletingId === sub.id;
+
+        return (
+          <div
+            key={sub.id}
+            className="flex items-start justify-between gap-4 rounded-xl border border-gray-200 bg-white p-4"
+          >
+            <div className="space-y-1">
+              <p className="font-medium text-gray-900">{sub.name}</p>
+              <p className="text-xs text-gray-400">
+                {sub.category.name} · {new Date(sub.createdAt).toLocaleDateString()}
+              </p>
+              {sub.feedback && (
+                <p className="mt-1 rounded-md bg-gray-50 px-2 py-1 text-xs text-gray-600">
+                  Feedback: {sub.feedback}
+                </p>
+              )}
+            </div>
+
+            <div className="flex shrink-0 flex-col items-end gap-2">
+              <span
+                className={`rounded-full border px-2 py-0.5 text-xs font-medium ${statusStyles[sub.status]}`}
+              >
+                {sub.status}
+              </span>
+
+              {sub.status === "PENDING" && (
+                <button
+                  type="button"
+                  onClick={() => handleDelete(sub.id, sub.name)}
+                  disabled={isDeleting}
+                  className="rounded-lg border border-red-200 px-3 py-1.5 text-xs font-medium text-red-600 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {isDeleting ? "Deleting…" : "Delete"}
+                </button>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## Goal

This PR improves the `My Submissions` page by allowing users to delete their own submissions while they are still in the `PENDING` state.

More specifically, the goals were:
- allow authors to delete their own `PENDING` submissions
- prevent authors from deleting `APPROVED` or `REJECTED` submissions
- update the list after deletion without a full page reload
- enforce the same rule in both the UI and the API

## Implementation

I kept the `My Submissions` page as a Server Component so it can continue to fetch data and check the current session on the server.

The interactive deletion flow was moved into a small Client Component responsible for:
- rendering a `Delete` button only for `PENDING` submissions
- showing a confirmation prompt before deletion
- calling `DELETE /api/modules/[id]`
- updating the local list immediately after a successful delete
- calling `router.refresh()` to re-sync with server data

On the API side, I updated the authorization logic so that:
- authors can delete only their own submissions when the status is `PENDING`
- admins keep their existing delete capability
- the API returns `403` when an author tries to delete a submission that is no longer pending

I chose this approach to keep the change focused, preserve the existing server/client separation in the project, and ensure the permission rule is enforced at the backend level instead of only in the UI.

## Testing

I verified the change with:
- `pnpm typecheck`
- `pnpm test`

I also checked the feature flow manually by:
1. signing in and opening `/my-submissions`
2. confirming that `PENDING` submissions show a `Delete` button
3. deleting a pending submission and confirming the prompt
4. verifying that the item disappears from the list without a full page reload
5. verifying that `APPROVED` and `REJECTED` submissions do not show a delete action for the author
6. verifying that the API rejects deletion attempts for author-owned submissions that are no longer `PENDING`

## AI Usage

I used AI as a development assistant to:
- inspect the codebase and identify the correct scope for the change
- reason about the server/client split for this feature
- review edge cases around authorization and post-delete UI updates

I still verified the final result myself by:
- reading the relevant code before making changes
- keeping the PR narrowly scoped on a dedicated branch
- running typecheck and tests after implementation