### PR TITLE
feat: add cursor-based module pagination

### DIFF
--- a/src/app/api/modules/route.ts
+++ b/src/app/api/modules/route.ts
@@ -6,6 +6,7 @@ import { generateSlug, makeUniqueSlug } from "@/lib/utils";
 
 // GET /api/modules — list approved modules (with optional category filter + search)
 export async function GET(req: NextRequest) {
+  const session = await auth();
   const { searchParams } = req.nextUrl;
   const category = searchParams.get("category");
   const search = searchParams.get("q");
@@ -40,7 +41,25 @@ export async function GET(req: NextRequest) {
   const items = hasMore ? modules.slice(0, limit) : modules;
   const nextCursor = hasMore ? items[items.length - 1].id : null;
 
-  return NextResponse.json({ items, nextCursor });
+  let votedIds = new Set<string>();
+  if (session?.user && items.length > 0) {
+    const votes = await db.vote.findMany({
+      where: {
+        userId: session.user.id,
+        moduleId: { in: items.map((module) => module.id) },
+      },
+      select: { moduleId: true },
+    });
+    votedIds = new Set(votes.map((vote) => vote.moduleId));
+  }
+
+  return NextResponse.json({
+    items: items.map((item) => ({
+      ...item,
+      hasVoted: votedIds.has(item.id),
+    })),
+    nextCursor,
+  });
 }
 
 // POST /api/modules — submit a new module (authenticated)

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 import { db } from "@/lib/db";
 import { auth } from "@/lib/auth";
-import { ModuleCard } from "@/components/module-card";
+import { ModuleList } from "@/components/module-list";
 
 // TODO [medium-challenge]: Add category filter with URL query params (state persists on refresh)
 // See: ISSUES.md for full acceptance criteria
@@ -12,6 +12,7 @@ export default async function HomePage({
 }) {
   const { q, category } = await searchParams;
   const session = await auth();
+  const limit = 12;
 
   const modules = await db.miniApp.findMany({
     where: {
@@ -32,8 +33,12 @@ export default async function HomePage({
       author: { select: { id: true, name: true, image: true } },
     },
     orderBy: { voteCount: "desc" },
-    take: 12,
+    take: limit + 1,
   });
+
+  const hasMore = modules.length > limit;
+  const initialItems = hasMore ? modules.slice(0, limit) : modules;
+  const initialNextCursor = hasMore ? initialItems[initialItems.length - 1].id : null;
 
   // Fetch which modules the current user has voted on
   let votedIds = new Set<string>();
@@ -41,7 +46,7 @@ export default async function HomePage({
     const votes = await db.vote.findMany({
       where: {
         userId: session.user.id,
-        moduleId: { in: modules.map((m) => m.id) },
+        moduleId: { in: initialItems.map((m) => m.id) },
       },
       select: { moduleId: true },
     });
@@ -113,15 +118,15 @@ export default async function HomePage({
           )}
         </div>
       ) : (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {modules.map((module) => (
-            <ModuleCard
-              key={module.id}
-              module={module}
-              hasVoted={votedIds.has(module.id)}
-            />
-          ))}
-        </div>
+        <ModuleList
+          initialModules={initialItems.map((module) => ({
+            ...module,
+            hasVoted: votedIds.has(module.id),
+          }))}
+          initialNextCursor={initialNextCursor}
+          q={q}
+          category={category}
+        />
       )}
     </div>
   );

--- a/src/components/module-list.tsx
+++ b/src/components/module-list.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState } from "react";
+import { ModuleCard } from "@/components/module-card";
+import type { Module } from "@/types";
+
+type ModuleListProps = {
+  initialModules: Module[];
+  initialNextCursor: string | null;
+  category?: string;
+  q?: string;
+};
+
+type ModulesResponse = {
+  items: Module[];
+  nextCursor: string | null;
+};
+
+export function ModuleList({
+  initialModules,
+  initialNextCursor,
+  category,
+  q,
+}: ModuleListProps) {
+  const [modules, setModules] = useState(initialModules);
+  const [nextCursor, setNextCursor] = useState(initialNextCursor);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function loadMore() {
+    if (!nextCursor || isLoadingMore) return;
+
+    setIsLoadingMore(true);
+    setError(null);
+
+    try {
+      const params = new URLSearchParams();
+      params.set("cursor", nextCursor);
+      if (category) params.set("category", category);
+      if (q) params.set("q", q);
+
+      const res = await fetch(`/api/modules?${params.toString()}`);
+      if (!res.ok) throw new Error("Failed to load more modules.");
+
+      const body = (await res.json()) as ModulesResponse;
+      setModules((current) => [...current, ...body.items]);
+      setNextCursor(body.nextCursor);
+    } catch {
+      setError("Failed to load more modules.");
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {modules.map((module) => (
+          <ModuleCard
+            key={module.id}
+            module={module}
+            hasVoted={module.hasVoted}
+          />
+        ))}
+      </div>
+
+      {error && <p className="text-sm text-red-600 dark:text-red-400">{error}</p>}
+
+      {nextCursor && (
+        <div className="flex justify-center">
+          <button
+            type="button"
+            onClick={loadMore}
+            disabled={isLoadingMore}
+            className="rounded-lg border border-gray-300 dark:border-gray-600 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isLoadingMore ? "Loading…" : "Load more"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Goal

This PR adds cursor-based pagination to the module listing so users can load more approved modules beyond the initial page.

The goals were:
- add a `Load more` interaction when more modules are available
- append the next page of results without a full page reload
- use the existing `nextCursor` API contract instead of offset-based pagination
- preserve the current filtering behavior and vote state for signed-in users

## Implementation

I used a hybrid approach to keep the initial page server-rendered while adding client-side pagination only where interactivity is needed.

The implementation includes:
- keeping the main page as a Server Component for the initial data fetch
- changing the initial query to fetch `limit + 1` items in order to detect whether more results exist
- introducing a small Client Component to manage:
  - the current list of modules
  - the next cursor
  - the loading state
  - fetch errors while loading additional pages
- wiring the `Load more` button to `GET /api/modules?cursor=...`
- appending the next batch of modules to the existing list on success
- updating the API response so paginated results also include `hasVoted` for the current signed-in user

I chose this approach because it preserves SSR for the first page, keeps the page responsive, and limits the client-side surface area to just the pagination behavior.

## Testing

I verified the change with:
- `pnpm typecheck`
- `pnpm test`

I also validated the feature flow manually by:
1. opening the home page with enough seeded modules to require pagination
2. verifying that the first page renders normally
3. clicking `Load more`
4. confirming that the next page is appended instead of replacing the existing list
5. verifying that the loading state is shown while the request is pending
6. confirming that the button disappears when there is no next cursor
7. verifying that search and category filters continue to work with paginated requests

## AI Usage

I used AI as a development assistant to:
- inspect the existing page and API implementation
- reason about the best split between Server and Client Components
- review how to preserve vote state in paginated API responses

I still verified the final solution manually by:
- reading the existing code paths before making changes
- keeping the feature isolated to a dedicated branch
- running typecheck and tests after implementation
