### PR TITLE
test: cover validation schemas

### DIFF
--- a/__tests__/validations.test.ts
+++ b/__tests__/validations.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { adminReviewSchema, submitModuleSchema } from "@/lib/validations";
+
+describe("submitModuleSchema", () => {
+  const validInput = {
+    name: "Pomodoro Timer",
+    description: "A focused timer app for study sessions and deep work blocks.",
+    categoryId: "cm9z8x2ha0000jv04m5jck7t9",
+    repoUrl: "https://github.com/example/pomodoro-timer",
+    demoUrl: "https://pomodoro.example.com",
+  };
+
+  it("accepts a valid module submission", () => {
+    const result = submitModuleSchema.safeParse(validInput);
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a repository URL outside GitHub", () => {
+    const result = submitModuleSchema.safeParse({
+      ...validInput,
+      repoUrl: "https://gitlab.com/example/pomodoro-timer",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.flatten().fieldErrors.repoUrl).toContain(
+      "Must be a GitHub repository URL"
+    );
+  });
+
+  it("rejects an invalid category id", () => {
+    const result = submitModuleSchema.safeParse({
+      ...validInput,
+      categoryId: "not-a-cuid",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.flatten().fieldErrors.categoryId).toContain(
+      "Please select a valid category"
+    );
+  });
+
+  it("rejects descriptions shorter than the minimum length", () => {
+    const result = submitModuleSchema.safeParse({
+      ...validInput,
+      description: "Too short",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.flatten().fieldErrors.description).toContain(
+      "Description must be at least 20 characters"
+    );
+  });
+
+  it("transforms an empty demo URL into undefined", () => {
+    const result = submitModuleSchema.safeParse({
+      ...validInput,
+      demoUrl: "",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data?.demoUrl).toBeUndefined();
+  });
+});
+
+describe("adminReviewSchema", () => {
+  it("accepts an approved review with optional feedback", () => {
+    const result = adminReviewSchema.safeParse({
+      status: "APPROVED",
+      feedback: "Looks good. Clear UX and sensible defaults.",
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects unsupported review statuses", () => {
+    const result = adminReviewSchema.safeParse({
+      status: "PENDING",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.flatten().fieldErrors.status).toBeTruthy();
+  });
+
+  it("rejects feedback longer than 500 characters", () => {
+    const result = adminReviewSchema.safeParse({
+      status: "REJECTED",
+      feedback: "x".repeat(501),
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.flatten().fieldErrors.feedback).toContain(
+      "Too big: expected string to have <=500 characters"
+    );
+  });
+});


### PR DESCRIPTION
## Goal

This PR adds test coverage for the validation schemas used by the module submission and admin review flows.

The goals were:
- verify that valid inputs are accepted
- verify that invalid inputs are rejected with the expected field-level errors
- cover important edge cases such as invalid repository URLs, invalid category IDs, short descriptions, and empty optional demo URLs
- increase confidence in the validation layer without changing production behavior

## Implementation

This PR adds a dedicated test file for the existing Zod schemas in `src/lib/validations.ts`.

The tests cover:
- successful parsing of valid module submission input
- rejection of non-GitHub repository URLs
- rejection of invalid `categoryId` values
- rejection of descriptions below the minimum length
- transformation of an empty `demoUrl` into `undefined`
- successful parsing of valid admin review input
- rejection of unsupported review statuses
- rejection of feedback longer than the allowed limit

I intentionally kept this PR test-only. I did not change the validation logic itself, because the goal here was to lock in the current behavior and improve confidence through automated checks.

## Testing

I verified the change with:
- `pnpm typecheck`
- `pnpm test`

In addition, the new tests specifically validate:
1. accepted and rejected submission payloads
2. schema transforms for optional values
3. accepted and rejected admin review payloads
4. field-level validation behavior for common edge cases

## AI Usage

I used AI as a development assistant to:
- inspect the existing validation schemas
- identify the most useful edge cases to cover
- refine the structure of the test cases before implementation

I still verified the final result manually by:
- reading the schema definitions directly before writing assertions
- keeping the PR focused on tests only
- running typecheck and the test suite after implementation
