### PR TITLE
feat: Add character counter to description textarea (max 500 chars)

### DIFF
--- a/src/components/submit-form.tsx
+++ b/src/components/submit-form.tsx
@@ -9,10 +9,14 @@ interface SubmitFormProps {
   categories: Category[];
 }
 
+const DESCRIPTION_MAX = 500;
+const DESCRIPTION_WARN_AT = 450;
+
 export function SubmitForm({ categories }: SubmitFormProps) {
   const router = useRouter();
   const [error, setError] = useState<Record<string, string[]>>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [descLength, setDescLength] = useState(0);
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -59,13 +63,26 @@ export function SubmitForm({ categories }: SubmitFormProps) {
         />
       </Field>
 
-      <Field label="Description" name="description" error={error.description} hint="Max 500 characters">
-        {/* TODO [easy-challenge]: add a live character counter below this textarea */}
+      <Field
+        label="Description"
+        name="description"
+        error={error.description}
+        hint={
+          <span
+            className={descLength >= DESCRIPTION_WARN_AT ? "text-red-500" : "text-gray-400"}
+            aria-live="polite"
+          >
+            {descLength} / {DESCRIPTION_MAX}
+          </span>
+        }
+      >
         <textarea
           name="description"
+          id="description"
           rows={4}
           placeholder="What does your module do? Who is it for?"
-          maxLength={500}
+          maxLength={DESCRIPTION_MAX}
+          onChange={(e) => setDescLength(e.target.value.length)}
           className={inputClass}
         />
       </Field>
@@ -125,7 +142,7 @@ function Field({
   label: string;
   name: string;
   error?: string[];
-  hint?: string;
+  hint?: React.ReactNode;
   children: React.ReactNode;
 }) {
   return (


### PR DESCRIPTION
## What does this PR do?

Add a live character counter to the description textarea in the submit form. Users can now see how many characters they've used out of the 500-character limit, with a visual warning when approaching the limit.

## Related Issue

Closes #168

## How to test

<!-- Exact steps for the reviewer to verify your change works -->

1. Go to /submit
2. Click into the "Description" textarea and start typing
3. Verify the counter below shows X / 500 and updates on each keystroke
4. Type until 450+ characters — verify the counter turns red
5. Paste text exceeding 500 chars — verify maxLength prevents input beyond the limit

## Checklist

- [x] I read the relevant code before writing my own
- [x] My code follows the existing patterns in the codebase (hint prop on Field, existing useState pattern)
- [x] I ran pnpm lint and pnpm typecheck locally — no errors
- [x] I added or updated tests where applicable (UI-only change, no logic to unit test)
- [x] I can explain every line of code I wrote (reviewer will ask)
- [x] I kept the PR focused — no unrelated changes
## Notes for reviewer

- Used the existing hint prop on the Field component rather than adding a new prop or separate element — keeps the pattern consistent with the rest of the form
- DESCRIPTION_WARN_AT = 450 is defined as a named constant alongside DESCRIPTION_MAX so the threshold is easy to adjust
- aria-live="polite" ensures screen readers announce the counter update without interrupting the user mid-typing
- maxLength on the textarea is the hard enforcement — the counter is purely informational
