### PR TITLE
feat: add character counter to discription textarea

### DIFF
--- a/src/components/submit-form.tsx
+++ b/src/components/submit-form.tsx
@@ -9,10 +9,14 @@ interface SubmitFormProps {
   categories: Category[];
 }
 
+const CHARS_MAX = 500;
+const CHARS_WARNING = 450;
+
 export function SubmitForm({ categories }: SubmitFormProps) {
   const router = useRouter();
   const [error, setError] = useState<Record<string, string[]>>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [descriptionLength, setDescriptionLength] = useState(0);
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -36,7 +40,9 @@ export function SubmitForm({ categories }: SubmitFormProps) {
 
       if (!res.ok) {
         const body = await res.json();
-        setError(body.error?.fieldErrors ?? { _: ["Submission failed. Try again."] });
+        setError(
+          body.error?.fieldErrors ?? { _: ["Submission failed. Try again."] },
+        );
         return;
       }
 
@@ -46,6 +52,9 @@ export function SubmitForm({ categories }: SubmitFormProps) {
       setIsSubmitting(false);
     }
   }
+
+  const isCloseLimit = descriptionLength >= CHARS_WARNING;
+  const isLimit = descriptionLength >= CHARS_MAX;
 
   return (
     <form onSubmit={handleSubmit} className="space-y-5">
@@ -59,7 +68,12 @@ export function SubmitForm({ categories }: SubmitFormProps) {
         />
       </Field>
 
-      <Field label="Description" name="description" error={error.description} hint="Max 500 characters">
+      <Field
+        label="Description"
+        name="description"
+        error={error.description}
+        hint="Max 500 characters"
+      >
         {/* TODO [easy-challenge]: add a live character counter below this textarea */}
         <textarea
           name="description"
@@ -67,14 +81,34 @@ export function SubmitForm({ categories }: SubmitFormProps) {
           placeholder="What does your module do? Who is it for?"
           maxLength={500}
           className={inputClass}
+          onChange={(e) => setDescriptionLength(e.target.value.length)}
+          aria-describedby="description-counter"
         />
+        <p
+          id="description-counter"
+          aria-live="polite"
+          aria-atomic="true"
+          className={`text-right text-xs tabular-num transition-colors ${
+            isLimit
+              ? "text-red-600 font-medium"
+              : isCloseLimit
+                ? "text-orange-400"
+                : "text-gray-400"
+          }`}
+        >
+          {descriptionLength} / {CHARS_MAX}
+        </p>
       </Field>
 
       <Field label="Category" name="categoryId" error={error.categoryId}>
         <select name="categoryId" className={inputClass} defaultValue="">
-          <option value="" disabled>Select a category</option>
+          <option value="" disabled>
+            Select a category
+          </option>
           {categories.map((c) => (
-            <option key={c.id} value={c.id}>{c.name}</option>
+            <option key={c.id} value={c.id}>
+              {c.name}
+            </option>
           ))}
         </select>
       </Field>
@@ -97,9 +131,7 @@ export function SubmitForm({ categories }: SubmitFormProps) {
         />
       </Field>
 
-      {error._ && (
-        <p className="text-sm text-red-600">{error._.join(", ")}</p>
-      )}
+      {error._ && <p className="text-sm text-red-600">{error._.join(", ")}</p>}
 
       <button
         type="submit"


### PR DESCRIPTION
## What does this PR do?

Add a live character counter below the description textarea . Users can now see how many characters they've typed out of the 500-character limit, with a color warning as they approach the cap.

## Related Issue

Closes #183 

## How to test

1. Start the app with pnpm dev
2. Login with github
3. Click into Submit module
4. Click into the **Description** field and start typing
5. Observe live counter change and warning when reach limit

## Screenshots / recordings (if UI change)

<!-- Drag and drop a screenshot or screen recording here -->
<img width="744" height="223" alt="image" src="https://github.com/user-attachments/assets/6566560d-aafe-441d-a9a1-aa17e27e0592" />

## Checklist

- [ x ] I read the relevant code **before** writing my own
- [ x ] My code follows the existing patterns in the codebase
- [ x ] I ran  and `pnpm typecheck` locally — no errors
- [ x ] I added or updated tests where applicable
- [ x ] I can explain every line of code I wrote (reviewer will ask)
- [ x ] I kept the PR focused — no unrelated changes

## Notes for reviewer

- During local development, I ran pnpm lint locally and noticed some errors in unrelated files that were already present in the codebase.
- These issues were outside the scope of this PR, so I focused only on implementing the live counter to description textarea.
- All changes in this PR pass lint and type checks for the relevant parts of the code I worked on.
