### PR TITLE
feat: allow deleting pending submissions in my submissions page

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { generateSlug, makeUniqueSlug, formatRelativeTime } from "@/lib/utils";
+import { generateSlug, makeUniqueSlug } from "@/lib/utils";
 
 // ============================================================
 // generateSlug — already written as examples

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,9 @@ services:
     image: postgres:16-alpine
     restart: unless-stopped
     environment:
-      POSTGRES_USER: td_user
-      POSTGRES_PASSWORD: td_password
-      POSTGRES_DB: td_community
+      POSTGRES_USER: intern_user
+      POSTGRES_PASSWORD: intern_password
+      POSTGRES_DB: intern_community
     ports:
       - "5432:5432"
     volumes:

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -36,7 +36,7 @@ async function main() {
   ]);
 
   // Seed demo admin user
-  const admin = await prisma.user.upsert({
+  await prisma.user.upsert({
     where: { email: "admin@td.com" },
     update: {},
     create: {

--- a/src/app/api/modules/[id]/route.ts
+++ b/src/app/api/modules/[id]/route.ts
@@ -8,7 +8,7 @@ type Params = { params: Promise<{ id: string }> };
 // GET /api/modules/[id]
 export async function GET(_req: NextRequest, { params }: Params) {
   const { id } = await params;
-  const module = await db.miniApp.findUnique({
+  const miniApp = await db.miniApp.findUnique({
     where: { id },
     include: {
       category: true,
@@ -16,8 +16,8 @@ export async function GET(_req: NextRequest, { params }: Params) {
       _count: { select: { votes: true } },
     },
   });
-  if (!module) return NextResponse.json({ error: "Not found" }, { status: 404 });
-  return NextResponse.json(module);
+  if (!miniApp) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  return NextResponse.json(miniApp);
 }
 
 // PATCH /api/modules/[id] — admin approve/reject
@@ -45,7 +45,7 @@ export async function PATCH(req: NextRequest, { params }: Params) {
   return NextResponse.json(updated);
 }
 
-// DELETE /api/modules/[id] — author or admin can delete their own submission
+// DELETE /api/modules/[id] — author can delete PENDING only, admin can delete any
 export async function DELETE(_req: NextRequest, { params }: Params) {
   const session = await auth();
   if (!session?.user) {
@@ -53,11 +53,21 @@ export async function DELETE(_req: NextRequest, { params }: Params) {
   }
 
   const { id } = await params;
-  const module = await db.miniApp.findUnique({ where: { id } });
-  if (!module) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  const miniApp = await db.miniApp.findUnique({ where: { id } });
+  if (!miniApp) return NextResponse.json({ error: "Not found" }, { status: 404 });
 
-  if (module.authorId !== session.user.id && !session.user.isAdmin) {
+  const isOwner = miniApp.authorId === session.user.id;
+  const isAdmin = !!session.user.isAdmin;
+
+  if (!isOwner && !isAdmin) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  if (isOwner && !isAdmin && miniApp.status !== "PENDING") {
+    return NextResponse.json(
+      { error: "Only pending submissions can be deleted" },
+      { status: 403 }
+    );
   }
 
   await db.miniApp.delete({ where: { id } });

--- a/src/app/api/modules/route.ts
+++ b/src/app/api/modules/route.ts
@@ -67,7 +67,7 @@ export async function POST(req: NextRequest) {
     .then((r) => r.map((m) => m.slug));
   const slug = makeUniqueSlug(baseSlug, existingSlugs);
 
-  const module = await db.miniApp.create({
+  const miniApp = await db.miniApp.create({
     data: {
       slug,
       name,
@@ -80,5 +80,5 @@ export async function POST(req: NextRequest) {
     },
   });
 
-  return NextResponse.json(module, { status: 201 });
+  return NextResponse.json(miniApp, { status: 201 });
 }

--- a/src/app/modules/[slug]/page.tsx
+++ b/src/app/modules/[slug]/page.tsx
@@ -8,15 +8,15 @@ type Props = { params: Promise<{ slug: string }> };
 
 export async function generateMetadata({ params }: Props) {
   const { slug } = await params;
-  const module = await db.miniApp.findUnique({ where: { slug } });
-  return { title: module ? `${module.name} — Intern Community Hub` : "Not Found" };
+  const miniApp = await db.miniApp.findUnique({ where: { slug } });
+  return { title: miniApp ? `${miniApp.name} — Intern Community Hub` : "Not Found" };
 }
 
 export default async function ModuleDetailPage({ params }: Props) {
   const { slug } = await params;
   const session = await auth();
 
-  const module = await db.miniApp.findUnique({
+  const miniApp = await db.miniApp.findUnique({
     where: { slug, status: "APPROVED" },
     include: {
       category: true,
@@ -24,13 +24,13 @@ export default async function ModuleDetailPage({ params }: Props) {
     },
   });
 
-  if (!module) notFound();
+  if (!miniApp) notFound();
 
   let hasVoted = false;
   if (session?.user) {
     const vote = await db.vote.findUnique({
       where: {
-        userId_moduleId: { userId: session.user.id, moduleId: module.id },
+        userId_moduleId: { userId: session.user.id, moduleId: miniApp.id },
       },
     });
     hasVoted = !!vote;
@@ -44,32 +44,32 @@ export default async function ModuleDetailPage({ params }: Props) {
 
       <div className="space-y-2">
         <div className="flex items-start justify-between gap-4">
-          <h1 className="text-2xl font-bold text-gray-900">{module.name}</h1>
+          <h1 className="text-2xl font-bold text-gray-900">{miniApp.name}</h1>
           <VoteButton
-            moduleId={module.id}
+            moduleId={miniApp.id}
             initialVoted={hasVoted}
-            initialCount={module.voteCount}
+            initialCount={miniApp.voteCount}
           />
         </div>
         <p className="text-sm text-gray-500">
-          by {module.author.name} · {module.category.name}
+          by {miniApp.author.name} · {miniApp.category.name}
         </p>
       </div>
 
-      <p className="text-gray-700">{module.description}</p>
+      <p className="text-gray-700">{miniApp.description}</p>
 
       <div className="flex gap-3">
         <a
-          href={module.repoUrl}
+          href={miniApp.repoUrl}
           target="_blank"
           rel="noopener noreferrer"
           className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
         >
           View on GitHub
         </a>
-        {module.demoUrl && (
+        {miniApp.demoUrl && (
           <a
-            href={module.demoUrl}
+            href={miniApp.demoUrl}
             target="_blank"
             rel="noopener noreferrer"
             className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
@@ -81,12 +81,12 @@ export default async function ModuleDetailPage({ params }: Props) {
 
       {/* TODO [hard-challenge]: Implement sandboxed iframe preview here.
           Requirements:
-          - Only show if module.demoUrl exists
+          - Only show if miniApp.demoUrl exists
           - Use sandbox="allow-scripts allow-same-origin" at minimum
           - Add Content-Security-Policy header for the iframe origin
           - Show a loading skeleton while the iframe loads
           See: ISSUES.md for full acceptance criteria */}
-      {module.demoUrl && (
+      {miniApp.demoUrl && (
         <div className="rounded-xl border border-dashed border-gray-300 p-8 text-center text-sm text-gray-400">
           Sandboxed preview coming soon. Contribute this feature! See{" "}
           <Link href="https://github.com" className="text-blue-600 hover:underline">

--- a/src/app/my-submissions/page.tsx
+++ b/src/app/my-submissions/page.tsx
@@ -2,12 +2,7 @@ import { redirect } from "next/navigation";
 import Link from "next/link";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
-
-const statusStyles: Record<string, string> = {
-  PENDING: "bg-yellow-50 text-yellow-700 border-yellow-200",
-  APPROVED: "bg-green-50 text-green-700 border-green-200",
-  REJECTED: "bg-red-50 text-red-700 border-red-200",
-};
+import { MySubmissionsList } from "@/components/my-submissions-list";
 
 export default async function MySubmissionsPage() {
   const session = await auth();
@@ -18,6 +13,15 @@ export default async function MySubmissionsPage() {
     include: { category: true },
     orderBy: { createdAt: "desc" },
   });
+
+  const initialSubmissions = submissions.map((sub) => ({
+    id: sub.id,
+    name: sub.name,
+    status: sub.status,
+    feedback: sub.feedback,
+    createdAt: sub.createdAt.toISOString(),
+    category: { name: sub.category.name },
+  }));
 
   return (
     <div className="space-y-6">
@@ -31,46 +35,7 @@ export default async function MySubmissionsPage() {
         </Link>
       </div>
 
-      {submissions.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-gray-300 p-12 text-center">
-          <p className="text-gray-500">No submissions yet.</p>
-          <Link
-            href="/submit"
-            className="mt-2 block text-sm text-blue-600 hover:underline"
-          >
-            Submit your first module →
-          </Link>
-        </div>
-      ) : (
-        <div className="space-y-3">
-          {submissions.map((sub) => (
-            <div
-              key={sub.id}
-              className="flex items-start justify-between rounded-xl border border-gray-200 bg-white p-4"
-            >
-              <div className="space-y-1">
-                <p className="font-medium text-gray-900">{sub.name}</p>
-                <p className="text-xs text-gray-400">
-                  {sub.category.name} ·{" "}
-                  {new Date(sub.createdAt).toLocaleDateString()}
-                </p>
-                {sub.feedback && (
-                  <p className="mt-1 rounded-md bg-gray-50 px-2 py-1 text-xs text-gray-600">
-                    Feedback: {sub.feedback}
-                  </p>
-                )}
-              </div>
-              <span
-                className={`shrink-0 rounded-full border px-2 py-0.5 text-xs font-medium ${
-                  statusStyles[sub.status]
-                }`}
-              >
-                {sub.status}
-              </span>
-            </div>
-          ))}
-        </div>
-      )}
+      <MySubmissionsList initialSubmissions={initialSubmissions} />
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { db } from "@/lib/db";
 import { auth } from "@/lib/auth";
 import { ModuleCard } from "@/components/module-card";
+import Link from "next/link";
 
 // TODO [medium-challenge]: Add category filter with URL query params (state persists on refresh)
 // See: ISSUES.md for full acceptance criteria
@@ -78,7 +79,7 @@ export default async function HomePage({
 
       {/* Category filter placeholder — see TODO above */}
       <div className="flex flex-wrap gap-2">
-        <a
+        <Link
           href="/"
           className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
             !category
@@ -87,7 +88,7 @@ export default async function HomePage({
           }`}
         >
           All
-        </a>
+        </Link>
         {categories.map((c) => (
           <a
             key={c.id}
@@ -107,9 +108,9 @@ export default async function HomePage({
         <div className="rounded-xl border border-dashed border-gray-300 p-12 text-center">
           <p className="text-gray-500">No modules found.</p>
           {q && (
-            <a href="/" className="mt-2 block text-sm text-blue-600 hover:underline">
+            <Link href="/" className="mt-2 block text-sm text-blue-600 hover:underline">
               Clear search
-            </a>
+            </Link>
           )}
         </div>
       ) : (

--- a/src/components/my-submissions-list.tsx
+++ b/src/components/my-submissions-list.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+
+type SubmissionStatus = "PENDING" | "APPROVED" | "REJECTED";
+
+type SubmissionItem = {
+  id: string;
+  name: string;
+  status: SubmissionStatus;
+  feedback: string | null;
+  createdAt: string;
+  category: { name: string };
+};
+
+const statusStyles: Record<SubmissionStatus, string> = {
+  PENDING: "bg-yellow-50 text-yellow-700 border-yellow-200",
+  APPROVED: "bg-green-50 text-green-700 border-green-200",
+  REJECTED: "bg-red-50 text-red-700 border-red-200",
+};
+
+interface MySubmissionsListProps {
+  initialSubmissions: SubmissionItem[];
+}
+
+export function MySubmissionsList({ initialSubmissions }: MySubmissionsListProps) {
+  const [submissions, setSubmissions] = useState(initialSubmissions);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleDelete(submission: SubmissionItem) {
+    if (submission.status !== "PENDING") return;
+
+    const confirmed = window.confirm(
+      `Delete submission \"${submission.name}\"? This action cannot be undone.`
+    );
+    if (!confirmed) return;
+
+    setError(null);
+    setDeletingId(submission.id);
+
+    try {
+      const res = await fetch(`/api/modules/${submission.id}`, {
+        method: "DELETE",
+      });
+
+      if (!res.ok) {
+        const data = (await res.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(data?.error || "Failed to delete submission");
+      }
+
+      setSubmissions((prev) => prev.filter((item) => item.id !== submission.id));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete submission");
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
+  if (submissions.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed border-gray-300 p-12 text-center">
+        <p className="text-gray-500">No submissions yet.</p>
+        <Link href="/submit" className="mt-2 block text-sm text-blue-600 hover:underline">
+          Submit your first module {"->"}
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {error && (
+        <p className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+          {error}
+        </p>
+      )}
+
+      {submissions.map((sub) => {
+        const isPending = sub.status === "PENDING";
+        const isDeleting = deletingId === sub.id;
+
+        return (
+          <div
+            key={sub.id}
+            className="flex items-start justify-between rounded-xl border border-gray-200 bg-white p-4"
+          >
+            <div className="space-y-1">
+              <p className="font-medium text-gray-900">{sub.name}</p>
+              <p className="text-xs text-gray-400">
+                {sub.category.name} · {new Date(sub.createdAt).toLocaleDateString()}
+              </p>
+              {sub.feedback && (
+                <p className="mt-1 rounded-md bg-gray-50 px-2 py-1 text-xs text-gray-600">
+                  Feedback: {sub.feedback}
+                </p>
+              )}
+            </div>
+
+            <div className="flex items-center gap-2">
+              <span
+                className={`shrink-0 rounded-full border px-2 py-0.5 text-xs font-medium ${
+                  statusStyles[sub.status]
+                }`}
+              >
+                {sub.status}
+              </span>
+
+              {isPending && (
+                <button
+                  type="button"
+                  onClick={() => handleDelete(sub)}
+                  disabled={isDeleting}
+                  className="rounded-lg border border-red-200 px-2.5 py-1 text-xs font-medium text-red-700 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {isDeleting ? "Deleting..." : "Delete"}
+                </button>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
PR này cải thiện luồng My Submissions để người dùng có thể xóa submission của chính mình khi trạng thái là PENDING, đồng thời ngăn xóa với các trạng thái APPROVED/REJECTED (trừ admin).
- Mục tiêu em muốn giải quyết: Hoàn thiện UX cho thao tác xóa submission: có confirm, có trạng thái loading, cập nhật danh sách ngay trên giao diện. Đảm bảo rule nghiệp vụ được enforce ở server: user thường chỉ được xóa PENDING của chính họ. Giữ thay đổi tập trung, không mở rộng scope ngoài yêu cầu bài.
- Cách em triển khai: Tách phần danh sách My Submissions sang client component để xử lý tương tác xóa và cập nhật state ngay sau khi API thành công. Chỉ hiển thị nút Delete cho submission PENDING. Thêm confirm trước khi xóa và hiển thị trạng thái Deleting... trong lúc gọi API. Cập nhật API DELETE để từ chối user không phải owner (403), từ chối owner nếu submission không phải PENDING (403), cho phép admin xóa mọi trạng thái. Dọn các lỗi lint chặn CI để pipeline chạy ổn định.
- Cách em kiểm thử: 
+ Em chạy lệnh: docker compose up -d rồi pnpm db:push rồi pnpm db:seed rồi mới chạy pnpm dev. Sau đó em đăng nhập user bình thường. Do chỉ có PENDING mới có nút Delete còn APPROVED và REJECTED thì không có thao tác xoá. Bấm Delete ở PENDING sẽ có form xác nhận rồi biến mất không reload lại.
+ Kiểm tra API/Network: Xoá PENDING của owner trả 204 còn xoá APPROVED/REJECTED thì trả 403.
+ Chạy pnpm lint rồi pnpm typecheck rồi pnpm test để đảm bảo test pass.
- Cách em sử dụng AI trong quá trình thực hiện:
+ Dùng AI để phân tích yêu cầu, rà soát phạm vi thay đổi và đề xuất hướng tách server/client component.
+ Dùng AI để kiểm tra tính đầy đủ của rule phân quyền và checklist test.
+ Em tự kiểm chứng lại toàn bộ thay đổi bằng lint/typecheck/test và test tay trước khi mở PR.