### PR TITLE
Feat/issue 173 challenge improvements

### DIFF
--- a/__tests__/browse-url.test.ts
+++ b/__tests__/browse-url.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { buildBrowseHref } from "@/lib/browse-url";
+
+describe("buildBrowseHref", () => {
+  it("returns root when no filters", () => {
+    expect(buildBrowseHref({})).toBe("/");
+  });
+
+  it("adds q only", () => {
+    expect(buildBrowseHref({ q: "timer" })).toBe("/?q=timer");
+  });
+
+  it("trims q", () => {
+    expect(buildBrowseHref({ q: "  hello  " })).toBe("/?q=hello");
+  });
+
+  it("adds category only", () => {
+    expect(buildBrowseHref({ category: "game" })).toBe("/?category=game");
+  });
+
+  it("composes q and category for filter + search together", () => {
+    expect(buildBrowseHref({ q: "pomodoro", category: "productivity" })).toBe(
+      "/?q=pomodoro&category=productivity"
+    );
+  });
+});

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { generateSlug, makeUniqueSlug, formatRelativeTime } from "@/lib/utils";
 
 // ============================================================
@@ -22,14 +22,23 @@ describe("generateSlug", () => {
     expect(generateSlug("a   b   c")).toBe("a-b-c");
   });
 
-  // TODO [easy-challenge]: Add test cases for the following:
-  // 1. A name that is already a valid slug (no changes needed)
-  // 2. A name with numbers (numbers should be preserved)
-  // 3. An empty string (what should the output be? Check the implementation)
-  // 4. A name with leading/trailing hyphens after special char removal
-  //
-  // Hint: read `src/lib/utils.ts` to understand the exact transformation rules
-  // before writing your assertions.
+  it("keeps an already slug-shaped name (lowercased, hyphens preserved)", () => {
+    expect(generateSlug("my-cool-app")).toBe("my-cool-app");
+  });
+
+  it("preserves digits in the slug", () => {
+    expect(generateSlug("App 2 Beta")).toBe("app-2-beta");
+    expect(generateSlug("v1.0 release")).toBe("v10-release");
+  });
+
+  it("returns an empty string for empty input", () => {
+    expect(generateSlug("")).toBe("");
+  });
+
+  it("strips leading and trailing hyphens after stripping special characters", () => {
+    expect(generateSlug("---hello---")).toBe("hello");
+    expect(generateSlug("!wow!")).toBe("wow");
+  });
 });
 
 // ============================================================
@@ -49,23 +58,79 @@ describe("makeUniqueSlug", () => {
     expect(makeUniqueSlug("my-app", ["my-app", "my-app-1"])).toBe("my-app-2");
   });
 
-  // TODO [easy-challenge]: Add test cases for:
-  // 1. When many suffixed versions already exist (e.g. -1 through -5)
-  // 2. When the existing list contains similar but non-conflicting slugs
-  //    e.g. existing = ["my-app-tool"] should NOT block "my-app"
+  it("finds the next free suffix when many suffixed versions exist", () => {
+    const existing = [
+      "my-app",
+      "my-app-1",
+      "my-app-2",
+      "my-app-3",
+      "my-app-4",
+      "my-app-5",
+    ];
+    expect(makeUniqueSlug("my-app", existing)).toBe("my-app-6");
+  });
+
+  it("does not treat a longer slug as a conflict with the base", () => {
+    expect(makeUniqueSlug("my-app", ["my-app-tool", "my-app-extra"])).toBe(
+      "my-app"
+    );
+  });
 });
 
 // ============================================================
-// formatRelativeTime — NOT yet tested, candidate must write all tests
+// formatRelativeTime
 // ============================================================
 
-// TODO [easy-challenge]: Write a full test suite for `formatRelativeTime`.
-// Requirements:
-// - "just now" for dates less than 1 minute ago
-// - "{n}m ago" for dates 1–59 minutes ago
-// - "{n}h ago" for dates 1–23 hours ago
-// - "{n}d ago" for dates 1–29 days ago
-// - toLocaleDateString() format for dates 30+ days ago
-//
-// Hint: You'll need to mock or control `Date.now()` to make these tests
-// deterministic. Look into Vitest's `vi.setSystemTime()`.
+describe("formatRelativeTime", () => {
+  const fixedNow = new Date("2025-06-15T12:00:00.000Z");
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(fixedNow);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns "just now" for timestamps less than one minute ago', () => {
+    const date = new Date(fixedNow.getTime() - 30_000);
+    expect(formatRelativeTime(date)).toBe("just now");
+  });
+
+  it('returns "{n}m ago" for 1–59 minutes ago', () => {
+    const fiveMinAgo = new Date(fixedNow.getTime() - 5 * 60_000);
+    expect(formatRelativeTime(fiveMinAgo)).toBe("5m ago");
+    const fiftyNineMinAgo = new Date(fixedNow.getTime() - 59 * 60_000);
+    expect(formatRelativeTime(fiftyNineMinAgo)).toBe("59m ago");
+  });
+
+  it('returns "{n}h ago" for 1–23 hours ago', () => {
+    const twoHoursAgo = new Date(fixedNow.getTime() - 2 * 60 * 60_000);
+    expect(formatRelativeTime(twoHoursAgo)).toBe("2h ago");
+    const twentyThreeHoursAgo = new Date(
+      fixedNow.getTime() - 23 * 60 * 60_000
+    );
+    expect(formatRelativeTime(twentyThreeHoursAgo)).toBe("23h ago");
+  });
+
+  it('returns "{n}d ago" for 1–29 days ago', () => {
+    const fifteenDaysAgo = new Date(
+      fixedNow.getTime() - 15 * 24 * 60 * 60_000
+    );
+    expect(formatRelativeTime(fifteenDaysAgo)).toBe("15d ago");
+    const twentyNineDaysAgo = new Date(
+      fixedNow.getTime() - 29 * 24 * 60 * 60_000
+    );
+    expect(formatRelativeTime(twentyNineDaysAgo)).toBe("29d ago");
+  });
+
+  it("uses toLocaleDateString for 30+ days ago", () => {
+    const fortyDaysAgo = new Date(
+      fixedNow.getTime() - 40 * 24 * 60 * 60_000
+    );
+    expect(formatRelativeTime(fortyDaysAgo)).toBe(
+      fortyDaysAgo.toLocaleDateString()
+    );
+  });
+});

--- a/__tests__/validations.test.ts
+++ b/__tests__/validations.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import {
+  submitModuleSchema,
+  adminReviewSchema,
+} from "@/lib/validations";
+
+/** Stable-looking value that satisfies z.string().cuid() for happy-path tests. */
+const SAMPLE_CUID = "ckjb4bsqi0000zjom3afq3q9";
+
+describe("submitModuleSchema", () => {
+  it("accepts a valid payload with optional empty demoUrl", () => {
+    const result = submitModuleSchema.safeParse({
+      name: "Cool Module",
+      description: "A useful module for the community.",
+      categoryId: SAMPLE_CUID,
+      repoUrl: "https://github.com/org/repo",
+      demoUrl: "",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.demoUrl).toBeUndefined();
+    }
+  });
+
+  it("rejects a name that is too short", () => {
+    const result = submitModuleSchema.safeParse({
+      name: "ab",
+      description: "At least twenty characters here.",
+      categoryId: SAMPLE_CUID,
+      repoUrl: "https://github.com/org/repo",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a description that is too short", () => {
+    const result = submitModuleSchema.safeParse({
+      name: "Good Name",
+      description: "Too short",
+      categoryId: SAMPLE_CUID,
+      repoUrl: "https://github.com/org/repo",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a non-GitHub repo URL", () => {
+    const result = submitModuleSchema.safeParse({
+      name: "Good Name",
+      description: "At least twenty characters here.",
+      categoryId: SAMPLE_CUID,
+      repoUrl: "https://gitlab.com/org/repo",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an invalid category id", () => {
+    const result = submitModuleSchema.safeParse({
+      name: "Good Name",
+      description: "At least twenty characters here.",
+      categoryId: "not-a-cuid",
+      repoUrl: "https://github.com/org/repo",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("adminReviewSchema", () => {
+  it("accepts APPROVED without feedback", () => {
+    const result = adminReviewSchema.safeParse({ status: "APPROVED" });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects feedback longer than 500 characters", () => {
+    const result = adminReviewSchema.safeParse({
+      status: "REJECTED",
+      feedback: "x".repeat(501),
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,21 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "X-Frame-Options", value: "SAMEORIGIN" },
+          {
+            key: "Referrer-Policy",
+            value: "strict-origin-when-cross-origin",
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -36,7 +36,7 @@ async function main() {
   ]);
 
   // Seed demo admin user
-  const admin = await prisma.user.upsert({
+  await prisma.user.upsert({
     where: { email: "admin@td.com" },
     update: {},
     create: {

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -38,8 +38,8 @@ export default async function AdminPage() {
           <p className="text-sm text-gray-400">No pending submissions. 🎉</p>
         ) : (
           <div className="grid gap-4 sm:grid-cols-2">
-            {pending.map((module) => (
-              <AdminReviewCard key={module.id} module={module} />
+            {pending.map((miniApp) => (
+              <AdminReviewCard key={miniApp.id} module={miniApp} />
             ))}
           </div>
         )}
@@ -48,20 +48,20 @@ export default async function AdminPage() {
       <section className="space-y-4">
         <h2 className="text-lg font-semibold text-gray-700">Recently Reviewed</h2>
         <div className="space-y-2">
-          {recentlyReviewed.map((module) => (
+          {recentlyReviewed.map((miniApp) => (
             <div
-              key={module.id}
+              key={miniApp.id}
               className="flex items-center justify-between rounded-lg border border-gray-200 bg-white px-4 py-3"
             >
-              <span className="text-sm font-medium text-gray-800">{module.name}</span>
+              <span className="text-sm font-medium text-gray-800">{miniApp.name}</span>
               <span
                 className={`rounded-full px-2 py-0.5 text-xs font-medium ${
-                  module.status === "APPROVED"
+                  miniApp.status === "APPROVED"
                     ? "bg-green-50 text-green-700"
                     : "bg-red-50 text-red-700"
                 }`}
               >
-                {module.status}
+                {miniApp.status}
               </span>
             </div>
           ))}

--- a/src/app/api/modules/[id]/route.ts
+++ b/src/app/api/modules/[id]/route.ts
@@ -8,7 +8,7 @@ type Params = { params: Promise<{ id: string }> };
 // GET /api/modules/[id]
 export async function GET(_req: NextRequest, { params }: Params) {
   const { id } = await params;
-  const module = await db.miniApp.findUnique({
+  const miniApp = await db.miniApp.findUnique({
     where: { id },
     include: {
       category: true,
@@ -16,8 +16,8 @@ export async function GET(_req: NextRequest, { params }: Params) {
       _count: { select: { votes: true } },
     },
   });
-  if (!module) return NextResponse.json({ error: "Not found" }, { status: 404 });
-  return NextResponse.json(module);
+  if (!miniApp) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  return NextResponse.json(miniApp);
 }
 
 // PATCH /api/modules/[id] — admin approve/reject
@@ -53,10 +53,10 @@ export async function DELETE(_req: NextRequest, { params }: Params) {
   }
 
   const { id } = await params;
-  const module = await db.miniApp.findUnique({ where: { id } });
-  if (!module) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  const miniApp = await db.miniApp.findUnique({ where: { id } });
+  if (!miniApp) return NextResponse.json({ error: "Not found" }, { status: 404 });
 
-  if (module.authorId !== session.user.id && !session.user.isAdmin) {
+  if (miniApp.authorId !== session.user.id && !session.user.isAdmin) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/src/app/api/modules/route.ts
+++ b/src/app/api/modules/route.ts
@@ -64,10 +64,10 @@ export async function POST(req: NextRequest) {
   const baseSlug = generateSlug(name);
   const existingSlugs = await db.miniApp
     .findMany({ where: { slug: { startsWith: baseSlug } }, select: { slug: true } })
-    .then((r) => r.map((m) => m.slug));
+    .then((rows) => rows.map((row) => row.slug));
   const slug = makeUniqueSlug(baseSlug, existingSlugs);
 
-  const module = await db.miniApp.create({
+  const created = await db.miniApp.create({
     data: {
       slug,
       name,
@@ -80,5 +80,5 @@ export async function POST(req: NextRequest) {
     },
   });
 
-  return NextResponse.json(module, { status: 201 });
+  return NextResponse.json(created, { status: 201 });
 }

--- a/src/app/api/modules/route.ts
+++ b/src/app/api/modules/route.ts
@@ -1,14 +1,22 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
+import { checkRateLimit } from "@/lib/rate-limit";
 import { submitModuleSchema } from "@/lib/validations";
 import { generateSlug, makeUniqueSlug } from "@/lib/utils";
+
+const MAX_BODY_BYTES = 65_536;
+const MAX_SEARCH_QUERY_LEN = 200;
 
 // GET /api/modules — list approved modules (with optional category filter + search)
 export async function GET(req: NextRequest) {
   const { searchParams } = req.nextUrl;
   const category = searchParams.get("category");
-  const search = searchParams.get("q");
+  const rawSearch = searchParams.get("q");
+  const search =
+    rawSearch && rawSearch.length > MAX_SEARCH_QUERY_LEN
+      ? rawSearch.slice(0, MAX_SEARCH_QUERY_LEN)
+      : rawSearch;
   const cursor = searchParams.get("cursor");
   const limit = 12;
 
@@ -50,7 +58,32 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const body = await req.json();
+  if (
+    !checkRateLimit(`submit:${session.user.id}`, {
+      max: 10,
+      windowMs: 3_600_000,
+    })
+  ) {
+    return NextResponse.json(
+      { error: "Too many submissions. Please try again later." },
+      { status: 429 }
+    );
+  }
+
+  const contentLength = req.headers.get("content-length");
+  if (contentLength !== null) {
+    const n = Number.parseInt(contentLength, 10);
+    if (Number.isFinite(n) && n > MAX_BODY_BYTES) {
+      return NextResponse.json({ error: "Payload too large" }, { status: 413 });
+    }
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
   const parsed = submitModuleSchema.safeParse(body);
   if (!parsed.success) {
     return NextResponse.json(

--- a/src/app/api/votes/route.ts
+++ b/src/app/api/votes/route.ts
@@ -1,23 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
+import { checkRateLimit } from "@/lib/rate-limit";
 
-// Simple in-memory rate limit: max 10 votes per minute per user.
-// In production, replace with Redis-backed sliding window (e.g. Upstash).
-// TODO [medium-challenge]: Replace this with a proper rate limiter
-const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
-
-function checkRateLimit(userId: string): boolean {
-  const now = Date.now();
-  const entry = rateLimitMap.get(userId);
-  if (!entry || entry.resetAt < now) {
-    rateLimitMap.set(userId, { count: 1, resetAt: now + 60_000 });
-    return true;
-  }
-  if (entry.count >= 10) return false;
-  entry.count++;
-  return true;
-}
+// Max 10 votes per minute per user (in-memory; see rate-limit.ts).
 
 // POST /api/votes — toggle vote on a module
 export async function POST(req: NextRequest) {
@@ -26,7 +12,9 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  if (!checkRateLimit(session.user.id)) {
+  if (
+    !checkRateLimit(`vote:${session.user.id}`, { max: 10, windowMs: 60_000 })
+  ) {
     return NextResponse.json(
       { error: "Too many votes. Please wait a moment." },
       { status: 429 }

--- a/src/app/modules/[slug]/page.tsx
+++ b/src/app/modules/[slug]/page.tsx
@@ -8,15 +8,17 @@ type Props = { params: Promise<{ slug: string }> };
 
 export async function generateMetadata({ params }: Props) {
   const { slug } = await params;
-  const module = await db.miniApp.findUnique({ where: { slug } });
-  return { title: module ? `${module.name} — Intern Community Hub` : "Not Found" };
+  const miniApp = await db.miniApp.findUnique({ where: { slug } });
+  return {
+    title: miniApp ? `${miniApp.name} — Intern Community Hub` : "Not Found",
+  };
 }
 
 export default async function ModuleDetailPage({ params }: Props) {
   const { slug } = await params;
   const session = await auth();
 
-  const module = await db.miniApp.findUnique({
+  const miniApp = await db.miniApp.findUnique({
     where: { slug, status: "APPROVED" },
     include: {
       category: true,
@@ -24,13 +26,13 @@ export default async function ModuleDetailPage({ params }: Props) {
     },
   });
 
-  if (!module) notFound();
+  if (!miniApp) notFound();
 
   let hasVoted = false;
   if (session?.user) {
     const vote = await db.vote.findUnique({
       where: {
-        userId_moduleId: { userId: session.user.id, moduleId: module.id },
+        userId_moduleId: { userId: session.user.id, moduleId: miniApp.id },
       },
     });
     hasVoted = !!vote;
@@ -44,32 +46,32 @@ export default async function ModuleDetailPage({ params }: Props) {
 
       <div className="space-y-2">
         <div className="flex items-start justify-between gap-4">
-          <h1 className="text-2xl font-bold text-gray-900">{module.name}</h1>
+          <h1 className="text-2xl font-bold text-gray-900">{miniApp.name}</h1>
           <VoteButton
-            moduleId={module.id}
+            moduleId={miniApp.id}
             initialVoted={hasVoted}
-            initialCount={module.voteCount}
+            initialCount={miniApp.voteCount}
           />
         </div>
         <p className="text-sm text-gray-500">
-          by {module.author.name} · {module.category.name}
+          by {miniApp.author.name} · {miniApp.category.name}
         </p>
       </div>
 
-      <p className="text-gray-700">{module.description}</p>
+      <p className="text-gray-700">{miniApp.description}</p>
 
       <div className="flex gap-3">
         <a
-          href={module.repoUrl}
+          href={miniApp.repoUrl}
           target="_blank"
           rel="noopener noreferrer"
           className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
         >
           View on GitHub
         </a>
-        {module.demoUrl && (
+        {miniApp.demoUrl && (
           <a
-            href={module.demoUrl}
+            href={miniApp.demoUrl}
             target="_blank"
             rel="noopener noreferrer"
             className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
@@ -86,7 +88,7 @@ export default async function ModuleDetailPage({ params }: Props) {
           - Add Content-Security-Policy header for the iframe origin
           - Show a loading skeleton while the iframe loads
           See: ISSUES.md for full acceptance criteria */}
-      {module.demoUrl && (
+      {miniApp.demoUrl && (
         <div className="rounded-xl border border-dashed border-gray-300 p-8 text-center text-sm text-gray-400">
           Sandboxed preview coming soon. Contribute this feature! See{" "}
           <Link href="https://github.com" className="text-blue-600 hover:underline">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { db } from "@/lib/db";
 import { auth } from "@/lib/auth";
 import { ModuleCard } from "@/components/module-card";
@@ -41,11 +42,11 @@ export default async function HomePage({
     const votes = await db.vote.findMany({
       where: {
         userId: session.user.id,
-        moduleId: { in: modules.map((m) => m.id) },
+        moduleId: { in: modules.map((row) => row.id) },
       },
       select: { moduleId: true },
     });
-    votedIds = new Set(votes.map((v) => v.moduleId));
+    votedIds = new Set(votes.map((vote) => vote.moduleId));
   }
 
   const categories = await db.category.findMany({ orderBy: { name: "asc" } });
@@ -78,7 +79,7 @@ export default async function HomePage({
 
       {/* Category filter placeholder — see TODO above */}
       <div className="flex flex-wrap gap-2">
-        <a
+        <Link
           href="/"
           className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
             !category
@@ -87,19 +88,19 @@ export default async function HomePage({
           }`}
         >
           All
-        </a>
-        {categories.map((c) => (
-          <a
-            key={c.id}
-            href={`/?category=${c.slug}`}
+        </Link>
+        {categories.map((cat) => (
+          <Link
+            key={cat.id}
+            href={`/?category=${cat.slug}`}
             className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
-              category === c.slug
+              category === cat.slug
                 ? "bg-blue-600 text-white"
                 : "bg-gray-100 text-gray-600 hover:bg-gray-200"
             }`}
           >
-            {c.name}
-          </a>
+            {cat.name}
+          </Link>
         ))}
       </div>
 
@@ -107,18 +108,21 @@ export default async function HomePage({
         <div className="rounded-xl border border-dashed border-gray-300 p-12 text-center">
           <p className="text-gray-500">No modules found.</p>
           {q && (
-            <a href="/" className="mt-2 block text-sm text-blue-600 hover:underline">
+            <Link
+              href="/"
+              className="mt-2 block text-sm text-blue-600 hover:underline"
+            >
               Clear search
-            </a>
+            </Link>
           )}
         </div>
       ) : (
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {modules.map((module) => (
+          {modules.map((miniApp) => (
             <ModuleCard
-              key={module.id}
-              module={module}
-              hasVoted={votedIds.has(module.id)}
+              key={miniApp.id}
+              module={miniApp}
+              hasVoted={votedIds.has(miniApp.id)}
             />
           ))}
         </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,19 +2,25 @@ import Link from "next/link";
 import { db } from "@/lib/db";
 import { auth } from "@/lib/auth";
 import { ModuleCard } from "@/components/module-card";
+import { buildBrowseHref } from "@/lib/browse-url";
 
-// TODO [medium-challenge]: Add category filter with URL query params (state persists on refresh)
-// See: ISSUES.md for full acceptance criteria
+const MAX_SEARCH_LEN = 200;
 
 export default async function HomePage({
   searchParams,
 }: {
   searchParams: Promise<{ q?: string; category?: string }>;
 }) {
-  const { q, category } = await searchParams;
+  const raw = await searchParams;
+  const category = raw.category;
+  const q =
+    raw.q && raw.q.length > MAX_SEARCH_LEN
+      ? raw.q.slice(0, MAX_SEARCH_LEN)
+      : raw.q;
   const session = await auth();
 
-  const modules = await db.miniApp.findMany({
+  const [modules, categories] = await Promise.all([
+    db.miniApp.findMany({
     where: {
       status: "APPROVED",
       ...(category ? { category: { slug: category } } : {}),
@@ -34,7 +40,9 @@ export default async function HomePage({
     },
     orderBy: { voteCount: "desc" },
     take: 12,
-  });
+  }),
+    db.category.findMany({ orderBy: { name: "asc" } }),
+  ]);
 
   // Fetch which modules the current user has voted on
   let votedIds = new Set<string>();
@@ -49,8 +57,6 @@ export default async function HomePage({
     votedIds = new Set(votes.map((vote) => vote.moduleId));
   }
 
-  const categories = await db.category.findMany({ orderBy: { name: "asc" } });
-
   return (
     <div className="space-y-6">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
@@ -61,7 +67,10 @@ export default async function HomePage({
           </p>
         </div>
 
-        <form className="flex gap-2">
+        <form method="get" className="flex gap-2">
+          {category ? (
+            <input type="hidden" name="category" value={category} />
+          ) : null}
           <input
             name="q"
             defaultValue={q}
@@ -77,10 +86,9 @@ export default async function HomePage({
         </form>
       </div>
 
-      {/* Category filter placeholder — see TODO above */}
       <div className="flex flex-wrap gap-2">
         <Link
-          href="/"
+          href={buildBrowseHref({ q })}
           className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
             !category
               ? "bg-blue-600 text-white"
@@ -92,7 +100,7 @@ export default async function HomePage({
         {categories.map((cat) => (
           <Link
             key={cat.id}
-            href={`/?category=${cat.slug}`}
+            href={buildBrowseHref({ q, category: cat.slug })}
             className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
               category === cat.slug
                 ? "bg-blue-600 text-white"
@@ -109,7 +117,7 @@ export default async function HomePage({
           <p className="text-gray-500">No modules found.</p>
           {q && (
             <Link
-              href="/"
+              href={buildBrowseHref({ category })}
               className="mt-2 block text-sm text-blue-600 hover:underline"
             >
               Clear search

--- a/src/components/module-card.tsx
+++ b/src/components/module-card.tsx
@@ -17,12 +17,12 @@ export function ModuleCard({ module, hasVoted = false }: ModuleCardProps) {
         >
           {module.name}
         </Link>
-        {/* TODO [easy-challenge]: icon-only buttons need aria-label — add one to the external link below */}
         {module.demoUrl && (
           <a
             href={module.demoUrl}
             target="_blank"
             rel="noopener noreferrer"
+            aria-label={`Open live demo for ${module.name} in a new tab`}
             className="shrink-0 text-gray-400 hover:text-gray-600"
           >
             <ExternalLinkIcon />

--- a/src/components/submit-form.tsx
+++ b/src/components/submit-form.tsx
@@ -9,10 +9,13 @@ interface SubmitFormProps {
   categories: Category[];
 }
 
+const DESCRIPTION_MAX = 500;
+
 export function SubmitForm({ categories }: SubmitFormProps) {
   const router = useRouter();
   const [error, setError] = useState<Record<string, string[]>>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [descriptionLength, setDescriptionLength] = useState(0);
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -51,6 +54,7 @@ export function SubmitForm({ categories }: SubmitFormProps) {
     <form onSubmit={handleSubmit} className="space-y-5">
       <Field label="Module name" name="name" error={error.name}>
         <input
+          id="name"
           name="name"
           type="text"
           placeholder="e.g. Pomodoro Timer"
@@ -59,19 +63,33 @@ export function SubmitForm({ categories }: SubmitFormProps) {
         />
       </Field>
 
-      <Field label="Description" name="description" error={error.description} hint="Max 500 characters">
-        {/* TODO [easy-challenge]: add a live character counter below this textarea */}
+      <Field label="Description" name="description" error={error.description}>
         <textarea
+          id="description"
           name="description"
           rows={4}
           placeholder="What does your module do? Who is it for?"
-          maxLength={500}
+          maxLength={DESCRIPTION_MAX}
           className={inputClass}
+          onChange={(e) => setDescriptionLength(e.target.value.length)}
+          aria-describedby="description-counter"
         />
+        <p
+          id="description-counter"
+          className="text-xs text-gray-400"
+          aria-live="polite"
+        >
+          {descriptionLength} / {DESCRIPTION_MAX} characters (min 20)
+        </p>
       </Field>
 
       <Field label="Category" name="categoryId" error={error.categoryId}>
-        <select name="categoryId" className={inputClass} defaultValue="">
+        <select
+          id="categoryId"
+          name="categoryId"
+          className={inputClass}
+          defaultValue=""
+        >
           <option value="" disabled>Select a category</option>
           {categories.map((c) => (
             <option key={c.id} value={c.id}>{c.name}</option>
@@ -81,6 +99,7 @@ export function SubmitForm({ categories }: SubmitFormProps) {
 
       <Field label="GitHub repository URL" name="repoUrl" error={error.repoUrl}>
         <input
+          id="repoUrl"
           name="repoUrl"
           type="url"
           placeholder="https://github.com/your-username/your-repo"
@@ -90,6 +109,7 @@ export function SubmitForm({ categories }: SubmitFormProps) {
 
       <Field label="Demo URL (optional)" name="demoUrl" error={error.demoUrl}>
         <input
+          id="demoUrl"
           name="demoUrl"
           type="url"
           placeholder="https://your-demo.vercel.app"

--- a/src/lib/browse-url.ts
+++ b/src/lib/browse-url.ts
@@ -1,0 +1,14 @@
+/**
+ * Builds home page URLs so search (`q`) and category filter compose correctly.
+ */
+export function buildBrowseHref(filters: {
+  q?: string | null;
+  category?: string | null;
+}): string {
+  const params = new URLSearchParams();
+  const q = filters.q?.trim();
+  if (q) params.set("q", q);
+  if (filters.category) params.set("category", filters.category);
+  const qs = params.toString();
+  return qs ? `/?${qs}` : "/";
+}

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,23 @@
+/**
+ * Simple in-memory sliding-window rate limiter (per-process).
+ * Suitable for dev/single-instance; use Redis (e.g. Upstash) in production.
+ */
+
+type Bucket = { count: number; resetAt: number };
+
+const buckets = new Map<string, Bucket>();
+
+export function checkRateLimit(
+  key: string,
+  options: { max: number; windowMs: number }
+): boolean {
+  const now = Date.now();
+  const entry = buckets.get(key);
+  if (!entry || entry.resetAt < now) {
+    buckets.set(key, { count: 1, resetAt: now + options.windowMs });
+    return true;
+  }
+  if (entry.count >= options.max) return false;
+  entry.count += 1;
+  return true;
+}


### PR DESCRIPTION
## What does this PR do?

This PR improves reliability, UX, and safety around browsing and submitting modules:

- **Tests:** Adds Vitest coverage for `generateSlug`, `makeUniqueSlug`, and `formatRelativeTime` in `src/lib/utils.ts`, plus Zod schema tests for `submitModuleSchema` and `adminReviewSchema`.
- **Browse / URL state:** Keeps **search (`q`) and category** in sync in the URL (filters + search survive refresh and navigation). Loads the home listing and categories in **parallel** to reduce latency. Caps overly long search input server-side for predictable queries.
- **API hardening:** Shared in-memory **rate limit** helper; applies limits to votes (existing behaviour, refactored) and to **module submissions**; rejects oversized JSON bodies (`Content-Length`) and invalid JSON with clear status codes.
- **HTTP headers:** Adds baseline security headers (`X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`) via `next.config.ts`.
- **UI / a11y:** Live **character counter** for the submit description field (with `aria-describedby` / `aria-live`), stable **`id`s** on form controls for labels, and an **`aria-label`** on the icon-only demo link in `ModuleCard`.
- **Tooling / CI hygiene:** Resolves Next.js ESLint rules (avoid binding name `module`, use `Link` for internal navigation) and removes an unused variable in `prisma/seed.ts` so `lint` / `build` stay green.

Together this addresses several small “intern challenge” style items (tests, filters, rate limits, a11y, validation coverage) in one coherent pass.

## Related Issue

Relates to and/or closes (adjust to maintainer preference — use a single `Closes` if they want one issue only):

- Closes #173
- Closes #175
- Closes #169
- Closes #157
- Addresses #177 (rate limiting on votes — shared limiter; submissions also limited)
- Addresses #183 / #168 (description character counter)

## How to test

1. **Install & Prisma client**
   - `pnpm install`
   - `pnpm db:generate`
2. **Automated checks (match CI)**
   - `pnpm lint`
   - `pnpm typecheck`
   - `pnpm test`
   - `pnpm build`
3. **Manual – home / URL**
   - `pnpm dev`, open `/`.
   - Pick a **category**, then **search**; refresh — both `category` and `q` should stay in the URL and results stay filtered.
   - Click **All** — category clears; if you had a search term, `q` should remain.
   - Use **Clear search** while a category is selected — search clears, category stays.
4. **Manual – submit / a11y**
   - Go to **Submit**, type in **Description** — counter updates; submit still works.
   - On a card with demo URL, screen reader / accessibility tree should show a clear label on the external demo control.
5. **Optional – API behaviour**
   - Rapid repeated **submissions** or **votes** may hit `429` (by design for abuse mitigation).

## Screenshots / recordings (if UI change)

N/A for mandatory review — changes are mostly behavioural (URL, counter, a11y).  
(Optional) Attach a short screen recording of: category + search + refresh, and the description counter on `/submit`.

## Checklist

- [x] I read the relevant code **before** writing my own
- [x] My code follows the existing patterns in the codebase
- [x] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
- [x] I added or updated tests where applicable
- [x] I can explain every line of code I wrote (reviewer will ask)
- [x] I kept the PR focused — no unrelated changes *(scope: tests + browse/API/security + small UX/a11y tied to open issues)*

## Notes for reviewer

- **MiniApp vs Module:** DB model remains `MiniApp`; UI copy stays “module” — no rename drift.
- **Rate limiting:** In-memory, same class of approach as existing vote limiting; documented in code as not for multi-instance production without Redis/Upstash.
- **Multiple `Closes`:** If you prefer **one issue per PR**, say which issue to keep and I’ll narrow the PR body / or split follow-up PRs.
- **AI use (if asked):** Used AI-assisted suggestions for test cases and structure; all changes were validated locally with `lint` / `test` / `build` and adjusted to match this codebase.
