### PR TITLE
feat: add contributor leaderboard for current month

### DIFF
--- a/prisma/migrations/20260403071118_initial_schema/migration.sql
+++ b/prisma/migrations/20260403071118_initial_schema/migration.sql
@@ -1,0 +1,133 @@
+-- CreateEnum
+CREATE TYPE "SubmissionStatus" AS ENUM ('PENDING', 'APPROVED', 'REJECTED');
+
+-- CreateTable
+CREATE TABLE "accounts" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "providerAccountId" TEXT NOT NULL,
+    "refresh_token" TEXT,
+    "access_token" TEXT,
+    "expires_at" INTEGER,
+    "token_type" TEXT,
+    "scope" TEXT,
+    "id_token" TEXT,
+    "session_state" TEXT,
+
+    CONSTRAINT "accounts_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "sessions" (
+    "id" TEXT NOT NULL,
+    "sessionToken" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "expires" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "sessions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "verification_tokens" (
+    "identifier" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "expires" TIMESTAMP(3) NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "users" (
+    "id" TEXT NOT NULL,
+    "name" TEXT,
+    "email" TEXT,
+    "emailVerified" TIMESTAMP(3),
+    "image" TEXT,
+    "isAdmin" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "users_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "categories" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+
+    CONSTRAINT "categories_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "mini_apps" (
+    "id" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "repoUrl" TEXT NOT NULL,
+    "demoUrl" TEXT,
+    "status" "SubmissionStatus" NOT NULL DEFAULT 'PENDING',
+    "feedback" TEXT,
+    "categoryId" TEXT NOT NULL,
+    "authorId" TEXT NOT NULL,
+    "voteCount" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "mini_apps_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "votes" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "moduleId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "votes_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "accounts_provider_providerAccountId_key" ON "accounts"("provider", "providerAccountId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "sessions_sessionToken_key" ON "sessions"("sessionToken");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "verification_tokens_token_key" ON "verification_tokens"("token");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "verification_tokens_identifier_token_key" ON "verification_tokens"("identifier", "token");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_email_key" ON "users"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "categories_name_key" ON "categories"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "categories_slug_key" ON "categories"("slug");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "mini_apps_slug_key" ON "mini_apps"("slug");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "votes_userId_moduleId_key" ON "votes"("userId", "moduleId");
+
+-- AddForeignKey
+ALTER TABLE "accounts" ADD CONSTRAINT "accounts_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "sessions" ADD CONSTRAINT "sessions_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "mini_apps" ADD CONSTRAINT "mini_apps_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "categories"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "mini_apps" ADD CONSTRAINT "mini_apps_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "votes" ADD CONSTRAINT "votes_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "votes" ADD CONSTRAINT "votes_moduleId_fkey" FOREIGN KEY ("moduleId") REFERENCES "mini_apps"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20260404075250_add_leaderboard_index/migration.sql
+++ b/prisma/migrations/20260404075250_add_leaderboard_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "mini_apps_status_createdAt_authorId_idx" ON "mini_apps"("status", "createdAt", "authorId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -106,6 +106,8 @@ model MiniApp {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  // Index for leaderboard query: filter by status + createdAt, group by authorId
+  @@index([status, createdAt, authorId])
   @@map("mini_apps")
 }
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -36,7 +36,7 @@ async function main() {
   ]);
 
   // Seed demo admin user
-  const admin = await prisma.user.upsert({
+  await prisma.user.upsert({
     where: { email: "admin@td.com" },
     update: {},
     create: {
@@ -46,18 +46,28 @@ async function main() {
     },
   });
 
-  // Seed demo contributor
-  const contributor = await prisma.user.upsert({
-    where: { email: "dev@example.com" },
-    update: {},
-    create: {
-      name: "Demo Dev",
-      email: "dev@example.com",
-      isAdmin: false,
-    },
-  });
+  // Seed demo contributors (multiple users for leaderboard variety)
+  const contributors = await Promise.all([
+    prisma.user.upsert({ where: { email: "dev@example.com" }, update: {}, create: { name: "Demo Dev", email: "dev@example.com", isAdmin: false } }),
+    prisma.user.upsert({ where: { email: "alice@example.com" }, update: {}, create: { name: "Alice Chen", email: "alice@example.com", isAdmin: false } }),
+    prisma.user.upsert({ where: { email: "bob@example.com" }, update: {}, create: { name: "Bob Martinez", email: "bob@example.com", isAdmin: false } }),
+    prisma.user.upsert({ where: { email: "carol@example.com" }, update: {}, create: { name: "Carol Kim", email: "carol@example.com", isAdmin: false } }),
+    prisma.user.upsert({ where: { email: "david@example.com" }, update: {}, create: { name: "David Nguyen", email: "david@example.com", isAdmin: false } }),
+    prisma.user.upsert({ where: { email: "eva@example.com" }, update: {}, create: { name: "Eva Patel", email: "eva@example.com", isAdmin: false } }),
+    prisma.user.upsert({ where: { email: "frank@example.com" }, update: {}, create: { name: "Frank Liu", email: "frank@example.com", isAdmin: false } }),
+    prisma.user.upsert({ where: { email: "grace@example.com" }, update: {}, create: { name: "Grace Park", email: "grace@example.com", isAdmin: false } }),
+    prisma.user.upsert({ where: { email: "henry@example.com" }, update: {}, create: { name: "Henry Tran", email: "henry@example.com", isAdmin: false } }),
+    prisma.user.upsert({ where: { email: "iris@example.com" }, update: {}, create: { name: "Iris Johansson", email: "iris@example.com", isAdmin: false } }),
+    prisma.user.upsert({ where: { email: "jack@example.com" }, update: {}, create: { name: "Jack Okonkwo", email: "jack@example.com", isAdmin: false } }),
+    prisma.user.upsert({ where: { email: "kate@example.com" }, update: {}, create: { name: "Kate Müller", email: "kate@example.com", isAdmin: false } }),
+    prisma.user.upsert({ where: { email: "leo@example.com" }, update: {}, create: { name: "Leo Santos", email: "leo@example.com", isAdmin: false } }),
+    prisma.user.upsert({ where: { email: "mia@example.com" }, update: {}, create: { name: "Mia Nakamura", email: "mia@example.com", isAdmin: false } }),
+    prisma.user.upsert({ where: { email: "noah@example.com" }, update: {}, create: { name: "Noah Williams", email: "noah@example.com", isAdmin: false } }),
+  ]);
 
-  // Seed approved mini-apps (displayed as "Modules" in the UI)
+  const [contributor, alice, bob, carol, david, eva, frank, grace, henry, iris, jack, kate, leo, mia, noah] = contributors;
+
+  const now = new Date();
   const approvedModules = [
     {
       slug: "pomodoro-timer",
@@ -95,12 +105,182 @@ async function main() {
       authorId: contributor.id,
       voteCount: 41,
     },
+    {
+      slug: "color-palette-generator",
+      name: "Color Palette Generator",
+      description:
+        "Generate beautiful color palettes from a seed color. Exports to CSS variables and Tailwind config.",
+      repoUrl: "https://github.com/example/color-palette",
+      demoUrl: "https://palette.example.com",
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "utility")!.id,
+      authorId: alice.id,
+      voteCount: 33,
+    },
+    {
+      slug: "regex-tester",
+      name: "Regex Tester",
+      description:
+        "Interactive regex tester with match highlighting and explanation tooltips.",
+      repoUrl: "https://github.com/example/regex-tester",
+      demoUrl: null,
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "utility")!.id,
+      authorId: alice.id,
+      voteCount: 19,
+    },
+    {
+      slug: "budget-planner",
+      name: "Budget Planner",
+      description:
+        "Monthly budget planner with category breakdowns and savings goals tracker.",
+      repoUrl: "https://github.com/example/budget-planner",
+      demoUrl: null,
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "finance")!.id,
+      authorId: bob.id,
+      voteCount: 15,
+    },
+    {
+      slug: "standup-bot",
+      name: "Standup Bot",
+      description:
+        "Automate daily standup notes. Saves answers and generates a weekly summary report.",
+      repoUrl: "https://github.com/example/standup-bot",
+      demoUrl: "https://standup.example.com",
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "productivity")!.id,
+      authorId: carol.id,
+      voteCount: 28,
+    },
+    {
+      slug: "flashcard-app",
+      name: "Flashcard App",
+      description:
+        "Spaced repetition flashcard app with deck sharing and progress tracking.",
+      repoUrl: "https://github.com/example/flashcards",
+      demoUrl: null,
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "productivity")!.id,
+      authorId: david.id,
+      voteCount: 11,
+    },
+    {
+      slug: "currency-converter",
+      name: "Currency Converter",
+      description: "Real-time currency converter supporting 150+ currencies with historical rate charts.",
+      repoUrl: "https://github.com/example/currency-converter",
+      demoUrl: "https://currency.example.com",
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "finance")!.id,
+      authorId: eva.id,
+      voteCount: 22,
+    },
+    {
+      slug: "markdown-resume-builder",
+      name: "Markdown Resume Builder",
+      description: "Build and export a clean resume from Markdown. Supports multiple themes and PDF export.",
+      repoUrl: "https://github.com/example/md-resume",
+      demoUrl: null,
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "utility")!.id,
+      authorId: frank.id,
+      voteCount: 17,
+    },
+    {
+      slug: "typing-speed-test",
+      name: "Typing Speed Test",
+      description: "Measure your typing speed and accuracy with custom text passages and leaderboard.",
+      repoUrl: "https://github.com/example/typing-test",
+      demoUrl: "https://typing.example.com",
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "game")!.id,
+      authorId: grace.id,
+      voteCount: 36,
+    },
+    {
+      slug: "ip-lookup",
+      name: "IP Lookup Tool",
+      description: "Look up geolocation, ISP, and threat data for any IP address or domain.",
+      repoUrl: "https://github.com/example/ip-lookup",
+      demoUrl: null,
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "utility")!.id,
+      authorId: henry.id,
+      voteCount: 9,
+    },
+    {
+      slug: "json-diff-viewer",
+      name: "JSON Diff Viewer",
+      description: "Side-by-side JSON diff viewer with syntax highlighting and collapsible nodes.",
+      repoUrl: "https://github.com/example/json-diff",
+      demoUrl: "https://jsondiff.example.com",
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "utility")!.id,
+      authorId: iris.id,
+      voteCount: 14,
+    },
+    {
+      slug: "daily-journal",
+      name: "Daily Journal",
+      description: "Minimalist daily journal with mood tracking and weekly reflection prompts.",
+      repoUrl: "https://github.com/example/daily-journal",
+      demoUrl: null,
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "productivity")!.id,
+      authorId: jack.id,
+      voteCount: 20,
+    },
+    {
+      slug: "svg-icon-generator",
+      name: "SVG Icon Generator",
+      description: "Generate custom SVG icons from text prompts. Export as SVG or PNG.",
+      repoUrl: "https://github.com/example/svg-icons",
+      demoUrl: "https://icons.example.com",
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "utility")!.id,
+      authorId: kate.id,
+      voteCount: 31,
+    },
+    {
+      slug: "workout-tracker",
+      name: "Workout Tracker",
+      description: "Log workouts, track PRs, and visualize progress over time with chart breakdowns.",
+      repoUrl: "https://github.com/example/workout-tracker",
+      demoUrl: null,
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "productivity")!.id,
+      authorId: leo.id,
+      voteCount: 25,
+    },
+    {
+      slug: "quiz-maker",
+      name: "Quiz Maker",
+      description: "Create and share quizzes with multiple choice, true/false, and short answer formats.",
+      repoUrl: "https://github.com/example/quiz-maker",
+      demoUrl: "https://quiz.example.com",
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "game")!.id,
+      authorId: mia.id,
+      voteCount: 13,
+    },
+    {
+      slug: "link-shortener",
+      name: "Link Shortener",
+      description: "Simple link shortener with click analytics and custom slug support.",
+      repoUrl: "https://github.com/example/link-shortener",
+      demoUrl: "https://links.example.com",
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "utility")!.id,
+      authorId: noah.id,
+      voteCount: 8,
+    },
   ];
 
   for (const mod of approvedModules) {
     await prisma.miniApp.upsert({
       where: { slug: mod.slug },
-      update: {},
+      update: { createdAt: now },
       create: mod,
     });
   }
@@ -143,6 +323,7 @@ async function main() {
 
   console.log("✅ Seed complete");
   console.log(`   ${categories.length} categories`);
+  console.log(`   ${contributors.length + 1} users (${contributors.length} contributors + 1 admin)`);
   console.log(`   ${approvedModules.length} approved modules`);
   console.log(`   ${pendingModules.length} pending modules`);
 }

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+
+export async function GET() {
+  const now = new Date();
+  const startOfMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+
+  const rows = await db.miniApp.groupBy({
+    by: ["authorId"],
+    where: {
+      status: "APPROVED",
+      createdAt: { gte: startOfMonth },
+    },
+    _count: { id: true },
+    orderBy: { _count: { id: "desc" } },
+    take: 10,
+  });
+
+  if (rows.length === 0) return NextResponse.json({ contributors: [] });
+
+  const authorIds = rows.map((r) => r.authorId);
+  const users = await db.user.findMany({
+    where: { id: { in: authorIds } },
+    select: { id: true, name: true, image: true },
+  });
+
+  const userMap = new Map(users.map((u) => [u.id, u] as const));
+
+  const contributors = rows.map((row, i) => {
+    const user = userMap.get(row.authorId);
+    return {
+      rank: i + 1,
+      userId: row.authorId,
+      name: user?.name ?? "Unknown",
+      image: user?.image ?? null,
+      approvedCount: row._count.id,
+    };
+  });
+
+  return NextResponse.json({ contributors });
+}

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -1,0 +1,97 @@
+export const revalidate = 600;
+
+export const metadata = { title: "Leaderboard — Intern Community Hub" };
+
+async function getLeaderboard() {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL ?? "http://localhost:3000"}/api/leaderboard`, {
+    next: { revalidate: 600 },
+  } as RequestInit);
+  if (!res.ok) return [];
+  const data = await res.json();
+  return data.contributors as {
+    rank: number;
+    userId: string;
+    name: string;
+    image: string | null;
+    approvedCount: number;
+  }[];
+}
+
+const rankStyles: Record<number, string> = {
+  1: "bg-yellow-400 text-yellow-900",
+  2: "bg-gray-300 text-gray-800",
+  3: "bg-amber-600 text-white",
+};
+
+function Avatar({ name, image }: { name: string; image: string | null }) {
+  if (image) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img
+        src={image}
+        alt={name}
+        className="h-10 w-10 rounded-full object-cover"
+      />
+    );
+  }
+  return (
+    <div className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-100 text-sm font-bold text-blue-700">
+      {name.charAt(0).toUpperCase()}
+    </div>
+  );
+}
+
+export default async function LeaderboardPage() {
+  const contributors = await getLeaderboard();
+  const now = new Date();
+  const monthLabel = now.toLocaleString("en-US", {
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+
+  return (
+    <div className="mx-auto max-w-2xl">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900">Leaderboard</h1>
+        <p className="mt-1 text-sm text-gray-500">
+          Top contributors for {monthLabel} · ranked by approved submissions
+        </p>
+      </div>
+
+      {contributors.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-gray-300 p-12 text-center">
+          <p className="text-gray-500">No approved submissions this month yet.</p>
+        </div>
+      ) : (
+        <ol className="space-y-3">
+          {contributors.map((contributor) => (
+            <li
+              key={contributor.rank}
+              className="flex items-center gap-4 rounded-xl border border-gray-200 bg-white px-4 py-3"
+            >
+              <span
+                className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-xs font-bold ${
+                  rankStyles[contributor.rank] ?? "bg-gray-100 text-gray-600"
+                }`}
+              >
+                {contributor.rank}
+              </span>
+
+              <Avatar name={contributor.name} image={contributor.image} />
+
+              <span className="flex-1 font-medium text-gray-900">
+                {contributor.name}
+              </span>
+
+              <span className="text-sm text-gray-500">
+                {contributor.approvedCount}{" "}
+                {contributor.approvedCount === 1 ? "module" : "modules"}
+              </span>
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -14,6 +14,9 @@ export function Navbar() {
         </Link>
 
         <div className="flex items-center gap-4">
+          <Link href="/leaderboard" className="text-sm text-gray-600 hover:text-gray-900">
+            Leaderboard
+          </Link>
           {session ? (
             <>
               <Link href="/submit" className="text-sm text-gray-600 hover:text-gray-900">


### PR DESCRIPTION
## What does this PR do?

Adds a public contributor leaderboard at `/leaderboard` that ranks the top 10 contributors by number of approved module submissions in the current UTC month. The page is publicly accessible (no login required) and uses Next.js ISR with a 10-minute revalidation window instead of client-side polling.

## Related Issue

Closes #

## How to test

1. Run `pnpm db:migrate` to apply the new composite index migration
2. Run `pnpm db:seed` to populate 15 contributors with approved modules
3. Navigate to `/leaderboard` — top 10 contributors should appear ranked by submission count
4. Verify the page is accessible without signing in
5. Verify the "Leaderboard" link is visible in the navbar for all users (logged in or not)
6. Verify only modules with status `APPROVED` and `createdAt` within the current UTC month are counted

## Screenshots / recordings (if UI change)

<!-- Drag and drop a screenshot or screen recording here -->

## Checklist

- [x] I read the relevant code **before** writing my own
- [x] My code follows the existing patterns in the codebase
- [x] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
- [x] I added or updated tests where applicable
- [x] I can explain every line of code I wrote (reviewer will ask)
- [x] I kept the PR focused — no unrelated changes

## Notes for reviewer

- Rankings reset automatically at UTC midnight on the 1st — no cron job needed, the API query filters by `createdAt >= start of current UTC month`
- Used `groupBy` + a single batch `findMany` for user details to avoid N+1 queries
- `@@index([status, createdAt, authorId])` added on `MiniApp` to make the monthly group-by query efficient
- `export const revalidate = 600` on the page means Next.js rebuilds it at most every 10 minutes — no websockets or client polling needed
