### PR TITLE
Feat/notification system

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { generateSlug, makeUniqueSlug, formatRelativeTime } from "@/lib/utils";
+import { generateSlug, makeUniqueSlug } from "@/lib/utils";
 
 // ============================================================
 // generateSlug — already written as examples

--- a/prisma/migrations/20260404105733_initial_schema/migration.sql
+++ b/prisma/migrations/20260404105733_initial_schema/migration.sql
@@ -1,0 +1,154 @@
+-- CreateEnum
+CREATE TYPE "SubmissionStatus" AS ENUM ('PENDING', 'APPROVED', 'REJECTED');
+
+-- CreateTable
+CREATE TABLE "accounts" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "providerAccountId" TEXT NOT NULL,
+    "refresh_token" TEXT,
+    "access_token" TEXT,
+    "expires_at" INTEGER,
+    "token_type" TEXT,
+    "scope" TEXT,
+    "id_token" TEXT,
+    "session_state" TEXT,
+
+    CONSTRAINT "accounts_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "sessions" (
+    "id" TEXT NOT NULL,
+    "sessionToken" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "expires" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "sessions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "verification_tokens" (
+    "identifier" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "expires" TIMESTAMP(3) NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "users" (
+    "id" TEXT NOT NULL,
+    "name" TEXT,
+    "email" TEXT,
+    "emailVerified" TIMESTAMP(3),
+    "image" TEXT,
+    "isAdmin" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "users_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "categories" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+
+    CONSTRAINT "categories_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "mini_apps" (
+    "id" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "repoUrl" TEXT NOT NULL,
+    "demoUrl" TEXT,
+    "status" "SubmissionStatus" NOT NULL DEFAULT 'PENDING',
+    "feedback" TEXT,
+    "categoryId" TEXT NOT NULL,
+    "authorId" TEXT NOT NULL,
+    "voteCount" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "mini_apps_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "votes" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "moduleId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "votes_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "notifications" (
+    "id" TEXT NOT NULL,
+    "status" "SubmissionStatus" NOT NULL,
+    "read" BOOLEAN NOT NULL DEFAULT false,
+    "userId" TEXT NOT NULL,
+    "moduleId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "notifications_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "accounts_provider_providerAccountId_key" ON "accounts"("provider", "providerAccountId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "sessions_sessionToken_key" ON "sessions"("sessionToken");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "verification_tokens_token_key" ON "verification_tokens"("token");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "verification_tokens_identifier_token_key" ON "verification_tokens"("identifier", "token");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_email_key" ON "users"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "categories_name_key" ON "categories"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "categories_slug_key" ON "categories"("slug");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "mini_apps_slug_key" ON "mini_apps"("slug");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "votes_userId_moduleId_key" ON "votes"("userId", "moduleId");
+
+-- CreateIndex
+CREATE INDEX "notifications_userId_read_idx" ON "notifications"("userId", "read");
+
+-- AddForeignKey
+ALTER TABLE "accounts" ADD CONSTRAINT "accounts_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "sessions" ADD CONSTRAINT "sessions_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "mini_apps" ADD CONSTRAINT "mini_apps_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "categories"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "mini_apps" ADD CONSTRAINT "mini_apps_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "votes" ADD CONSTRAINT "votes_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "votes" ADD CONSTRAINT "votes_moduleId_fkey" FOREIGN KEY ("moduleId") REFERENCES "mini_apps"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_moduleId_fkey" FOREIGN KEY ("moduleId") REFERENCES "mini_apps"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -60,10 +60,11 @@ model User {
   // Our custom fields
   isAdmin       Boolean   @default(false)
 
-  accounts    Account[]
-  sessions    Session[]
-  submissions MiniApp[]
-  votes       Vote[]
+  accounts      Account[]
+  sessions      Session[]
+  submissions   MiniApp[]
+  votes         Vote[]
+  notifications Notification[]
 
   createdAt DateTime @default(now())
 
@@ -98,7 +99,8 @@ model MiniApp {
   author   User   @relation(fields: [authorId], references: [id])
   authorId String
 
-  votes     Vote[]
+  votes         Vote[]
+  notifications Notification[]
   // Denormalized for read performance on the browse page.
   // DO NOT remove this field and replace with COUNT(*) without running EXPLAIN ANALYZE first.
   voteCount Int    @default(0)
@@ -122,6 +124,24 @@ model Vote {
 
   @@unique([userId, moduleId])
   @@map("votes")
+}
+
+model Notification {
+  id     String           @id @default(cuid())
+  status SubmissionStatus
+
+  read Boolean @default(false)
+
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId String
+
+  module   MiniApp @relation(fields: [moduleId], references: [id], onDelete: Cascade)
+  moduleId String
+
+  createdAt DateTime @default(now())
+
+  @@index([userId, read])
+  @@map("notifications")
 }
 
 enum SubmissionStatus {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -36,7 +36,7 @@ async function main() {
   ]);
 
   // Seed demo admin user
-  const admin = await prisma.user.upsert({
+  await prisma.user.upsert({
     where: { email: "admin@td.com" },
     update: {},
     create: {

--- a/src/app/api/modules/[id]/route.ts
+++ b/src/app/api/modules/[id]/route.ts
@@ -8,7 +8,7 @@ type Params = { params: Promise<{ id: string }> };
 // GET /api/modules/[id]
 export async function GET(_req: NextRequest, { params }: Params) {
   const { id } = await params;
-  const module = await db.miniApp.findUnique({
+  const miniApp = await db.miniApp.findUnique({
     where: { id },
     include: {
       category: true,
@@ -16,8 +16,8 @@ export async function GET(_req: NextRequest, { params }: Params) {
       _count: { select: { votes: true } },
     },
   });
-  if (!module) return NextResponse.json({ error: "Not found" }, { status: 404 });
-  return NextResponse.json(module);
+  if (!miniApp) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  return NextResponse.json(miniApp);
 }
 
 // PATCH /api/modules/[id] — admin approve/reject
@@ -34,6 +34,9 @@ export async function PATCH(req: NextRequest, { params }: Params) {
     return NextResponse.json({ error: parsed.error.flatten() }, { status: 422 });
   }
 
+  const existing = await db.miniApp.findUnique({ where: { id } });
+  if (!existing) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
   const updated = await db.miniApp.update({
     where: { id },
     data: {
@@ -41,6 +44,16 @@ export async function PATCH(req: NextRequest, { params }: Params) {
       feedback: parsed.data.feedback,
     },
   });
+
+  if (existing.status !== parsed.data.status) {
+    await db.notification.create({
+      data: {
+        userId: existing.authorId,
+        moduleId: existing.id,
+        status: parsed.data.status,
+      },
+    });
+  }
 
   return NextResponse.json(updated);
 }
@@ -53,10 +66,10 @@ export async function DELETE(_req: NextRequest, { params }: Params) {
   }
 
   const { id } = await params;
-  const module = await db.miniApp.findUnique({ where: { id } });
-  if (!module) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  const miniApp = await db.miniApp.findUnique({ where: { id } });
+  if (!miniApp) return NextResponse.json({ error: "Not found" }, { status: 404 });
 
-  if (module.authorId !== session.user.id && !session.user.isAdmin) {
+  if (miniApp.authorId !== session.user.id && !session.user.isAdmin) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/src/app/api/modules/route.ts
+++ b/src/app/api/modules/route.ts
@@ -67,7 +67,7 @@ export async function POST(req: NextRequest) {
     .then((r) => r.map((m) => m.slug));
   const slug = makeUniqueSlug(baseSlug, existingSlugs);
 
-  const module = await db.miniApp.create({
+  const miniApp = await db.miniApp.create({
     data: {
       slug,
       name,
@@ -80,5 +80,5 @@ export async function POST(req: NextRequest) {
     },
   });
 
-  return NextResponse.json(module, { status: 201 });
+  return NextResponse.json(miniApp, { status: 201 });
 }

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+
+export async function GET() {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const notifications = await db.notification.findMany({
+    where: { userId: session.user.id },
+    include: { module: { select: { name: true, slug: true } } },
+    orderBy: { createdAt: "desc" },
+    take: 50,
+  });
+
+  const unreadCount = notifications.filter((n) => !n.read).length;
+
+  return NextResponse.json({ notifications, unreadCount });
+}
+
+export async function PATCH(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await req.json().catch(() => ({}));
+  const ids: string[] | undefined = body.ids;
+
+  await db.notification.updateMany({
+    where: {
+      userId: session.user.id,
+      ...(ids ? { id: { in: ids } } : {}),
+    },
+    data: { read: true },
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/modules/[slug]/page.tsx
+++ b/src/app/modules/[slug]/page.tsx
@@ -8,15 +8,15 @@ type Props = { params: Promise<{ slug: string }> };
 
 export async function generateMetadata({ params }: Props) {
   const { slug } = await params;
-  const module = await db.miniApp.findUnique({ where: { slug } });
-  return { title: module ? `${module.name} — Intern Community Hub` : "Not Found" };
+  const miniApp = await db.miniApp.findUnique({ where: { slug } });
+  return { title: miniApp ? `${miniApp.name} — Intern Community Hub` : "Not Found" };
 }
 
 export default async function ModuleDetailPage({ params }: Props) {
   const { slug } = await params;
   const session = await auth();
 
-  const module = await db.miniApp.findUnique({
+  const miniApp = await db.miniApp.findUnique({
     where: { slug, status: "APPROVED" },
     include: {
       category: true,
@@ -24,13 +24,13 @@ export default async function ModuleDetailPage({ params }: Props) {
     },
   });
 
-  if (!module) notFound();
+  if (!miniApp) notFound();
 
   let hasVoted = false;
   if (session?.user) {
     const vote = await db.vote.findUnique({
       where: {
-        userId_moduleId: { userId: session.user.id, moduleId: module.id },
+        userId_moduleId: { userId: session.user.id, moduleId: miniApp.id },
       },
     });
     hasVoted = !!vote;
@@ -44,32 +44,32 @@ export default async function ModuleDetailPage({ params }: Props) {
 
       <div className="space-y-2">
         <div className="flex items-start justify-between gap-4">
-          <h1 className="text-2xl font-bold text-gray-900">{module.name}</h1>
+          <h1 className="text-2xl font-bold text-gray-900">{miniApp.name}</h1>
           <VoteButton
-            moduleId={module.id}
+            moduleId={miniApp.id}
             initialVoted={hasVoted}
-            initialCount={module.voteCount}
+            initialCount={miniApp.voteCount}
           />
         </div>
         <p className="text-sm text-gray-500">
-          by {module.author.name} · {module.category.name}
+          by {miniApp.author.name} · {miniApp.category.name}
         </p>
       </div>
 
-      <p className="text-gray-700">{module.description}</p>
+      <p className="text-gray-700">{miniApp.description}</p>
 
       <div className="flex gap-3">
         <a
-          href={module.repoUrl}
+          href={miniApp.repoUrl}
           target="_blank"
           rel="noopener noreferrer"
           className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
         >
           View on GitHub
         </a>
-        {module.demoUrl && (
+        {miniApp.demoUrl && (
           <a
-            href={module.demoUrl}
+            href={miniApp.demoUrl}
             target="_blank"
             rel="noopener noreferrer"
             className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
@@ -81,12 +81,12 @@ export default async function ModuleDetailPage({ params }: Props) {
 
       {/* TODO [hard-challenge]: Implement sandboxed iframe preview here.
           Requirements:
-          - Only show if module.demoUrl exists
+          - Only show if miniApp.demoUrl exists
           - Use sandbox="allow-scripts allow-same-origin" at minimum
           - Add Content-Security-Policy header for the iframe origin
           - Show a loading skeleton while the iframe loads
           See: ISSUES.md for full acceptance criteria */}
-      {module.demoUrl && (
+      {miniApp.demoUrl && (
         <div className="rounded-xl border border-dashed border-gray-300 p-8 text-center text-sm text-gray-400">
           Sandboxed preview coming soon. Contribute this feature! See{" "}
           <Link href="https://github.com" className="text-blue-600 hover:underline">

--- a/src/app/notifications/mark-read.tsx
+++ b/src/app/notifications/mark-read.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { useEffect } from "react";
+
+export function MarkAllRead() {
+  useEffect(() => {
+    fetch("/api/notifications", { method: "PATCH", body: JSON.stringify({}), headers: { "Content-Type": "application/json" } });
+  }, []);
+
+  return null;
+}

--- a/src/app/notifications/page.tsx
+++ b/src/app/notifications/page.tsx
@@ -1,0 +1,59 @@
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { MarkAllRead } from "./mark-read";
+
+export const metadata = { title: "Notifications — Intern Community Hub" };
+
+export default async function NotificationsPage() {
+  const session = await auth();
+  if (!session?.user) redirect("/api/auth/signin");
+
+  const notifications = await db.notification.findMany({
+    where: { userId: session.user.id },
+    include: { module: { select: { name: true, slug: true } } },
+    orderBy: { createdAt: "desc" },
+    take: 50,
+  });
+
+
+  if (notifications.length === 0) {
+    return (
+      <div className="py-16 text-center text-gray-500">
+        No notifications yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl">
+      <MarkAllRead />
+      <h1 className="mb-6 text-xl font-bold text-gray-900">Notifications</h1>
+      <ul className="divide-y divide-gray-100 rounded-lg border border-gray-200 bg-white">
+        {notifications.map((n) => (
+          <li
+            key={n.id}
+            className={`flex items-start justify-between gap-4 px-4 py-3 ${!n.read ? "bg-blue-50" : ""}`}
+          >
+            <div>
+              <p className="text-sm text-gray-800">
+                <Link href={`/modules/${n.module.slug}`} className="font-medium hover:underline">
+                  {n.module.name}
+                </Link>{" "}
+                was{" "}
+                <span className={n.status === "APPROVED" ? "font-medium text-green-600" : "font-medium text-red-600"}>
+                  {n.status === "APPROVED" ? "approved" : "rejected"}
+                </span>
+              </p>
+              <p className="mt-0.5 text-xs text-gray-400">
+                {new Date(n.createdAt).toLocaleString()}
+              </p>
+            </div>
+            {!n.read && <span className="mt-1 h-2 w-2 shrink-0 rounded-full bg-blue-500" />}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { db } from "@/lib/db";
 import { auth } from "@/lib/auth";
 import { ModuleCard } from "@/components/module-card";
@@ -78,7 +79,7 @@ export default async function HomePage({
 
       {/* Category filter placeholder — see TODO above */}
       <div className="flex flex-wrap gap-2">
-        <a
+        <Link
           href="/"
           className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
             !category
@@ -87,9 +88,9 @@ export default async function HomePage({
           }`}
         >
           All
-        </a>
+        </Link>
         {categories.map((c) => (
-          <a
+          <Link
             key={c.id}
             href={`/?category=${c.slug}`}
             className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
@@ -99,7 +100,7 @@ export default async function HomePage({
             }`}
           >
             {c.name}
-          </a>
+          </Link>
         ))}
       </div>
 
@@ -107,9 +108,9 @@ export default async function HomePage({
         <div className="rounded-xl border border-dashed border-gray-300 p-12 text-center">
           <p className="text-gray-500">No modules found.</p>
           {q && (
-            <a href="/" className="mt-2 block text-sm text-blue-600 hover:underline">
+            <Link href="/" className="mt-2 block text-sm text-blue-600 hover:underline">
               Clear search
-            </a>
+            </Link>
           )}
         </div>
       ) : (

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useSession, signIn, signOut } from "next-auth/react";
+import { NotificationBell } from "@/components/notification-bell";
 
 export function Navbar() {
   const { data: session } = useSession();
@@ -27,6 +28,7 @@ export function Navbar() {
                   Admin
                 </Link>
               )}
+              <NotificationBell />
               <button
                 onClick={() => signOut()}
                 className="text-sm text-gray-400 hover:text-gray-600"

--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+export function NotificationBell() {
+  const [unreadCount, setUnreadCount] = useState<number | null>(null);
+
+  useEffect(() => {
+    const fetchUnread = () =>
+      fetch("/api/notifications")
+        .then((r) => r.json())
+        .then((d) => setUnreadCount(d.unreadCount ?? 0))
+        .catch(() => undefined);
+
+    const interval = setInterval(fetchUnread, 30_000);
+    window.addEventListener("focus", fetchUnread);
+    fetchUnread();
+
+    return () => {
+      clearInterval(interval);
+      window.removeEventListener("focus", fetchUnread);
+    };
+  }, []);
+
+  return (
+    <Link href="/notifications" className="relative text-gray-600 hover:text-gray-900">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="20"
+        height="20"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-label="Notifications"
+      >
+        <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+        <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+      </svg>
+      {unreadCount !== null && unreadCount > 0 && (
+        <span className="absolute -right-1.5 -top-1.5 flex h-4 w-4 items-center justify-center rounded-full bg-red-500 text-[10px] font-bold text-white">
+          {unreadCount > 9 ? "9+" : unreadCount}
+        </span>
+      )}
+    </Link>
+  );
+}


### PR DESCRIPTION
## What does this PR do?

Implements an in-app notification system that alerts contributors when their submitted module is approved or rejected by an admin.

When an admin reviews a submission, a notification is created and stored in the database. Contributors see a live bell icon in the navbar that shows an unread count badge, polling every 30 seconds and on window focus. Visiting `/notifications` displays the full list and automatically marks all as read.


## How to test

1. Run `pnpm db:migrate` then `pnpm db:seed` to apply the new `notifications` table
2. Sign in as a contributor and submit a module
3. Sign out, sign in as an admin, go to `/admin`, and approve or reject the submission
4. Sign back in as the contributor — the bell icon in the navbar should show a red badge with count `1`
5. Click the bell / navigate to `/notifications` — the notification should appear with the correct status (green "approved" or red "rejected"), and the badge should disappear after the page loads


## Checklist

- [x] I read the relevant code **before** writing my own
- [x] My code follows the existing patterns in the codebase
- [x] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
- [x] I added or updated tests where applicable
- [x] I can explain every line of code I wrote (reviewer will ask)
- [x] I kept the PR focused — no unrelated changes

## Notes for reviewer

- `MarkAllRead` is a client component that fires `PATCH /api/notifications` on mount rather than marking read server-side — this ensures the bell count is visible before the user lands on the page
- The bell polls on `window focus` in addition to the 30 s interval to keep counts fresh without websockets
- `@@index([userId, read])` added on the `Notification` model to make the unread count query efficient
