### PR TITLE
chore: add husky to ensure consistent commit messages

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,12 @@
+# Enforce Conventional Commits format
+commit_msg=$(cat "$1")
+pattern="^(feat|fix|chore|docs|style|refactor|test|perf|ci|build|revert)(\(.+\))?: .{1,100}"
+if ! echo "$commit_msg" | grep -qE "$pattern"; then
+  echo ""
+  echo "  Commit message does not follow Conventional Commits format."
+  echo "  Expected: <type>(optional-scope): <description>"
+  echo "  Example:  feat(auth): add GitHub OAuth login"
+  echo "  Types: feat|fix|chore|docs|style|refactor|test|perf|ci|build|revert"
+  echo ""
+  exit 1
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+pnpm exec lint-staged

--- a/package.json
+++ b/package.json
@@ -15,10 +15,17 @@
     "db:push": "prisma db push",
     "db:seed": "tsx prisma/seed.ts",
     "db:studio": "prisma studio",
-    "db:generate": "prisma generate"
+    "db:generate": "prisma generate",
+    "prepare": "husky"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"
+  },
+  "lint-staged": {
+    "*.{ts,tsx}": [
+      "eslint --fix",
+      "tsc --noEmit --skipLibCheck"
+    ]
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.11.1",
@@ -45,6 +52,8 @@
     "@vitest/coverage-v8": "^4.1.2",
     "eslint": "^9",
     "eslint-config-next": "16.2.2",
+    "husky": "^9.1.7",
+    "lint-staged": "^16.4.0",
     "tailwindcss": "^4",
     "tsx": "^4.21.0",
     "typescript": "^5",

--- a/src/hooks/use-optimistic-vote.ts
+++ b/src/hooks/use-optimistic-vote.ts
@@ -43,6 +43,7 @@ export function useOptimisticVote({
   // BUG: this ref is never reset when the component unmounts and remounts
   // with the same moduleId (e.g. navigating away and back in the same session).
   // The stale `isMounted` from the previous render is reused.
+
   const isMounted = useRef(true);
 
   const toggle = useCallback(async () => {


### PR DESCRIPTION
## What does this PR do?

Sets up Husky with a `commit-msg` hook that enforces Conventional Commits format on every commit, and a `pre-commit` hook that runs ESLint via lint-staged on all staged `.ts` and `.tsx` files.

## Related Issue

Closes #

## How to test

1. Run `pnpm install` to install the husky hooks
2. Try committing with a bad message (e.g. `git commit -m "fix stuff"`) — it should be rejected with a clear error
3. Try committing with a valid message (e.g. `git commit -m "fix: correct typo in navbar"`) — it should pass
4. Stage a `.ts` file with a lint error and commit — ESLint should run and either auto-fix or block the commit

## Checklist

- [x] I read the relevant code **before** writing my own
- [x] My code follows the existing patterns in the codebase
- [x] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
- [x] I added or updated tests where applicable
- [x] I can explain every line of code I wrote (reviewer will ask)
- [x] I kept the PR focused — no unrelated changes

## Notes for reviewer

- Conventional Commits pattern enforced: `feat|fix|chore|docs|style|refactor|test|perf|ci|build|revert` with optional scope and body up to 100 chars

