### PR TITLE
feat: add public user profile page with activity overview

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -35,7 +35,7 @@ async function main() {
     }),
   ]);
 
-  // Seed demo admin user
+  // Seed demo users
   const admin = await prisma.user.upsert({
     where: { email: "admin@td.com" },
     update: {},
@@ -46,13 +46,32 @@ async function main() {
     },
   });
 
-  // Seed demo contributor
   const contributor = await prisma.user.upsert({
     where: { email: "dev@example.com" },
     update: {},
     create: {
       name: "Demo Dev",
       email: "dev@example.com",
+      isAdmin: false,
+    },
+  });
+
+  const contributor2 = await prisma.user.upsert({
+    where: { email: "maker@example.com" },
+    update: {},
+    create: {
+      name: "Demo Maker",
+      email: "maker@example.com",
+      isAdmin: false,
+    },
+  });
+
+  const contributor3 = await prisma.user.upsert({
+    where: { email: "coder@example.com" },
+    update: {},
+    create: {
+      name: "Code Enthusiast",
+      email: "coder@example.com",
       isAdmin: false,
     },
   });
@@ -94,6 +113,186 @@ async function main() {
       categoryId: categories.find((c) => c.slug === "game")!.id,
       authorId: contributor.id,
       voteCount: 41,
+    },
+    {
+      slug: "team-chat",
+      name: "Team Chat",
+      description:
+        "A lightweight chat app for teams, with channels, mentions, and file sharing.",
+      repoUrl: "https://github.com/example/team-chat",
+      demoUrl: "https://chat.example.com",
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "social")!.id,
+      authorId: contributor2.id,
+      voteCount: 27,
+    },
+    {
+      slug: "password-manager",
+      name: "Password Manager",
+      description:
+        "Store and organize passwords securely with browser autofill support.",
+      repoUrl: "https://github.com/example/password-manager",
+      demoUrl: null,
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "utility")!.id,
+      authorId: contributor2.id,
+      voteCount: 44,
+    },
+    {
+      slug: "stock-screener",
+      name: "Stock Screener",
+      description:
+        "Search stocks by sector, market cap, and valuation metrics to build watch lists.",
+      repoUrl: "https://github.com/example/stock-screener",
+      demoUrl: "https://stocks.example.com",
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "finance")!.id,
+      authorId: contributor.id,
+      voteCount: 32,
+    },
+    {
+      slug: "recipe-book",
+      name: "Recipe Book",
+      description:
+        "Save recipes, plan meals, and generate shopping lists from your favorite dishes.",
+      repoUrl: "https://github.com/example/recipe-book",
+      demoUrl: "https://recipes.example.com",
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "utility")!.id,
+      authorId: contributor2.id,
+      voteCount: 20,
+    },
+    {
+      slug: "weather-dashboard",
+      name: "Weather Dashboard",
+      description:
+        "Local weather, 5-day forecasts, and sunrise/sunset times with animated weather cards.",
+      repoUrl: "https://github.com/example/weather-dashboard",
+      demoUrl: "https://weather.example.com",
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "utility")!.id,
+      authorId: contributor.id,
+      voteCount: 16,
+    },
+    {
+      slug: "study-planner",
+      name: "Study Planner",
+      description:
+        "Organize your study sessions, subjects, and deadlines with a clean planner interface.",
+      repoUrl: "https://github.com/example/study-planner",
+      demoUrl: null,
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "productivity")!.id,
+      authorId: contributor2.id,
+      voteCount: 35,
+    },
+    {
+      slug: "event-invites",
+      name: "Event Invites",
+      description:
+        "Create shareable event pages, RSVP tracking, and calendar integration for meetups.",
+      repoUrl: "https://github.com/example/event-invites",
+      demoUrl: "https://events.example.com",
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "social")!.id,
+      authorId: contributor.id,
+      voteCount: 14,
+    },
+    {
+      slug: "focus-sounds",
+      name: "Focus Sounds",
+      description:
+        "Ambient sound mixer with white noise, rain, and forest tracks for concentration.",
+      repoUrl: "https://github.com/example/focus-sounds",
+      demoUrl: "https://focus.example.com",
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "productivity")!.id,
+      authorId: contributor2.id,
+      voteCount: 21,
+    },
+    {
+      slug: "budget-splitter",
+      name: "Budget Splitter",
+      description:
+        "Split expenses with friends and calculate how much each person owes after group events.",
+      repoUrl: "https://github.com/example/budget-splitter",
+      demoUrl: null,
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "finance")!.id,
+      authorId: contributor.id,
+      voteCount: 29,
+    },
+    {
+      slug: "color-picker",
+      name: "Color Picker",
+      description:
+        "Pick colors, copy values in HEX/RGB/HSL, and save palettes for future design work.",
+      repoUrl: "https://github.com/example/color-picker",
+      demoUrl: "https://colors.example.com",
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "utility")!.id,
+      authorId: contributor2.id,
+      voteCount: 12,
+    },
+    {
+      slug: "language-flashcards",
+      name: "Language Flashcards",
+      description:
+        "Practice vocabulary with spaced repetition and multiple choice review cards.",
+      repoUrl: "https://github.com/example/language-flashcards",
+      demoUrl: null,
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "productivity")!.id,
+      authorId: contributor.id,
+      voteCount: 18,
+    },
+    {
+      slug: "community-map",
+      name: "Community Map",
+      description:
+        "Discover local meetups, coding groups, and shared workspaces from the developer community.",
+      repoUrl: "https://github.com/example/community-map",
+      demoUrl: "https://community.example.com",
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "social")!.id,
+      authorId: contributor2.id,
+      voteCount: 9,
+    },
+    {
+      slug: "meeting-timer",
+      name: "Meeting Timer",
+      description:
+        "Keep meetings on track with agenda timers, speaker cues, and automatic timeboxing.",
+      repoUrl: "https://github.com/example/meeting-timer",
+      demoUrl: null,
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "productivity")!.id,
+      authorId: contributor.id,
+      voteCount: 19,
+    },
+    {
+      slug: "snake-game",
+      name: "Snake Game",
+      description:
+        "Classic Snake game with smooth controls, score tracking, and retro pixel art.",
+      repoUrl: "https://github.com/example/snake-game",
+      demoUrl: "https://snake.example.com",
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "game")!.id,
+      authorId: contributor3.id,
+      voteCount: 33,
+    },
+    {
+      slug: "todo-list",
+      name: "Smart Todo List",
+      description:
+        "AI-powered task management with smart suggestions, priority scoring, and deadline reminders.",
+      repoUrl: "https://github.com/example/todo-list",
+      demoUrl: "https://todo.example.com",
+      status: SubmissionStatus.APPROVED,
+      categoryId: categories.find((c) => c.slug === "productivity")!.id,
+      authorId: contributor3.id,
+      voteCount: 28,
     },
   ];
 

--- a/src/app/modules/[slug]/page.tsx
+++ b/src/app/modules/[slug]/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { db } from "@/lib/db";
 import { auth } from "@/lib/auth";
 import { VoteButton } from "@/components/vote-button";
+import { BackButton } from "@/components/back-button";
 
 type Props = { params: Promise<{ slug: string }> };
 
@@ -19,10 +20,10 @@ export default async function ModuleDetailPage({
   searchParams,
 }: {
   params: Promise<{ slug: string }>;
-  searchParams: Promise<{ from?: string }>;
+  searchParams: Promise<{ from?: string; profileId?: string }>;
 }) {
   const { slug } = await params;
-  const { from } = await searchParams;
+  const { from, profileId } = await searchParams;
   const session = await auth();
 
   const module = await db.miniApp.findUnique({
@@ -48,19 +49,14 @@ export default async function ModuleDetailPage({
   // Determine back URL
   const getBackUrl = () => {
     if (from === "profile") {
-      return `/users/${module.author.id}`;
+      return profileId ? `/users/${profileId}` : `/users/${module.author.id}`;
     }
     return "/";
   };
 
   return (
     <div className="mx-auto max-w-2xl space-y-6">
-      <Link
-        href={getBackUrl()}
-        className="text-sm text-gray-400 hover:text-gray-600"
-      >
-        ← Back to {from === "profile" ? "profile" : "modules"}
-      </Link>
+      <BackButton fallbackUrl={getBackUrl()}>← Back</BackButton>
 
       <div className="space-y-2">
         <div className="flex items-start justify-between gap-4">

--- a/src/app/modules/[slug]/page.tsx
+++ b/src/app/modules/[slug]/page.tsx
@@ -9,11 +9,20 @@ type Props = { params: Promise<{ slug: string }> };
 export async function generateMetadata({ params }: Props) {
   const { slug } = await params;
   const module = await db.miniApp.findUnique({ where: { slug } });
-  return { title: module ? `${module.name} — Intern Community Hub` : "Not Found" };
+  return {
+    title: module ? `${module.name} — Intern Community Hub` : "Not Found",
+  };
 }
 
-export default async function ModuleDetailPage({ params }: Props) {
+export default async function ModuleDetailPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<{ from?: string }>;
+}) {
   const { slug } = await params;
+  const { from } = await searchParams;
   const session = await auth();
 
   const module = await db.miniApp.findUnique({
@@ -36,10 +45,21 @@ export default async function ModuleDetailPage({ params }: Props) {
     hasVoted = !!vote;
   }
 
+  // Determine back URL
+  const getBackUrl = () => {
+    if (from === "profile") {
+      return `/users/${module.author.id}`;
+    }
+    return "/";
+  };
+
   return (
     <div className="mx-auto max-w-2xl space-y-6">
-      <Link href="/" className="text-sm text-gray-400 hover:text-gray-600">
-        ← Back to modules
+      <Link
+        href={getBackUrl()}
+        className="text-sm text-gray-400 hover:text-gray-600"
+      >
+        ← Back to {from === "profile" ? "profile" : "modules"}
       </Link>
 
       <div className="space-y-2">
@@ -52,7 +72,14 @@ export default async function ModuleDetailPage({ params }: Props) {
           />
         </div>
         <p className="text-sm text-gray-500">
-          by {module.author.name} · {module.category.name}
+          by{" "}
+          <Link
+            href={`/users/${module.author.id}`}
+            className="font-medium hover:text-blue-600 hover:underline"
+          >
+            {module.author.name}
+          </Link>{" "}
+          · {module.category.name}
         </p>
       </div>
 
@@ -89,7 +116,10 @@ export default async function ModuleDetailPage({ params }: Props) {
       {module.demoUrl && (
         <div className="rounded-xl border border-dashed border-gray-300 p-8 text-center text-sm text-gray-400">
           Sandboxed preview coming soon. Contribute this feature! See{" "}
-          <Link href="https://github.com" className="text-blue-600 hover:underline">
+          <Link
+            href="https://github.com"
+            className="text-blue-600 hover:underline"
+          >
             ISSUES.md
           </Link>
         </div>

--- a/src/app/my-submissions/page.tsx
+++ b/src/app/my-submissions/page.tsx
@@ -1,53 +1,13 @@
 import { redirect } from "next/navigation";
-import Link from "next/link";
 import { auth } from "@/lib/auth";
-import { db } from "@/lib/db";
-
-const statusStyles: Record<string, string> = {
-  PENDING: "bg-yellow-50 text-yellow-700 border-yellow-200",
-  APPROVED: "bg-green-50 text-green-700 border-green-200",
-  REJECTED: "bg-red-50 text-red-700 border-red-200",
-};
 
 export default async function MySubmissionsPage() {
   const session = await auth();
   if (!session?.user) redirect("/api/auth/signin");
 
-  const submissions = await db.miniApp.findMany({
-    where: { authorId: session.user.id },
-    include: { category: true },
-    orderBy: { createdAt: "desc" },
-  });
-
-  return (
-    <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold text-gray-900">My Submissions</h1>
-        <Link
-          href="/submit"
-          className="rounded-lg bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700"
-        >
-          + New Submission
-        </Link>
-      </div>
-
-      {submissions.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-gray-300 p-12 text-center">
-          <p className="text-gray-500">No submissions yet.</p>
-          <Link
-            href="/submit"
-            className="mt-2 block text-sm text-blue-600 hover:underline"
-          >
-            Submit your first module →
-          </Link>
-        </div>
-      ) : (
-        <div className="space-y-3">
-          {submissions.map((sub) => (
-            <div
-              key={sub.id}
-              className="flex items-start justify-between rounded-xl border border-gray-200 bg-white p-4"
-            >
+  // Redirect to user's profile page where submissions are now displayed
+  redirect(`/users/${session.user.id}`);
+}
               <div className="space-y-1">
                 <p className="font-medium text-gray-900">{sub.name}</p>
                 <p className="text-xs text-gray-400">

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -1,0 +1,274 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { db } from "@/lib/db";
+import { auth } from "@/lib/auth";
+import { ModuleCard } from "@/components/module-card";
+
+const statusStyles: Record<string, string> = {
+  PENDING: "bg-yellow-50 text-yellow-700 border-yellow-200",
+  APPROVED: "bg-green-50 text-green-700 border-green-200",
+  REJECTED: "bg-red-50 text-red-700 border-red-200",
+};
+
+type Props = { params: Promise<{ id: string }> };
+
+export async function generateMetadata({ params }: Props) {
+  const { id } = await params;
+  const user = await db.user.findUnique({
+    where: { id },
+    select: { name: true },
+  });
+  return {
+    title: user
+      ? `${user.name}'s Profile — Intern Community Hub`
+      : "User Profile",
+  };
+}
+
+export default async function UserProfilePage({ params }: Props) {
+  const { id } = await params;
+  const session = await auth();
+
+  // Fetch user info
+  const user = await db.user.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      image: true,
+      isAdmin: true,
+      createdAt: true,
+    },
+  });
+
+  if (!user) notFound();
+
+  // Fetch user's submitted modules
+  // If viewing own profile, show all submissions with status
+  // If viewing others' profile, show only approved modules
+  const isOwnProfile = session?.user?.id === id;
+  const submittedModules = await db.miniApp.findMany({
+    where: {
+      authorId: id,
+      ...(isOwnProfile ? {} : { status: "APPROVED" }),
+    },
+    include: {
+      category: true,
+      author: { select: { id: true, name: true, image: true } },
+    },
+    orderBy: isOwnProfile ? { createdAt: "desc" } : { voteCount: "desc" },
+  });
+
+  // Fetch modules user has voted on
+  const votedModules = await db.miniApp.findMany({
+    where: {
+      votes: {
+        some: { userId: id },
+      },
+      status: "APPROVED",
+    },
+    include: {
+      category: true,
+      author: { select: { id: true, name: true, image: true } },
+    },
+    orderBy: { voteCount: "desc" },
+  });
+
+  // Get vote IDs for current user (for hasVoted logic)
+  let currentUserVotedIds = new Set<string>();
+  if (session?.user) {
+    const votes = await db.vote.findMany({
+      where: {
+        userId: session.user.id,
+        moduleId: {
+          in: [...submittedModules, ...votedModules].map((m) => m.id),
+        },
+      },
+      select: { moduleId: true },
+    });
+    currentUserVotedIds = new Set(votes.map((v) => v.moduleId));
+  }
+
+  // Calculate stats
+  const totalVotesReceived = submittedModules.reduce(
+    (sum, mod) => sum + mod.voteCount,
+    0,
+  );
+  const totalVotesGiven = votedModules.length;
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-8">
+      <Link href="/" className="text-sm text-gray-400 hover:text-gray-600">
+        ← Back to modules
+      </Link>
+
+      {/* User Profile Header */}
+      <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <div className="flex items-start gap-6">
+          <div className="flex-shrink-0">
+            {user.image ? (
+              <img
+                src={user.image}
+                alt={user.name || "User"}
+                className="h-20 w-20 rounded-full object-cover"
+              />
+            ) : (
+              <div className="flex h-20 w-20 items-center justify-center rounded-full bg-gray-100 text-2xl font-semibold text-gray-600">
+                {(user.name || user.email || "?").charAt(0).toUpperCase()}
+              </div>
+            )}
+          </div>
+
+          <div className="flex-1 space-y-2">
+            <div className="flex items-center gap-2">
+              <h1 className="text-2xl font-bold text-gray-900">{user.name}</h1>
+              {user.isAdmin && (
+                <span className="rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700">
+                  Admin
+                </span>
+              )}
+            </div>
+
+            <p className="text-gray-600">{user.email}</p>
+
+            <div className="flex gap-6 text-sm text-gray-500">
+              <div>
+                <span className="font-medium text-gray-900">
+                  {submittedModules.length}
+                </span>{" "}
+                modules submitted
+              </div>
+              <div>
+                <span className="font-medium text-gray-900">
+                  {totalVotesReceived}
+                </span>{" "}
+                votes received
+              </div>
+              <div>
+                <span className="font-medium text-gray-900">
+                  {totalVotesGiven}
+                </span>{" "}
+                votes given
+              </div>
+            </div>
+
+            <p className="text-xs text-gray-400">
+              Joined {new Date(user.createdAt).toLocaleDateString()}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Submitted Modules */}
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-xl font-semibold text-gray-900">
+            {isOwnProfile ? "My Submissions" : "Submitted Modules"} (
+            {submittedModules.length})
+          </h2>
+          {isOwnProfile && (
+            <Link
+              href="/submit"
+              className="rounded-lg bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700"
+            >
+              + New Submission
+            </Link>
+          )}
+        </div>
+
+        {submittedModules.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-gray-300 p-8 text-center">
+            <p className="text-gray-500">
+              {isOwnProfile
+                ? "No submissions yet."
+                : "No modules submitted yet."}
+            </p>
+            {isOwnProfile && (
+              <Link
+                href="/submit"
+                className="mt-2 block text-sm text-blue-600 hover:underline"
+              >
+                Submit your first module →
+              </Link>
+            )}
+          </div>
+        ) : isOwnProfile ? (
+          // List view for own submissions with status
+          <div className="space-y-3">
+            {submittedModules.map((module) => (
+              <div
+                key={module.id}
+                className="flex items-start justify-between rounded-xl border border-gray-200 bg-white p-4"
+              >
+                <div className="flex-1 space-y-2">
+                  <div className="flex items-center gap-3">
+                    <Link
+                      href={`/modules/${module.slug}`}
+                      className="text-lg font-semibold text-gray-900 hover:text-blue-600"
+                    >
+                      {module.name}
+                    </Link>
+                    <span
+                      className={`rounded-full border px-2 py-0.5 text-xs font-medium ${
+                        statusStyles[module.status]
+                      }`}
+                    >
+                      {module.status.toLowerCase()}
+                    </span>
+                  </div>
+                  <p className="text-sm text-gray-600 line-clamp-2">
+                    {module.description}
+                  </p>
+                  <div className="flex items-center gap-4 text-xs text-gray-500">
+                    <span>{module.category.name}</span>
+                    <span>{module.voteCount} votes</span>
+                    <span>
+                      {new Date(module.createdAt).toLocaleDateString()}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          // Grid view for others' approved modules
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {submittedModules.map((module) => (
+              <ModuleCard
+                key={module.id}
+                module={module}
+                hasVoted={currentUserVotedIds.has(module.id)}
+                fromProfile={true}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Voted Modules */}
+      <div className="space-y-4">
+        <h2 className="text-xl font-semibold text-gray-900">
+          Voted Modules ({votedModules.length})
+        </h2>
+
+        {votedModules.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-gray-300 p-8 text-center">
+            <p className="text-gray-500">No modules voted yet.</p>
+          </div>
+        ) : (
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {votedModules.map((module) => (
+              <ModuleCard
+                key={module.id}
+                module={module}
+                hasVoted={currentUserVotedIds.has(module.id)}
+                fromProfile={true}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { db } from "@/lib/db";
 import { auth } from "@/lib/auth";
 import { ModuleCard } from "@/components/module-card";
+import { BackButton } from "@/components/back-button";
 
 const statusStyles: Record<string, string> = {
   PENDING: "bg-yellow-50 text-yellow-700 border-yellow-200",
@@ -99,9 +100,7 @@ export default async function UserProfilePage({ params }: Props) {
 
   return (
     <div className="mx-auto max-w-4xl space-y-8">
-      <Link href="/" className="text-sm text-gray-400 hover:text-gray-600">
-        ← Back to modules
-      </Link>
+      <BackButton fallbackUrl="/">← Back</BackButton>
 
       {/* User Profile Header */}
       <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
@@ -240,6 +239,7 @@ export default async function UserProfilePage({ params }: Props) {
                 module={module}
                 hasVoted={currentUserVotedIds.has(module.id)}
                 fromProfile={true}
+                profileId={id}
               />
             ))}
           </div>
@@ -264,6 +264,7 @@ export default async function UserProfilePage({ params }: Props) {
                 module={module}
                 hasVoted={currentUserVotedIds.has(module.id)}
                 fromProfile={true}
+                profileId={id}
               />
             ))}
           </div>

--- a/src/components/back-button.tsx
+++ b/src/components/back-button.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+interface BackButtonProps {
+  fallbackUrl?: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function BackButton({
+  fallbackUrl = "/",
+  children,
+  className = "text-sm text-gray-400 hover:text-gray-600",
+}: BackButtonProps) {
+  const router = useRouter();
+
+  const handleBack = () => {
+    // Try to go back in history, fallback to provided URL if can't
+    if (window.history.length > 1) {
+      router.back();
+    } else {
+      router.push(fallbackUrl);
+    }
+  };
+
+  return (
+    <button onClick={handleBack} className={className}>
+      {children}
+    </button>
+  );
+}

--- a/src/components/module-card.tsx
+++ b/src/components/module-card.tsx
@@ -5,14 +5,19 @@ import type { Module } from "@/types";
 interface ModuleCardProps {
   module: Module;
   hasVoted?: boolean;
+  fromProfile?: boolean;
 }
 
-export function ModuleCard({ module, hasVoted = false }: ModuleCardProps) {
+export function ModuleCard({
+  module,
+  hasVoted = false,
+  fromProfile = false,
+}: ModuleCardProps) {
   return (
     <article className="flex flex-col gap-3 rounded-xl border border-gray-200 bg-white p-5 shadow-sm transition-shadow hover:shadow-md">
       <div className="flex items-start justify-between gap-2">
         <Link
-          href={`/modules/${module.slug}`}
+          href={`/modules/${module.slug}${fromProfile ? "?from=profile" : ""}`}
           className="text-base font-semibold text-gray-900 hover:text-blue-600 hover:underline"
         >
           {module.name}
@@ -43,13 +48,42 @@ export function ModuleCard({ module, hasVoted = false }: ModuleCardProps) {
           initialCount={module.voteCount}
         />
       </div>
+
+      {/* Author info with link to profile */}
+      <div className="flex items-center gap-2 pt-2 border-t border-gray-100">
+        <Link
+          href={`/users/${module.author.id}`}
+          className="flex items-center gap-2 text-xs text-gray-500 hover:text-gray-700"
+        >
+          {module.author.image ? (
+            <img
+              src={module.author.image}
+              alt={module.author.name || "Author"}
+              className="h-4 w-4 rounded-full object-cover"
+            />
+          ) : (
+            <div className="flex h-4 w-4 items-center justify-center rounded-full bg-gray-200 text-xs font-medium text-gray-600">
+              {(module.author.name || "?").charAt(0).toUpperCase()}
+            </div>
+          )}
+          <span>{module.author.name}</span>
+        </Link>
+      </div>
     </article>
   );
 }
 
 function ExternalLinkIcon() {
   return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 14 14"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      aria-hidden="true"
+    >
       <path d="M5 2H2a1 1 0 0 0-1 1v9a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1V9" />
       <path d="M8 1h5v5" />
       <path d="M13 1 7 7" />

--- a/src/components/module-card.tsx
+++ b/src/components/module-card.tsx
@@ -6,18 +6,30 @@ interface ModuleCardProps {
   module: Module;
   hasVoted?: boolean;
   fromProfile?: boolean;
+  profileId?: string;
 }
 
 export function ModuleCard({
   module,
   hasVoted = false,
   fromProfile = false,
+  profileId,
 }: ModuleCardProps) {
+  const queryParams = new URLSearchParams();
+  if (fromProfile) {
+    queryParams.set("from", "profile");
+    if (profileId) {
+      queryParams.set("profileId", profileId);
+    }
+  }
+
+  const moduleUrl = `/modules/${module.slug}${queryParams.toString() ? `?${queryParams.toString()}` : ""}`;
+
   return (
     <article className="flex flex-col gap-3 rounded-xl border border-gray-200 bg-white p-5 shadow-sm transition-shadow hover:shadow-md">
       <div className="flex items-start justify-between gap-2">
         <Link
-          href={`/modules/${module.slug}${fromProfile ? "?from=profile" : ""}`}
+          href={moduleUrl}
           className="text-base font-semibold text-gray-900 hover:text-blue-600 hover:underline"
         >
           {module.name}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -16,14 +16,17 @@ export function Navbar() {
         <div className="flex items-center gap-4">
           {session ? (
             <>
-              <Link href="/submit" className="text-sm text-gray-600 hover:text-gray-900">
+              <Link
+                href="/submit"
+                className="text-sm text-gray-600 hover:text-gray-900"
+              >
                 Submit Module
               </Link>
-              <Link href="/my-submissions" className="text-sm text-gray-600 hover:text-gray-900">
-                My Submissions
-              </Link>
               {session.user.isAdmin && (
-                <Link href="/admin" className="text-sm font-medium text-orange-600 hover:text-orange-700">
+                <Link
+                  href="/admin"
+                  className="text-sm font-medium text-orange-600 hover:text-orange-700"
+                >
                   Admin
                 </Link>
               )}
@@ -33,7 +36,12 @@ export function Navbar() {
               >
                 Sign out
               </button>
-              <span className="text-sm text-gray-700">{session.user.name}</span>
+              <Link
+                href={`/users/${session.user.id}`}
+                className="text-sm text-gray-700 hover:text-gray-900"
+              >
+                {session.user.name}
+              </Link>
             </>
           ) : (
             <button


### PR DESCRIPTION
## Mục tiêu
Hiện tại dự án đã có trang `my-submissions`, tuy nhiên chưa xem lại được submissions chi tiết và chưa có một trang profile tổng thể để:
- xem toàn bộ hoạt động của user 
- truy cập profile của user khác
PR này nhằm bổ sung trang profile cho user để cải thiện trải nghiệm và tăng tính cộng đồng.

---

## Cách triển khai

### 1. Trang profile user
- Tạo route động `/users/[id]`
- Hiển thị thông tin user và các thống kê cơ bản:
  - số module đã submit
  - số vote đã thực hiện
  - số vote nhận được

### 2. Dữ liệu hiển thị
- Tái sử dụng dữ liệu từ `my-submissions`
- Bổ sung thêm:
  - danh sách modules đã vote

### 3. Link tới profile
- Cập nhật navbar: tên user trở thành link tới trang profile
- Cải thiện UX với hover state

---

## Cách kiểm thử

- Truy cập `/users/[id]`:
  - hiển thị đúng thông tin user
- Truy cập `/users/[invalid-id]`:
  - hiển thị trạng thái lỗi phù hợp
- Click tên user trên navbar:
  - điều hướng tới profile cá nhân
- Kiểm tra dữ liệu:
  - danh sách module submit đúng (consistent với my-submissions)
  - danh sách module vote đúng
  - thống kê khớp với dữ liệu

---

## Sử dụng AI

Trong quá trình thực hiện, tôi đã sử dụng các công cụ AI như GitHub Copilot (tích hợp trong VSCode) và AI code assistant để:

- hỗ trợ viết nhanh các đoạn boilerplate component và UI
- gợi ý cấu trúc route và component cho trang profile
- kiểm tra và tham khảo cách viết truy vấn dữ liệu

Tôi chủ động kiểm tra, điều chỉnh và đảm bảo toàn bộ logic phù hợp với codebase hiện tại. Tất cả code đều được hiểu rõ và kiểm thử thủ công trước khi hoàn thiện.

---