### PR TITLE
Feat/add cursor based pagination to module listing

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@ import { auth } from "@/lib/auth";
 import { ModuleCard } from "@/components/module-card";
 import { CategoryFilter } from "@/components/category-filter";
 import { Suspense } from "react";
+import { ModuleList } from "@/components/module-list";
 
 // TODO [medium-challenge]: Add category filter with URL query params (state persists on refresh)
 // See: ISSUES.md for full acceptance criteria
@@ -12,8 +13,10 @@ export default async function HomePage({
 }: {
   searchParams: Promise<{ q?: string; category?: string }>;
 }) {
-  const { q, category } = await searchParams;
+  const params = await searchParams;
+  const { q, category } = params;
   const session = await auth();
+  const LIMIT = 12;
 
   const modules = await db.miniApp.findMany({
     where: {
@@ -34,7 +37,7 @@ export default async function HomePage({
       author: { select: { id: true, name: true, image: true } },
     },
     orderBy: { voteCount: "desc" },
-    take: 12,
+    take: LIMIT,
   });
 
   // Fetch which modules the current user has voted on
@@ -49,6 +52,9 @@ export default async function HomePage({
     });
     votedIds = new Set(votes.map((v) => v.moduleId));
   }
+
+  // Identify the initial cursor (which is the ID of the last element if there are 12).
+  const initialCursor = modules.length === LIMIT ? modules[modules.length - 1].id : null;
 
   const categories = await db.category.findMany({ orderBy: { name: "asc" } });
 
@@ -93,15 +99,12 @@ export default async function HomePage({
           )}
         </div>
       ) : (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {modules.map((module) => (
-            <ModuleCard
-              key={module.id}
-              module={module}
-              hasVoted={votedIds.has(module.id)}
-            />
-          ))}
-        </div>
+        <ModuleList 
+          initialModules={modules as any} 
+          initialCursor={initialCursor}
+          votedIds={votedIds}
+          searchParams={params}
+        />
       )}
     </div>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,8 @@
 import { db } from "@/lib/db";
 import { auth } from "@/lib/auth";
 import { ModuleCard } from "@/components/module-card";
+import { CategoryFilter } from "@/components/category-filter";
+import { Suspense } from "react";
 
 // TODO [medium-challenge]: Add category filter with URL query params (state persists on refresh)
 // See: ISSUES.md for full acceptance criteria
@@ -76,32 +78,10 @@ export default async function HomePage({
         </form>
       </div>
 
-      {/* Category filter placeholder — see TODO above */}
-      <div className="flex flex-wrap gap-2">
-        <a
-          href="/"
-          className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
-            !category
-              ? "bg-blue-600 text-white"
-              : "bg-gray-100 text-gray-600 hover:bg-gray-200"
-          }`}
-        >
-          All
-        </a>
-        {categories.map((c) => (
-          <a
-            key={c.id}
-            href={`/?category=${c.slug}`}
-            className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
-              category === c.slug
-                ? "bg-blue-600 text-white"
-                : "bg-gray-100 text-gray-600 hover:bg-gray-200"
-            }`}
-          >
-            {c.name}
-          </a>
-        ))}
-      </div>
+      {/* Category filter optimization */}
+      <Suspense fallback={<div className="h-8 animate-pulse bg-gray-100 rounded-full w-full" />}>
+        <CategoryFilter categories={categories} activeCategory={category} />
+      </Suspense>
 
       {modules.length === 0 ? (
         <div className="rounded-xl border border-dashed border-gray-300 p-12 text-center">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -55,6 +55,7 @@ export default async function HomePage({
 
   // Identify the initial cursor (which is the ID of the last element if there are 12).
   const initialCursor = modules.length === LIMIT ? modules[modules.length - 1].id : null;
+  const filterKey = `${category || 'all'}-${q || ''}`;
 
   const categories = await db.category.findMany({ orderBy: { name: "asc" } });
 
@@ -100,6 +101,7 @@ export default async function HomePage({
         </div>
       ) : (
         <ModuleList 
+          key={filterKey}
           initialModules={modules as any} 
           initialCursor={initialCursor}
           votedIds={votedIds}

--- a/src/components/category-filter.tsx
+++ b/src/components/category-filter.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { Category } from "@prisma/client";
+
+interface CategoryFilterProps {
+  categories: Category[];
+  activeCategory?: string;
+}
+
+export function CategoryFilter({ categories, activeCategory }: CategoryFilterProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const handleFilter = (slug?: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+
+    if (slug) {
+      params.set("category", slug);
+    } else {
+      // Select All
+      params.delete("category");
+    }
+
+    router.push(`/?${params.toString()}`, { scroll: false });
+  };
+
+  return (
+    <div className="flex flex-wrap gap-2 cursor-pointer">
+      <button
+        onClick={() => handleFilter()}
+        className={`rounded-full px-3 py-1 text-xs font-medium transition-colors cursor-pointer ${
+          !activeCategory
+            ? "bg-blue-600 text-white"
+            : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+        }`}
+      >
+        All
+      </button>
+      {categories.map((c) => (
+        <button
+          key={c.id}
+          onClick={() => handleFilter(c.slug)}
+          className={`rounded-full px-3 py-1 text-xs font-medium transition-colors cursor-pointer ${
+            activeCategory === c.slug
+              ? "bg-blue-600 text-white"
+              : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+          }`}
+        >
+          {c.name}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/module-list.tsx
+++ b/src/components/module-list.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useState } from "react";
+import { ModuleCard } from "./module-card";
+import { MiniApp, Category } from "@prisma/client";
+
+type ExtendedModule = MiniApp & {
+  category: Category;
+  author: { id: string; name: string | null; image: string | null };
+};
+
+interface ModuleListProps {
+  initialModules: ExtendedModule[];
+  initialCursor: string | null;
+  votedIds: Set<string>;
+  searchParams: { q?: string; category?: string };
+}
+
+export function ModuleList({ initialModules, initialCursor, votedIds, searchParams }: ModuleListProps) {
+  const [modules, setModules] = useState<ExtendedModule[]>(initialModules);
+  const [cursor, setCursor] = useState<string | null>(initialCursor);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const loadMore = async () => {
+    if (isLoading || !cursor) return;
+    setIsLoading(true);
+
+    try {
+      const params = new URLSearchParams({
+        cursor,
+        limit: "12",
+        ...(searchParams.q && { q: searchParams.q }),
+        ...(searchParams.category && { category: searchParams.category }),
+      });
+
+      const res = await fetch(`/api/modules?${params.toString()}`);
+      if (!res.ok) throw new Error("Failed to fetch");
+      
+      const json = await res.json();
+      
+      // Check before append new module to list
+      if (json.items && Array.isArray(json.items)) {
+        setModules((prev) => [...prev, ...json.items]);
+      }
+
+      setCursor(json.nextCursor || null);
+    } catch (error) {
+      console.error("Error loading more modules:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-8">
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {modules.map((module) => (
+          <ModuleCard
+            key={module.id}
+            module={module}
+            hasVoted={votedIds.has(module.id)}
+          />
+        ))}
+      </div>
+
+      {cursor && (
+        <div className="flex justify-center pt-4">
+          <button
+            onClick={loadMore}
+            disabled={isLoading}
+            className="rounded-lg border border-gray-300 px-6 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 flex items-center gap-2"
+          >
+            {isLoading ? (
+              <>
+                <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-blue-600" />
+                Loading...
+              </>
+            ) : (
+              "Load more"
+            )}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## What does this PR do?

This PR replaces the static 12-module limit with a dynamic Cursor-based Pagination system. It allows users to load more modules incrementally via a "Load more" button, improving performance and preventing the issue of duplicate items that often occurs with traditional offset pagination when new data is inserted.

## Related Issue

Closes #232 

## How to test

1. Initial Load: Navigate to the home page; it should load the first batch of modules (e.g., 3 or 12 depending on the limit).
2. Pagination: Scroll to the bottom and click "Load more". Verify that additional modules are appended to the grid without a full page refresh.
3. End State: Continue loading until no more modules are available; verify that the "Load more" button disappears when nextCursor is null.
4. Filtered Pagination: Apply a search or category filter, then click "Load more". Ensure the appended modules still respect the active filters.

## Screenshots / recordings (if UI change)
Limit 3 to test
<img width="1365" height="767" alt="image" src="https://github.com/user-attachments/assets/d8dc3a18-eff2-4dbd-b876-4c51c67f1212" />
And load more
<img width="1365" height="767" alt="image" src="https://github.com/user-attachments/assets/7f291f9a-8ada-4e5f-a141-1fe5613bb425" />

## Checklist

- [x] I read the relevant code **before** writing my own
- [x] My code follows the existing patterns in the codebase
- [x] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
- [x] I added or updated tests where applicable
- [x] I can explain every line of code I wrote (reviewer will ask)
- [x] I kept the PR focused — no unrelated changes

## Notes for reviewer
+ API Discovery: During implementation, I identified that the API returns data in an { items: [], nextCursor: string } structure rather than a generic { data: [] }. I've updated the client-side fetching logic to correctly map these items.
+ Hybrid Pattern: I maintained the initial server-side render for the first batch of modules (SEO-friendly) and transitioned to client-side state management for subsequent "Load more" requests.
+ State Reset: To ensure data consistency, I implemented a key prop on the ModuleList component. This forces a clean state reset whenever filters (Category/Search) change, preventing old "Load more" data from leaking into new search results.
+ Scalability: Cursor-based pagination was chosen over OFFSET to ensure stable performance as the database grows, as it avoids the $O(n)$ cost of skipping rows in PostgreSQL.