### PR TITLE
feat: add cursor-based pagination with Load More button

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -32,11 +32,11 @@ export default async function HomePage({
       author: { select: { id: true, name: true, image: true } },
     },
     orderBy: { voteCount: "desc" },
-    take: 3,
+    take: 13,
   });
 
-  const hasMore = modules.length > 2;
-  const items = hasMore ? modules.slice(0, 2) : modules;
+  const hasMore = modules.length > 12;
+  const items = hasMore ? modules.slice(0, 12) : modules;
   const nextCursor = hasMore ? items[items.length - 1].id : null;
 
   // Fetch which modules the current user has voted on

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 import { db } from "@/lib/db";
 import { auth } from "@/lib/auth";
-import { ModuleCard } from "@/components/module-card";
+import { ModuleListWithPagination } from "@/components/module-list-with-pagination";
 
 // TODO [medium-challenge]: Add category filter with URL query params (state persists on refresh)
 // See: ISSUES.md for full acceptance criteria
@@ -32,8 +32,12 @@ export default async function HomePage({
       author: { select: { id: true, name: true, image: true } },
     },
     orderBy: { voteCount: "desc" },
-    take: 12,
+    take: 3,
   });
+
+  const hasMore = modules.length > 2;
+  const items = hasMore ? modules.slice(0, 2) : modules;
+  const nextCursor = hasMore ? items[items.length - 1].id : null;
 
   // Fetch which modules the current user has voted on
   let votedIds = new Set<string>();
@@ -41,7 +45,7 @@ export default async function HomePage({
     const votes = await db.vote.findMany({
       where: {
         userId: session.user.id,
-        moduleId: { in: modules.map((m) => m.id) },
+        moduleId: { in: items.map((m) => m.id) },
       },
       select: { moduleId: true },
     });
@@ -113,15 +117,13 @@ export default async function HomePage({
           )}
         </div>
       ) : (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {modules.map((module) => (
-            <ModuleCard
-              key={module.id}
-              module={module}
-              hasVoted={votedIds.has(module.id)}
-            />
-          ))}
-        </div>
+        <ModuleListWithPagination
+          initialModules={items}
+          initialVotedIds={Array.from(votedIds)}
+          initialNextCursor={nextCursor}
+          searchQuery={q}
+          categorySlug={category}
+        />
       )}
     </div>
   );

--- a/src/components/module-list-with-pagination.tsx
+++ b/src/components/module-list-with-pagination.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import Link from "next/link";
+import { ModuleCard } from "@/components/module-card";
+import type { Module } from "@/types";
+
+interface ModuleListWithPaginationProps {
+  initialModules: Module[];
+  initialVotedIds: string[];
+  initialNextCursor: string | null;
+  searchQuery?: string;
+  categorySlug?: string;
+}
+
+export function ModuleListWithPagination({
+  initialModules,
+  initialVotedIds,
+  initialNextCursor,
+  searchQuery,
+  categorySlug,
+}: ModuleListWithPaginationProps) {
+  const [modules, setModules] = useState<Module[]>(initialModules);
+  const [votedIds] = useState<Set<string>>(
+    () => new Set(initialVotedIds)
+  );
+  const [nextCursor, setNextCursor] = useState<string | null>(
+    initialNextCursor
+  );
+  const [isLoading, setIsLoading] = useState(false);
+
+  const loadMore = useCallback(async () => {
+    if (!nextCursor || isLoading) return;
+
+    setIsLoading(true);
+    try {
+      const params = new URLSearchParams();
+      params.set("cursor", nextCursor);
+      if (searchQuery) params.set("q", searchQuery);
+      if (categorySlug) params.set("category", categorySlug);
+
+      const res = await fetch(`/api/modules?${params.toString()}`);
+      if (!res.ok) throw new Error("Failed to fetch modules");
+
+      const data: { items: Module[]; nextCursor: string | null } =
+        await res.json();
+
+      setModules((prev) => [...prev, ...data.items]);
+      setNextCursor(data.nextCursor);
+    } catch {
+      // Silently fail — user can retry by clicking again
+    } finally {
+      setIsLoading(false);
+    }
+  }, [nextCursor, isLoading, searchQuery, categorySlug]);
+
+  if (modules.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed border-gray-300 p-12 text-center">
+        <p className="text-gray-500">No modules found.</p>
+        {searchQuery && (
+          <Link
+            href="/"
+            className="mt-2 block text-sm text-blue-600 hover:underline"
+          >
+            Clear search
+          </Link>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {modules.map((module) => (
+          <ModuleCard
+            key={module.id}
+            module={module}
+            hasVoted={votedIds.has(module.id)}
+          />
+        ))}
+      </div>
+
+      {nextCursor && (
+        <div className="flex justify-center">
+          <button
+            onClick={loadMore}
+            disabled={isLoading}
+            className="rounded-lg border border-gray-300 bg-white px-6 py-2.5 text-sm font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isLoading ? (
+              <span className="flex items-center gap-2">
+                <LoadingSpinner />
+                Loading…
+              </span>
+            ) : (
+              "Load more"
+            )}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function LoadingSpinner() {
+  return (
+    <svg
+      className="h-4 w-4 animate-spin text-gray-500"
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+    >
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+      />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION

## What does this PR do?

Adds cursor-based pagination to the module listing on the home page. Previously, only the first 12 approved modules were displayed with no way to browse beyond that. Now a "Load more" button appears when there are additional modules, fetching the next batch using the existing `nextCursor` API contract and appending them to the list without a full page reload.

## Related Issue

Closes #155

## How to test

1. Run `pnpm db:seed` (ensure there are more than 12 approved modules, or temporarily change `take` from `13` to a smaller number like `3` in page.tsx for testing with seed data)
2. Run `pnpm dev` and open http://localhost:3000
3. Verify the "Load more" button appears at the bottom of the module grid when there are more results
4. Click "Load more" — new modules should append below existing ones
5. Verify a loading spinner appears while fetching
6. Verify the button disappears when all modules have been loaded
7. Test with search query (`?q=...`) — pagination should still work
8. Test with category filter (`?category=game`) — pagination should still work
9. Run `pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm build` — all pass

## Screenshots

Initial state with Load more button visible
<img width="971" height="867" alt="image" src="https://github.com/user-attachments/assets/2141f1bc-3338-40ad-81c0-80b1ab752f98" />


After clicking Load more, additional modules are appended without a full page reload
<img width="831" height="873" alt="image" src="https://github.com/user-attachments/assets/bde58bf8-36e6-4e63-a3a1-f1a25ba84582" />

Test with search query (`?q=...`) — pagination should still work
<img width="1379" height="430" alt="image" src="https://github.com/user-attachments/assets/2bc1c14c-0605-4574-88b8-414de7cc5f74" />

Test with category filter (`?category=game`) — pagination should still work
<img width="1431" height="425" alt="image" src="https://github.com/user-attachments/assets/742d2826-1397-4e0e-a757-e166134120a6" />

<img width="1390" height="427" alt="image" src="https://github.com/user-attachments/assets/7edfdf2e-9979-4d00-8e09-42c5944b13d2" />







## Checklist

- [x] I read the relevant code **before** writing my own
- [x] My code follows the existing patterns in the codebase
- [x] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
- [x] I added or updated tests where applicable
- [x] I can explain every line of code I wrote (reviewer will ask)
- [x] I kept the PR focused — no unrelated changes

## Notes for reviewer

**Approach:** The home page (page.tsx) is a Server Component that fetches the initial batch of 12 modules — I kept it that way and added the `take: 13` trick (fetch limit+1 to detect if there's a next page) matching the same pattern already used in `GET /api/modules` route. The new `ModuleListWithPagination` client component receives initial server-rendered data and handles subsequent fetches client-side.

**Design decisions:**
- Reused the existing `/api/modules?cursor=` API contract — no backend changes needed
- The `take: limit + 1` pattern in the server query mirrors the API route's approach for consistency
- Search query and category slug are passed as props to the client component so they're included in subsequent fetch requests
- Used `useCallback` to memoize the `loadMore` function and prevent unnecessary re-renders
- Loading state disables the button and shows a spinner to prevent double-clicks

**AI usage:** I used GitHub Copilot (Claude) to analyze the existing codebase structure, understand the API contract in `/api/modules/route.ts`, and assist with implementing the client component. All code was reviewed and verified manually — I can explain every line.

**Trade-off:** The newly fetched modules via "Load more" do not include the user's vote state (`hasVoted`). This is because the `/api/modules` endpoint does not return per-user vote info. A future improvement could add vote state to the API response for authenticated users.
