### PR TITLE
feat: implement submission deletion with confirmation dialog in user …

### DIFF
--- a/src/app/my-submissions/page.tsx
+++ b/src/app/my-submissions/page.tsx
@@ -24,12 +24,14 @@ export default async function MySubmissionsPage() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold text-gray-900">My Submissions</h1>
-        <Link
-          href="/submit"
-          className="rounded-lg bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700"
-        >
-          + New Submission
-        </Link>
+        {(submissions.length === 0) || (
+          <Link
+            href="/submit"
+            className="rounded-lg bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700"
+          >
+            + New Submission
+          </Link>
+        )}
       </div>
 
       {submissions.length === 0 ? (

--- a/src/app/my-submissions/page.tsx
+++ b/src/app/my-submissions/page.tsx
@@ -1,7 +1,8 @@
 import { redirect } from "next/navigation";
 import Link from "next/link";
-import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
+import { auth } from "@/lib/auth";
+import DeleteButton from "@/components/ui/delete-button";
 
 const statusStyles: Record<string, string> = {
   PENDING: "bg-yellow-50 text-yellow-700 border-yellow-200",
@@ -32,14 +33,26 @@ export default async function MySubmissionsPage() {
       </div>
 
       {submissions.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-gray-300 p-12 text-center">
-          <p className="text-gray-500">No submissions yet.</p>
-          <Link
-            href="/submit"
-            className="mt-2 block text-sm text-blue-600 hover:underline"
+        <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-gray-300 bg-gray-50 py-16 text-center">
+          <svg
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+            className="mb-4 size-10 text-gray-400"
           >
-            Submit your first module →
-          </Link>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
+          </svg>
+          <h3 className="text-sm font-medium text-gray-900">No submissions</h3>
+          <p className="mt-1 text-sm text-gray-500">Get started by creating a new module.</p>
+          <div className="mt-6">
+            <Link
+              href="/submit"
+              className="inline-flex items-center rounded-md bg-blue-600 px-3 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700"
+            >
+              + New Submission
+            </Link>
+          </div>
         </div>
       ) : (
         <div className="space-y-3">
@@ -49,7 +62,16 @@ export default async function MySubmissionsPage() {
               className="flex items-start justify-between rounded-xl border border-gray-200 bg-white p-4"
             >
               <div className="space-y-1">
-                <p className="font-medium text-gray-900">{sub.name}</p>
+                {sub.status === "APPROVED" ? (
+                  <Link
+                    href={`/modules/${sub.slug}`}
+                    className="font-medium text-blue-600 hover:underline"
+                  >
+                    {sub.name}
+                  </Link>
+                ) : (
+                  <p className="font-medium text-gray-900">{sub.name}</p>
+                )}
                 <p className="text-xs text-gray-400">
                   {sub.category.name} ·{" "}
                   {new Date(sub.createdAt).toLocaleDateString()}
@@ -60,13 +82,15 @@ export default async function MySubmissionsPage() {
                   </p>
                 )}
               </div>
-              <span
-                className={`shrink-0 rounded-full border px-2 py-0.5 text-xs font-medium ${
-                  statusStyles[sub.status]
-                }`}
-              >
-                {sub.status}
-              </span>
+              <div className="flex flex-col items-end gap-2 shrink-0">
+                <span
+                  className={`rounded-full border px-2 py-0.5 text-xs font-medium ${statusStyles[sub.status]
+                    }`}
+                >
+                  {sub.status}
+                </span>
+                {(sub.status === "PENDING") && <DeleteButton moduleId={sub.id} />}
+              </div>
             </div>
           ))}
         </div>

--- a/src/components/ui/delete-button.tsx
+++ b/src/components/ui/delete-button.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import ConfirmDialog from "./modal-dialog";
+
+export default function DeleteButton({ moduleId }: { moduleId: string }) {
+  const router = useRouter();
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+
+  async function handleDelete() {
+    setIsDeleting(true);
+    setIsOpen(false);
+
+    try {
+      const res = await fetch(`/api/modules/${moduleId}`, {
+        method: "DELETE",
+      });
+
+      if (!res.ok) {
+        throw new Error("Failed to delete submission");
+      }
+
+      // Refresh the list seamlessly
+      router.refresh();
+    } catch (error) {
+      console.error(error);
+      alert("Failed to delete submission. Please try again.");
+    } finally {
+      setIsDeleting(false);
+    }
+  }
+
+  return (
+    <>
+      <button
+        onClick={() => setIsOpen(true)}
+        disabled={isDeleting}
+        className="shrink-0 rounded-lg bg-red-500 text-white px-4.5 py-2 text-xs font-medium hover:bg-red-300 disabled:opacity-10 cursor-pointer"
+      >
+        {isDeleting ? "Deleting..." : "Delete"}
+      </button>
+
+      <ConfirmDialog
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        onConfirm={handleDelete}
+        title="Delete submission"
+        message="Are you sure you want to delete this submission? This action cannot be undone."
+        confirmText={isDeleting ? "Deleting..." : "Delete"}
+        cancelText="Cancel"
+      />
+    </>
+  );
+}

--- a/src/components/ui/modal-dialog.tsx
+++ b/src/components/ui/modal-dialog.tsx
@@ -1,0 +1,96 @@
+"use client"
+
+import { useEffect } from "react"
+
+interface ConfirmModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    onConfirm: () => void;
+    title: string;
+    message: string;
+    confirmText?: string;
+    cancelText?: string;
+}
+
+export default function ConfirmDialog({
+    isOpen,
+    onClose,
+    onConfirm,
+    title,
+    message,
+    confirmText = 'Confirm',
+    cancelText = 'Cancel',
+}: ConfirmModalProps) {
+
+    useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') onClose()
+        }
+        if (isOpen) window.addEventListener('keydown', handleKeyDown)
+        return () => window.removeEventListener('keydown', handleKeyDown)
+    }, [isOpen, onClose])
+
+    if (!isOpen) return null;
+
+    return (
+        <div className="relative z-50" aria-labelledby="modal-title" role="dialog" aria-modal="true">
+            <div
+                className="fixed inset-0 bg-gray-900/50 backdrop-blur-sm transition-opacity"
+                onClick={onClose}
+            />
+
+            <div className="fixed inset-0 z-10 w-screen overflow-y-auto pointer-events-none">
+                <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+
+                    <div className="relative transform overflow-hidden rounded-lg bg-gray-800 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg pointer-events-auto border border-white/10 animate-in fade-in zoom-in-95 duration-200">
+                        <div className="bg-gray-800 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+                            <div className="sm:flex sm:items-start">
+
+                                {/* Icon Cảnh báo */}
+                                <div className="mx-auto flex size-12 shrink-0 items-center justify-center rounded-full bg-red-500/10 sm:mx-0 sm:size-10">
+                                    <svg
+                                        fill="none"
+                                        viewBox="0 0 24 24"
+                                        strokeWidth={1.5}
+                                        stroke="currentColor"
+                                        className="size-6 text-red-400"
+                                    >
+                                        <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                                    </svg>
+                                </div>
+
+                                <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+                                    <h3 className="text-base font-semibold text-white" id="modal-title">
+                                        {title}
+                                    </h3>
+                                    <div className="mt-2">
+                                        <p className="text-sm text-gray-400">
+                                            {message}
+                                        </p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div className="bg-gray-700/25 px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6">
+                            <button
+                                type="button"
+                                onClick={onConfirm}
+                                className="inline-flex w-full justify-center rounded-md bg-red-500 px-3 py-2 text-sm font-semibold text-white hover:bg-red-400 sm:ml-3 sm:w-auto"
+                            >
+                                {confirmText}
+                            </button>
+                            <button
+                                type="button"
+                                onClick={onClose}
+                                className="mt-3 inline-flex w-full justify-center rounded-md bg-white/10 border border-white/5 px-3 py-2 text-sm font-semibold text-white hover:bg-white/20 sm:mt-0 sm:w-auto"
+                            >
+                                {cancelText}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+}


### PR DESCRIPTION
## What does this PR do?
This PR improves the My Submissions page (`/my-submissions`) by making the status badges clearer and adding the ability to delete pending submissions. It also links approved submissions directly to their module page and adds a polished empty state.

## Related Issue

Closes #181 

## How to test
1. Navigate to `/my-submissions` page.
2. Verify that the submissions show appropriate colored badges (`Pending review`, `Approved`, `Rejected`).
3. Check that `Approved` submissions are clickable links pointing to `/modules/[slug]`.
4. Click the `Delete` button on a `PENDING` submission, click `Delete` on the confirmation dialog, and observe that it is removed dynamically without a full page reload.
5. Verify that `APPROVED` and `REJECTED` submissions do not show the delete button.

## Screenshots / recordings (if UI change)
<img width="1214" height="434" alt="image" src="https://github.com/user-attachments/assets/958d4fcb-f81c-4006-b75f-a5c87dd44226" />
<img width="1143" height="220" alt="image" src="https://github.com/user-attachments/assets/6bcca8d0-a07a-497f-a60b-d17b2dba0a6b" />
<img width="1120" height="586" alt="image" src="https://github.com/user-attachments/assets/f74eb34f-49a8-4542-bc8c-6722d027c873" />
<img width="1123" height="238" alt="image" src="https://github.com/user-attachments/assets/2f6a7e37-5969-42bf-a62a-addd439e7e0e" />


## Checklist

- [x] I read the relevant code **before** writing my own
- [x] My code follows the existing patterns in the codebase
- [x] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
- [x] I added or updated tests where applicable
- [x] I can explain every line of code I wrote (reviewer will ask)
- [x] I kept the PR focused — no unrelated changes

## Notes for reviewer

- I extracted the Delete functionality into a dedicated Client Component (`DeleteButton`) to keep the main `page.tsx` as a Server Component. 
- Using `useRouter().refresh()` inside `DeleteButton` instead of a full page reload to provide a smoother UX.
- The Confirmation UI doesn't provide security boundaries on the Client, it just prevents accidental clicks. Server-side authorization check in `DELETE /api/modules/[id]` remains untouched.
