### PR TITLE
feat: add category filtering component with URL query parameter support

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { db } from "@/lib/db";
 import { auth } from "@/lib/auth";
 import { ModuleCard } from "@/components/module-card";
+import CategoryFilter from "@/components/category-filter";
 
 // TODO [medium-challenge]: Add category filter with URL query params (state persists on refresh)
 // See: ISSUES.md for full acceptance criteria
@@ -77,31 +78,7 @@ export default async function HomePage({
       </div>
 
       {/* Category filter placeholder — see TODO above */}
-      <div className="flex flex-wrap gap-2">
-        <a
-          href="/"
-          className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
-            !category
-              ? "bg-blue-600 text-white"
-              : "bg-gray-100 text-gray-600 hover:bg-gray-200"
-          }`}
-        >
-          All
-        </a>
-        {categories.map((c) => (
-          <a
-            key={c.id}
-            href={`/?category=${c.slug}`}
-            className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
-              category === c.slug
-                ? "bg-blue-600 text-white"
-                : "bg-gray-100 text-gray-600 hover:bg-gray-200"
-            }`}
-          >
-            {c.name}
-          </a>
-        ))}
-      </div>
+      <CategoryFilter selectedCategory={category} categories={categories}/>
 
       {modules.length === 0 ? (
         <div className="rounded-xl border border-dashed border-gray-300 p-12 text-center">

--- a/src/components/category-filter.tsx
+++ b/src/components/category-filter.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname, useSearchParams } from "next/navigation";
+
+export interface CategoryFilterProps {
+	categories: { id: string; name: string; slug: string }[];
+	selectedCategory?: string;
+}
+
+export default function CategoryFilter({
+	categories,
+	selectedCategory,
+}: CategoryFilterProps) {
+	const pathname = usePathname();
+	const searchParams = useSearchParams();
+
+	const buildHref = (slug?: string) => {
+		const params = new URLSearchParams(searchParams.toString());
+
+		if (
+			!slug ||
+			slug === selectedCategory // If current category is already selected, toggle them off
+		) {
+			params.delete("category");
+		} else {
+			params.set("category", slug);
+		}
+
+		const query = params.toString();
+		return query ? `${pathname}?${query}` : pathname;
+	};
+
+	return (
+		<div className="flex flex-wrap gap-2">
+			<Link
+				className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+					!selectedCategory
+					? "bg-blue-600 text-white"
+					: "bg-gray-100 text-gray-600 hover:bg-gray-200"
+				}`}
+				href={buildHref(undefined)}
+			>
+				All
+			</Link>
+			{categories.map((c) => (
+				<Link
+					key={c.id}
+					className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+						selectedCategory === c.slug
+							? "bg-blue-600 text-white"
+							: "bg-gray-100 text-gray-600 hover:bg-gray-200"
+					}`}
+					href={buildHref(c.slug)}
+				>
+					{c.name}
+				</Link>
+			))}
+		</div>
+	);
+}


### PR DESCRIPTION
## What does this PR do?

Added a client-side CategoryFilter component and integrated it into the homepage so the selected category is read from and written to the category URL query parameter. This makes category selection persist across refreshes and be bookmarkable/shareable, and it drives the server-side module query so the list shows the filtered results. A single-select approach was chosen to keep the UX simple and aligned with a browsing-focused use case, avoiding unnecessary complexity from multi-select filtering.

## Related Issue

Closes #175

## How to test

1. Start the app with pnpm dev and navigate to http://localhost:3000
2. Select any category pill — the page should update without a full reload
3. Reload the page — the previously selected category should remain applied
4. Enter a search query, then choose a category — the ?q= parameter should persist in the URL
5. Click the currently active category again — the filter should be removed
6. Navigate using the browser’s back/forward buttons — the filter state should be restored accordingly

## Screenshots / recordings (if UI change)

<video controls src="20260407-1444-04.4086040.mp4" title="Title"></video>

## Checklist

- [x] I read the relevant code **before** writing my own
- [x] My code follows the existing patterns in the codebase
- [x] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
- [x] I added or updated tests where applicable
- [x] I can explain every line of code I wrote (reviewer will ask)
- [x] I kept the PR focused — no unrelated changes

## Notes for reviewer

There are pre-existing lint errors in the codebase (related to `module` variable usage and `<a>` tags). These were not introduced in this PR. My changes do not introduce new lint issues.

## AI Usage
Used AI (Claude, Gemini, DeepSeek) as a reference tool to analyze requirements, clarify ambiguous aspects (e.g. filter behavior), explore different implementation approaches and trade-offs, and to improve clarity in documentation. All code was written, reviewed, and validated manually to ensure correctness and alignment with project requirements.