### PR TITLE
test/issue-226-add missing unit tests for generateSlug, makeUniqueSlug, and fo…

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { generateSlug, makeUniqueSlug, formatRelativeTime } from "@/lib/utils";
 
 // ============================================================
@@ -22,14 +22,21 @@ describe("generateSlug", () => {
     expect(generateSlug("a   b   c")).toBe("a-b-c");
   });
 
-  // TODO [easy-challenge]: Add test cases for the following:
-  // 1. A name that is already a valid slug (no changes needed)
-  // 2. A name with numbers (numbers should be preserved)
-  // 3. An empty string (what should the output be? Check the implementation)
-  // 4. A name with leading/trailing hyphens after special char removal
-  //
-  // Hint: read `src/lib/utils.ts` to understand the exact transformation rules
-  // before writing your assertions.
+  it("returns the same string when already a valid slug", () => {
+    expect(generateSlug("my-cool-app")).toBe("my-cool-app");
+  });
+
+  it("preserves numbers in the name", () => {
+    expect(generateSlug("App 2024 v3")).toBe("app-2024-v3");
+  });
+
+  it("returns an empty string for empty input", () => {
+    expect(generateSlug("")).toBe("");
+  });
+
+  it("strips leading and trailing hyphens after special char removal", () => {
+    expect(generateSlug("!!!hello!!!")).toBe("hello");
+  });
 });
 
 // ============================================================
@@ -49,23 +56,98 @@ describe("makeUniqueSlug", () => {
     expect(makeUniqueSlug("my-app", ["my-app", "my-app-1"])).toBe("my-app-2");
   });
 
-  // TODO [easy-challenge]: Add test cases for:
-  // 1. When many suffixed versions already exist (e.g. -1 through -5)
-  // 2. When the existing list contains similar but non-conflicting slugs
-  //    e.g. existing = ["my-app-tool"] should NOT block "my-app"
+  it("finds the next available suffix when -1 through -5 are taken", () => {
+    const existing = ["app", "app-1", "app-2", "app-3", "app-4", "app-5"];
+    expect(makeUniqueSlug("app", existing)).toBe("app-6");
+  });
+
+  it("does not treat similar but non-conflicting slugs as conflicts", () => {
+    expect(makeUniqueSlug("my-app", ["my-app-tool"])).toBe("my-app");
+  });
 });
 
 // ============================================================
 // formatRelativeTime — NOT yet tested, candidate must write all tests
 // ============================================================
 
-// TODO [easy-challenge]: Write a full test suite for `formatRelativeTime`.
-// Requirements:
-// - "just now" for dates less than 1 minute ago
-// - "{n}m ago" for dates 1–59 minutes ago
-// - "{n}h ago" for dates 1–23 hours ago
-// - "{n}d ago" for dates 1–29 days ago
-// - toLocaleDateString() format for dates 30+ days ago
-//
-// Hint: You'll need to mock or control `Date.now()` to make these tests
-// deterministic. Look into Vitest's `vi.setSystemTime()`.
+describe("formatRelativeTime", () => {
+  const NOW = new Date("2026-04-08T12:00:00Z");
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns 'just now' for 0 seconds ago", () => {
+    expect(formatRelativeTime(new Date(NOW))).toBe("just now");
+  });
+
+  it("returns 'just now' for 30 seconds ago", () => {
+    const date = new Date(NOW.getTime() - 30_000);
+    expect(formatRelativeTime(date)).toBe("just now");
+  });
+
+  it("returns 'just now' for 59 seconds ago", () => {
+    const date = new Date(NOW.getTime() - 59_000);
+    expect(formatRelativeTime(date)).toBe("just now");
+  });
+
+  it("returns '1m ago' for exactly 1 minute ago", () => {
+    const date = new Date(NOW.getTime() - 60_000);
+    expect(formatRelativeTime(date)).toBe("1m ago");
+  });
+
+  it("returns '30m ago' for 30 minutes ago", () => {
+    const date = new Date(NOW.getTime() - 30 * 60_000);
+    expect(formatRelativeTime(date)).toBe("30m ago");
+  });
+
+  it("returns '59m ago' for 59 minutes ago", () => {
+    const date = new Date(NOW.getTime() - 59 * 60_000);
+    expect(formatRelativeTime(date)).toBe("59m ago");
+  });
+
+  it("returns '1h ago' for exactly 1 hour ago", () => {
+    const date = new Date(NOW.getTime() - 60 * 60_000);
+    expect(formatRelativeTime(date)).toBe("1h ago");
+  });
+
+  it("returns '12h ago' for 12 hours ago", () => {
+    const date = new Date(NOW.getTime() - 12 * 3_600_000);
+    expect(formatRelativeTime(date)).toBe("12h ago");
+  });
+
+  it("returns '23h ago' for 23 hours ago", () => {
+    const date = new Date(NOW.getTime() - 23 * 3_600_000);
+    expect(formatRelativeTime(date)).toBe("23h ago");
+  });
+
+  it("returns '1d ago' for exactly 1 day ago", () => {
+    const date = new Date(NOW.getTime() - 24 * 3_600_000);
+    expect(formatRelativeTime(date)).toBe("1d ago");
+  });
+
+  it("returns '15d ago' for 15 days ago", () => {
+    const date = new Date(NOW.getTime() - 15 * 86_400_000);
+    expect(formatRelativeTime(date)).toBe("15d ago");
+  });
+
+  it("returns '29d ago' for 29 days ago", () => {
+    const date = new Date(NOW.getTime() - 29 * 86_400_000);
+    expect(formatRelativeTime(date)).toBe("29d ago");
+  });
+
+  it("returns toLocaleDateString() for exactly 30 days ago", () => {
+    const date = new Date(NOW.getTime() - 30 * 86_400_000);
+    expect(formatRelativeTime(date)).toBe(date.toLocaleDateString());
+  });
+
+  it("returns toLocaleDateString() for dates older than 30 days", () => {
+    const date = new Date(NOW.getTime() - 365 * 86_400_000);
+    expect(formatRelativeTime(date)).toBe(date.toLocaleDateString());
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fill all `// TODO [easy-challenge]` test cases in `__tests__/utils.test.ts`:
- `generateSlug`: 4 new edge cases (valid slug, numbers, empty string, leading/trailing hyphens)
- `makeUniqueSlug`: 2 new edge cases (many existing suffixes -1 through -5, non-conflicting similar slugs)
- `formatRelativeTime`: complete test suite — 14 cases covering all time boundaries

## Related Issue

Closes #226

## How I implemented it

1. Read `src/lib/utils.ts` to understand the exact logic of each function before writing any test
2. For `generateSlug`: traced the 4-step regex chain (`toLowerCase` → strip non-alphanumeric → spaces to hyphens → collapse → trim hyphens) to derive expected outputs for each edge case
3. For `makeUniqueSlug`: tested the `while` loop behavior when many suffixes exist, and verified `Array.includes()` does exact match (so `"my-app-tool"` doesn't block `"my-app"`)
4. For `formatRelativeTime`: used `vi.useFakeTimers()` + `vi.setSystemTime()` to pin `Date.now()` at a fixed point, then created dates at exact boundary offsets to test each time bracket

## How to test

1. Run `pnpm test`
2. All 27 tests pass (7 existing + 20 new), deterministic, no flakiness

## Screenshots / recordings (if UI change)

N/A — no UI changes, test-only PR.

## Checklist

- [x] I read the relevant code **before** writing my own
- [x] My code follows the existing patterns in the codebase
- [x] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
- [x] I added or updated tests where applicable
- [x] I can explain every line of code I wrote (reviewer will ask)
- [x] I kept the PR focused — no unrelated changes

> **Note on lint:** `pnpm typecheck` passes cleanly. `pnpm lint` reports 7 pre-existing errors (e.g. `module` variable assignment in API routes, `<a>` tags instead of `<Link>` on browse page) — all present on `master` before this PR. This PR introduces **zero new lint errors**.

## Notes for reviewer

- Each test targets a specific boundary (e.g. 59s → "just now", 60s → "1m ago") to catch off-by-one errors
- `generateSlug("")` returns `""` because `.trim()` on empty string stays empty, then all regex replacements are no-ops
- I used `beforeEach`/`afterEach` to setup and teardown fake timers, preventing timer leaks between tests

## AI Usage

**What I used AI for:**
- Asked Claude to explain Vitest fake timer API (`vi.useFakeTimers`, `vi.setSystemTime`, `vi.useRealTimers`) and the correct `beforeEach`/`afterEach` pattern to avoid timer leaks between tests
- Asked Claude to confirm whether `vi.setSystemTime()` affects `Date.now()` or only `new Date()` — answer: it affects both

**What I did myself:**
- Read `src/lib/utils.ts` line by line — traced each regex step in `generateSlug` to determine expected outputs (e.g. `"!!!hello!!!"` → special chars removed → `"hello"` → leading/trailing hyphen strip → `"hello"`)
- Identified boundary values by analyzing `Math.floor()` calls in `formatRelativeTime` (e.g. 59,999ms floors to 0 minutes → "just now", 60,000ms floors to 1 minute → "1m ago")
- Chose test cases to cover: zero input, mid-range, and boundary of each time bracket
- Reviewed existing test style (describe/it naming, assertion patterns) and matched it