### PR TITLE
feat/issue-155-add cursor-based pagination to module listing

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,11 @@
 import { db } from "@/lib/db";
 import { auth } from "@/lib/auth";
-import { ModuleCard } from "@/components/module-card";
+import { LoadMoreModules } from "@/components/load-more-modules";
 
 // TODO [medium-challenge]: Add category filter with URL query params (state persists on refresh)
 // See: ISSUES.md for full acceptance criteria
+
+const PAGE_SIZE = 12;
 
 export default async function HomePage({
   searchParams,
@@ -13,7 +15,7 @@ export default async function HomePage({
   const { q, category } = await searchParams;
   const session = await auth();
 
-  const modules = await db.miniApp.findMany({
+  const rows = await db.miniApp.findMany({
     where: {
       status: "APPROVED",
       ...(category ? { category: { slug: category } } : {}),
@@ -32,11 +34,15 @@ export default async function HomePage({
       author: { select: { id: true, name: true, image: true } },
     },
     orderBy: { voteCount: "desc" },
-    take: 12,
+    take: PAGE_SIZE + 1,
   });
 
+  const hasMore = rows.length > PAGE_SIZE;
+  const modules = hasMore ? rows.slice(0, PAGE_SIZE) : rows;
+  const nextCursor = hasMore ? modules[modules.length - 1].id : null;
+
   // Fetch which modules the current user has voted on
-  let votedIds = new Set<string>();
+  let votedIds: string[] = [];
   if (session?.user) {
     const votes = await db.vote.findMany({
       where: {
@@ -45,7 +51,7 @@ export default async function HomePage({
       },
       select: { moduleId: true },
     });
-    votedIds = new Set(votes.map((v) => v.moduleId));
+    votedIds = votes.map((v) => v.moduleId);
   }
 
   const categories = await db.category.findMany({ orderBy: { name: "asc" } });
@@ -54,7 +60,9 @@ export default async function HomePage({
     <div className="space-y-6">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Community Modules</h1>
+          <h1 className="text-2xl font-bold text-gray-900">
+            Community Modules
+          </h1>
           <p className="text-sm text-gray-500">
             Discover mini-apps built by the Intern developer community.
           </p>
@@ -107,21 +115,23 @@ export default async function HomePage({
         <div className="rounded-xl border border-dashed border-gray-300 p-12 text-center">
           <p className="text-gray-500">No modules found.</p>
           {q && (
-            <a href="/" className="mt-2 block text-sm text-blue-600 hover:underline">
+            <a
+              href="/"
+              className="mt-2 block text-sm text-blue-600 hover:underline"
+            >
               Clear search
             </a>
           )}
         </div>
       ) : (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {modules.map((module) => (
-            <ModuleCard
-              key={module.id}
-              module={module}
-              hasVoted={votedIds.has(module.id)}
-            />
-          ))}
-        </div>
+        <LoadMoreModules
+          key={`${q ?? ""}-${category ?? ""}`}
+          initialModules={modules}
+          initialVotedIds={votedIds}
+          initialCursor={nextCursor}
+          searchQuery={q}
+          category={category}
+        />
       )}
     </div>
   );

--- a/src/components/load-more-modules.tsx
+++ b/src/components/load-more-modules.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { ModuleCard } from "@/components/module-card";
+import type { Module } from "@/types";
+
+interface LoadMoreModulesProps {
+  initialModules: Module[];
+  initialVotedIds: string[];
+  initialCursor: string | null;
+  searchQuery?: string;
+  category?: string;
+}
+
+export function LoadMoreModules({
+  initialModules,
+  initialVotedIds,
+  initialCursor,
+  searchQuery,
+  category,
+}: LoadMoreModulesProps) {
+  const [modules, setModules] = useState<Module[]>(initialModules);
+  const [votedIds] = useState<Set<string>>(() => new Set(initialVotedIds));
+  const [cursor, setCursor] = useState<string | null>(initialCursor);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadMore = useCallback(async () => {
+    if (isLoading || !cursor) return;
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const params = new URLSearchParams();
+      params.set("cursor", cursor);
+      if (searchQuery) params.set("q", searchQuery);
+      if (category) params.set("category", category);
+
+      const res = await fetch(`/api/modules?${params.toString()}`);
+      if (!res.ok) throw new Error("Failed to fetch modules");
+
+      const data: { items: Module[]; nextCursor: string | null } =
+        await res.json();
+
+      setModules((prev) => [...prev, ...data.items]);
+      setCursor(data.nextCursor);
+    } catch {
+      setError("Failed to load more modules. Please try again.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [cursor, isLoading, searchQuery, category]);
+
+  return (
+    <>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {modules.map((m) => (
+          <ModuleCard key={m.id} module={m} hasVoted={votedIds.has(m.id)} />
+        ))}
+      </div>
+
+      {error && (
+        <p className="text-center text-sm text-red-600" role="alert">
+          {error}
+        </p>
+      )}
+
+      {cursor && (
+        <div className="flex justify-center pt-4">
+          <button
+            onClick={loadMore}
+            disabled={isLoading}
+            className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:opacity-50"
+          >
+            {isLoading ? (
+              <span className="flex items-center gap-2">
+                <svg
+                  className="h-4 w-4 animate-spin"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  aria-hidden="true"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                  />
+                </svg>
+                Loading…
+              </span>
+            ) : (
+              "Load more"
+            )}
+          </button>
+        </div>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## What does this PR do?

Adds a "Load more" button to the module listing on the home page. The first 12 modules are server-rendered for SEO, and subsequent pages are fetched client-side using the existing cursor-based `/api/modules?cursor=` API contract. No backend changes were needed.

## Related Issue

Closes #155

## How to test

1. Ensure there are more than 12 approved modules in the database (run `pnpm db:seed` — the seed includes 18 approved modules)
2. Run `pnpm dev` and open http://localhost:3000
3. Verify the "Load more" button appears below the module grid
4. Click "Load more" — additional modules should append without a full page reload
5. Verify the button disappears after all modules are loaded
6. Verify a loading spinner shows while fetching
7. Test with a category filter (`?category=game`) — click "Load more" and confirm only modules from that category are appended
8. Test with search (`?q=timer`) — confirm pagination respects the search query
9. Change category/search — confirm the list resets correctly (no stale data from previous filter)
10. Run `pnpm typecheck`, `pnpm test`, `pnpm build` — all pass

## Screenshots / recordings (if UI change)

**All modules — initial load (12 modules, Load more visible):**
<img width="590" height="551" alt="1" src="https://github.com/user-attachments/assets/5df753e9-703f-4005-8739-428dc7136914" />

**All modules — after first Load more (24 modules):**
<img width="601" height="553" alt="5" src="https://github.com/user-attachments/assets/11fd56ac-b08f-42cd-b673-ba6d5d569863" />

**All modules — all loaded (27 modules, button hidden):**
<img width="608" height="608" alt="6" src="https://github.com/user-attachments/assets/6c10e8a3-4d06-41ec-88c8-0c716957e7a7" />

**Game filter — 12 Game modules with Load more:**
<img width="409" height="635" alt="3" src="https://github.com/user-attachments/assets/69870b32-e947-4072-99e0-379960d802e0" />

**Game filter — all 13 Game modules loaded, button hidden:**
<img width="407" height="668" alt="4" src="https://github.com/user-attachments/assets/4cad483a-3b7d-4176-b5e9-c5134d9ad62e" />


## Checklist

- [x] I read the relevant code **before** writing my own
- [x] My code follows the existing patterns in the codebase
- [x] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
- [x] I added or updated tests where applicable
- [x] I can explain every line of code I wrote (reviewer will ask)
- [x] I kept the PR focused — no unrelated changes

## AI disclosure:

I used Claude (via VS Code) as an AI coding assistant. Specifically, it helped with scaffolding the `LoadMoreModules` component structure and drafting the PR description. I reviewed and understood every line before committing — for example, the `key` prop fix for stale state and the `take: PAGE_SIZE + 1` pattern for cursor detection were deliberate choices I can walk through in detail. All testing (typecheck, lint, test, build, manual browser testing) was done by me.

## Notes for reviewer

**Approach:** A hybrid server/client pattern — `page.tsx` remains a Server Component that fetches the first batch of 12 modules (using `take: PAGE_SIZE + 1` to detect if there's a next page). A new `LoadMoreModules` client component receives the initial data and handles subsequent client-side fetches.

**Key design decisions:**

- **`key` prop on `<LoadMoreModules>`** — Forces a full remount when search query or category changes. Without this, `useState(initialModules)` would keep showing stale data from the previous filter because React only uses the initial value on first mount. This is a subtle bug that's easy to miss.
- **`useCallback` for `loadMore`** — Memoized to prevent unnecessary re-renders of the component tree.
- **`PAGE_SIZE` constant** — Avoids magic numbers; the API route already uses `limit = 12` so this stays consistent.
- **Error state with `role="alert"`** — Accessible error message instead of silently failing. Users can retry by clicking the button again.
- **No API changes** — The existing `GET /api/modules?cursor=` endpoint already returns `{ items, nextCursor }`. I intentionally kept the scope to the UI layer only.

**Known limitation:** Modules loaded via "Load more" do not include per-user `hasVoted` state because the `/api/modules` endpoint doesn't return it. I chose not to modify the API in this PR to keep the scope focused on issue #155. A follow-up PR could add vote state to the API response for authenticated users.


