### PR TITLE
Feat/issue 30 contributor leaderboard

### DIFF
--- a/__tests__/leaderboard.test.ts
+++ b/__tests__/leaderboard.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    miniApp: {
+      groupBy: vi.fn(),
+    },
+    user: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+import { db } from "@/lib/db";
+import { getMonthlyLeaderboard } from "@/lib/leaderboard";
+
+type GroupByFn = ReturnType<typeof vi.fn>;
+type FindManyFn = ReturnType<typeof vi.fn>;
+
+const groupByMock = db.miniApp.groupBy as unknown as GroupByFn;
+const findManyMock = db.user.findMany as unknown as FindManyFn;
+
+describe("getMonthlyLeaderboard", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-08T12:34:56.000Z"));
+    groupByMock.mockReset();
+    findManyMock.mockReset();
+  });
+
+  it("queries current UTC month with expected ordering and limit", async () => {
+    groupByMock.mockResolvedValue([]);
+
+    await getMonthlyLeaderboard(10);
+
+    expect(groupByMock).toHaveBeenCalledTimes(1);
+    expect(groupByMock).toHaveBeenCalledWith({
+      by: ["authorId"],
+      where: {
+        status: "APPROVED",
+        createdAt: {
+          gte: new Date("2026-04-01T00:00:00.000Z"),
+          lt: new Date("2026-05-01T00:00:00.000Z"),
+        },
+      },
+      _count: { id: true },
+      orderBy: [
+        { _count: { id: "desc" } },
+        { _min: { createdAt: "asc" } },
+        { authorId: "asc" },
+      ],
+      take: 10,
+    });
+  });
+
+  it("maps grouped rows to ranked leaderboard entries", async () => {
+    groupByMock.mockResolvedValue([
+      { authorId: "u2", _count: { id: 7 } },
+      { authorId: "u1", _count: { id: 5 } },
+      { authorId: "u3", _count: { id: 5 } },
+    ]);
+
+    findManyMock.mockResolvedValue([
+      { id: "u1", name: "  Linh Nguyen  ", image: "https://img/linh.png" },
+      { id: "u2", name: null, image: null },
+      { id: "u3", name: "An Le", image: null },
+    ]);
+
+    const result = await getMonthlyLeaderboard(10);
+
+    expect(findManyMock).toHaveBeenCalledWith({
+      where: { id: { in: ["u2", "u1", "u3"] } },
+      select: { id: true, name: true, image: true },
+    });
+
+    expect(result.items).toEqual([
+      {
+        rank: 1,
+        userId: "u2",
+        name: "Anonymous Contributor",
+        image: null,
+        approvedSubmissions: 7,
+      },
+      {
+        rank: 2,
+        userId: "u1",
+        name: "Linh Nguyen",
+        image: "https://img/linh.png",
+        approvedSubmissions: 5,
+      },
+      {
+        rank: 3,
+        userId: "u3",
+        name: "An Le",
+        image: null,
+        approvedSubmissions: 5,
+      },
+    ]);
+
+    expect(result.monthStartUtc).toBe("2026-04-01T00:00:00.000Z");
+    expect(result.nextMonthStartUtc).toBe("2026-05-01T00:00:00.000Z");
+    expect(result.generatedAtUtc).toBe("2026-04-08T12:34:56.000Z");
+  });
+
+  it("returns empty items and skips user query when no contributors", async () => {
+    groupByMock.mockResolvedValue([]);
+
+    const result = await getMonthlyLeaderboard(10);
+
+    expect(findManyMock).not.toHaveBeenCalled();
+    expect(result.items).toEqual([]);
+    expect(result.monthStartUtc).toBe("2026-04-01T00:00:00.000Z");
+    expect(result.nextMonthStartUtc).toBe("2026-05-01T00:00:00.000Z");
+  });
+});

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import { getMonthlyLeaderboard } from "@/lib/leaderboard";
+
+export async function GET() {
+  try {
+    const leaderboard = await getMonthlyLeaderboard(10);
+    return NextResponse.json(leaderboard);
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to load leaderboard" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -1,0 +1,31 @@
+import { LeaderboardList } from "@/components/leaderboard-list";
+import { getMonthlyLeaderboard } from "@/lib/leaderboard";
+
+export const revalidate = 600;
+
+function formatMonthYear(dateIso: string): string {
+  const date = new Date(dateIso);
+  return new Intl.DateTimeFormat("en-US", {
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(date);
+}
+
+export default async function LeaderboardPage() {
+  const leaderboard = await getMonthlyLeaderboard(10);
+  const monthLabel = formatMonthYear(leaderboard.monthStartUtc);
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6">
+      <div className="space-y-1">
+        <h1 className="text-2xl font-bold text-gray-900">Top Contributors</h1>
+        <p className="text-sm text-gray-500">
+          Ranked by approved module submissions in {monthLabel} (UTC).
+        </p>
+      </div>
+
+      <LeaderboardList items={leaderboard.items} />
+    </div>
+  );
+}

--- a/src/components/leaderboard-list.tsx
+++ b/src/components/leaderboard-list.tsx
@@ -16,6 +16,37 @@ function getInitials(name: string): string {
   return `${parts[0][0]}${parts[1][0]}`.toUpperCase();
 }
 
+function Avatar({
+  image,
+  name,
+  sizeClass,
+}: {
+  image: string | null;
+  name: string;
+  sizeClass: string;
+}) {
+  if (image) {
+    return (
+      <>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={image}
+          alt={`${name} avatar`}
+          className={`${sizeClass} rounded-full border border-gray-200 object-cover`}
+        />
+      </>
+    );
+  }
+
+  return (
+    <div
+      className={`flex ${sizeClass} items-center justify-center rounded-full border border-gray-200 bg-gray-100 text-xs font-semibold text-gray-700`}
+    >
+      {getInitials(name)}
+    </div>
+  );
+}
+
 export function LeaderboardList({ items }: LeaderboardListProps) {
   if (items.length === 0) {
     return (
@@ -25,38 +56,72 @@ export function LeaderboardList({ items }: LeaderboardListProps) {
     );
   }
 
+  const topThree = items.slice(0, 3);
+  const remaining = items.slice(3);
+  const first = topThree.find((entry) => entry.rank === 1);
+  const second = topThree.find((entry) => entry.rank === 2);
+  const third = topThree.find((entry) => entry.rank === 3);
+
   return (
-    <ol className="space-y-3">
-      {items.map((entry) => (
-        <li
-          key={entry.userId}
-          className="flex items-center justify-between gap-4 rounded-xl border border-gray-200 bg-white px-4 py-3 shadow-sm"
-        >
-          <div className="flex items-center gap-3">
-            <span className="w-7 text-sm font-semibold text-gray-500">#{entry.rank}</span>
-
-            {entry.image ? (
-              /* eslint-disable-next-line @next/next/no-img-element */
-              <img
-                src={entry.image}
-                alt={`${entry.name} avatar`}
-                className="h-10 w-10 rounded-full border border-gray-200 object-cover"
-              />
-            ) : (
-              <div className="flex h-10 w-10 items-center justify-center rounded-full border border-gray-200 bg-gray-100 text-xs font-semibold text-gray-700">
-                {getInitials(entry.name)}
+    <div className="space-y-5">
+      <section className="rounded-2xl border border-blue-100 bg-gradient-to-b from-blue-50 to-white p-5">
+        <h2 className="text-center text-sm font-semibold tracking-wide text-blue-700 uppercase">
+          Top Contributors
+        </h2>
+        <ol className="mt-4 grid grid-cols-1 items-end gap-4 sm:grid-cols-3">
+          {[second, first, third].filter(Boolean).map((entry) => (
+            <li
+              key={entry!.userId}
+              className="flex flex-col items-center rounded-xl border border-blue-100 bg-white p-4 text-center"
+            >
+              <span className="text-xs font-semibold text-blue-600">#{entry!.rank}</span>
+              <div
+                className={`my-2 rounded-full border-2 p-1 ${
+                  entry!.rank === 1 ? "border-yellow-400" : "border-blue-300"
+                }`}
+              >
+                <Avatar
+                  image={entry!.image}
+                  name={entry!.name}
+                  sizeClass={entry!.rank === 1 ? "h-20 w-20" : "h-14 w-14"}
+                />
               </div>
-            )}
+              <p className="line-clamp-1 text-sm font-semibold text-gray-900">{entry!.name}</p>
+              <p className="text-xs text-gray-500">
+                <span className="font-semibold text-gray-800">{entry!.approvedSubmissions}</span>{" "}
+                approved
+              </p>
+            </li>
+          ))}
+        </ol>
+      </section>
 
-            <p className="text-sm font-medium text-gray-900">{entry.name}</p>
+      {remaining.length > 0 && (
+        <section className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+          <div className="grid grid-cols-[70px_1fr_120px] border-b border-gray-100 bg-gray-50 px-4 py-3 text-xs font-semibold tracking-wide text-gray-500 uppercase">
+            <span>Rank</span>
+            <span>Name</span>
+            <span className="text-right">Approved</span>
           </div>
-
-          <p className="text-sm text-gray-600">
-            <span className="font-semibold text-gray-900">{entry.approvedSubmissions}</span>{" "}
-            approved
-          </p>
-        </li>
-      ))}
-    </ol>
+          <ol>
+            {remaining.map((entry) => (
+              <li
+                key={entry.userId}
+                className="grid grid-cols-[70px_1fr_120px] items-center border-b border-gray-100 px-4 py-3 last:border-b-0"
+              >
+                <span className="text-sm font-semibold text-gray-600">#{entry.rank}</span>
+                <div className="flex items-center gap-3">
+                  <Avatar image={entry.image} name={entry.name} sizeClass="h-9 w-9" />
+                  <span className="text-sm font-medium text-gray-900">{entry.name}</span>
+                </div>
+                <span className="text-right text-sm font-semibold text-gray-800">
+                  {entry.approvedSubmissions}
+                </span>
+              </li>
+            ))}
+          </ol>
+        </section>
+      )}
+    </div>
   );
 }

--- a/src/components/leaderboard-list.tsx
+++ b/src/components/leaderboard-list.tsx
@@ -1,0 +1,62 @@
+import type { LeaderboardEntry } from "@/types";
+
+interface LeaderboardListProps {
+  items: LeaderboardEntry[];
+}
+
+function getInitials(name: string): string {
+  const parts = name
+    .split(" ")
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+  if (parts.length === 0) return "?";
+  if (parts.length === 1) return parts[0].slice(0, 1).toUpperCase();
+
+  return `${parts[0][0]}${parts[1][0]}`.toUpperCase();
+}
+
+export function LeaderboardList({ items }: LeaderboardListProps) {
+  if (items.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed border-gray-300 bg-white p-10 text-center">
+        <p className="text-sm text-gray-500">No approved submissions yet this month.</p>
+      </div>
+    );
+  }
+
+  return (
+    <ol className="space-y-3">
+      {items.map((entry) => (
+        <li
+          key={entry.userId}
+          className="flex items-center justify-between gap-4 rounded-xl border border-gray-200 bg-white px-4 py-3 shadow-sm"
+        >
+          <div className="flex items-center gap-3">
+            <span className="w-7 text-sm font-semibold text-gray-500">#{entry.rank}</span>
+
+            {entry.image ? (
+              /* eslint-disable-next-line @next/next/no-img-element */
+              <img
+                src={entry.image}
+                alt={`${entry.name} avatar`}
+                className="h-10 w-10 rounded-full border border-gray-200 object-cover"
+              />
+            ) : (
+              <div className="flex h-10 w-10 items-center justify-center rounded-full border border-gray-200 bg-gray-100 text-xs font-semibold text-gray-700">
+                {getInitials(entry.name)}
+              </div>
+            )}
+
+            <p className="text-sm font-medium text-gray-900">{entry.name}</p>
+          </div>
+
+          <p className="text-sm text-gray-600">
+            <span className="font-semibold text-gray-900">{entry.approvedSubmissions}</span>{" "}
+            approved
+          </p>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -1,10 +1,19 @@
 "use client";
 
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { useSession, signIn, signOut } from "next-auth/react";
 
 export function Navbar() {
   const { data: session } = useSession();
+  const pathname = usePathname();
+
+  const navLinkClass = (href: string) =>
+    `text-sm transition-colors ${
+      pathname === href
+        ? "font-medium text-gray-900"
+        : "text-gray-600 hover:text-gray-900"
+    }`;
 
   return (
     <nav className="border-b border-gray-200 bg-white">
@@ -14,16 +23,27 @@ export function Navbar() {
         </Link>
 
         <div className="flex items-center gap-4">
+          <Link href="/leaderboard" className={navLinkClass("/leaderboard")}>
+            Leaderboard
+          </Link>
+
           {session ? (
             <>
-              <Link href="/submit" className="text-sm text-gray-600 hover:text-gray-900">
+              <Link href="/submit" className={navLinkClass("/submit")}>
                 Submit Module
               </Link>
-              <Link href="/my-submissions" className="text-sm text-gray-600 hover:text-gray-900">
+              <Link href="/my-submissions" className={navLinkClass("/my-submissions")}>
                 My Submissions
               </Link>
               {session.user.isAdmin && (
-                <Link href="/admin" className="text-sm font-medium text-orange-600 hover:text-orange-700">
+                <Link
+                  href="/admin"
+                  className={
+                    pathname === "/admin"
+                      ? "text-sm font-medium text-orange-700"
+                      : "text-sm font-medium text-orange-600 hover:text-orange-700"
+                  }
+                >
                   Admin
                 </Link>
               )}

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -1,0 +1,71 @@
+import { db } from "@/lib/db";
+import type { LeaderboardEntry, LeaderboardResult } from "@/types";
+
+function getCurrentUtcMonthRange(now = new Date()): {
+  monthStart: Date;
+  nextMonthStart: Date;
+} {
+  const monthStart = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1, 0, 0, 0, 0)
+  );
+  const nextMonthStart = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1, 0, 0, 0, 0)
+  );
+
+  return { monthStart, nextMonthStart };
+}
+
+export async function getMonthlyLeaderboard(limit = 10): Promise<LeaderboardResult> {
+  const { monthStart, nextMonthStart } = getCurrentUtcMonthRange();
+
+  const grouped = await db.miniApp.groupBy({
+    by: ["authorId"],
+    where: {
+      status: "APPROVED",
+      createdAt: {
+        gte: monthStart,
+        lt: nextMonthStart,
+      },
+    },
+    _count: {
+      id: true,
+    },
+    // Tie-breaker: if approved counts are equal, contributor with the earliest
+    // approved submission in the current UTC month ranks higher.
+    orderBy: [
+      { _count: { id: "desc" } },
+      { _min: { createdAt: "asc" } },
+      { authorId: "asc" },
+    ],
+    take: limit,
+  });
+
+  const authorIds = grouped.map((row) => row.authorId);
+  const users = authorIds.length
+    ? await db.user.findMany({
+        where: { id: { in: authorIds } },
+        select: { id: true, name: true, image: true },
+      })
+    : [];
+
+  const usersById = new Map(users.map((user) => [user.id, user]));
+
+  const items = grouped.map((row, index) => {
+    const user = usersById.get(row.authorId);
+
+    return {
+      rank: index + 1,
+      userId: row.authorId,
+      name: user?.name?.trim() || "Anonymous Contributor",
+      image: user?.image ?? null,
+      approvedSubmissions: row._count.id,
+    } satisfies LeaderboardEntry;
+  });
+
+  return {
+    monthStartUtc: monthStart.toISOString(),
+    nextMonthStartUtc: nextMonthStart.toISOString(),
+    generatedAtUtc: new Date().toISOString(),
+    items,
+  };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,3 +12,4 @@ export type Module = MiniApp & {
 export type ModuleStatus = SubmissionStatus;
 
 export type { Category, User };
+export type { LeaderboardEntry, LeaderboardResult } from "./leaderboard";

--- a/src/types/leaderboard.ts
+++ b/src/types/leaderboard.ts
@@ -1,0 +1,14 @@
+export interface LeaderboardEntry {
+  rank: number;
+  userId: string;
+  name: string;
+  image: string | null;
+  approvedSubmissions: number;
+}
+
+export interface LeaderboardResult {
+  monthStartUtc: string;
+  nextMonthStartUtc: string;
+  generatedAtUtc: string;
+  items: LeaderboardEntry[];
+}


### PR DESCRIPTION
## What does this PR do?

This PR adds a public monthly leaderboard at /leaderboard to highlight top community contributors by approved module submissions. It includes a server-side leaderboard query with UTC month boundaries, an API route, navbar entry, and a leaderboard UI that highlights top 3 contributors. It also adds unit tests for ranking/query behavior and a richer seed script for local demo data.

## Related Issue

Closes #30

## How to test

1. Checkout this branch and install deps: pnpm install
2. Run app: pnpm dev
3. Open http://localhost:3000/leaderboard
4. Verify page is public (sign out and confirm it still loads)
5. Verify top 10 list is shown with: rank, avatar, name, approved count
6. Verify top 3 are highlighted in podium-style cards; remaining contributors appear in the table below
7. Verify navbar has Leaderboard link and active state on /leaderboard
8. Run checks:
   ```bash
   pnpm typecheck
   pnpm vitest run __tests__/leaderboard.test.ts


## Screenshots / recordings (if UI change)

<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/91e6094f-1f7f-4e1d-8819-d5e804fb7309" />

<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/3471f315-996e-4584-bbc0-b26847af7d99" />

## Checklist

- [x] I read the relevant code **before** writing my own
- [x] My code follows the existing patterns in the codebase
- [ ] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
- [x] I added or updated tests where applicable
- [x] I can explain every line of code I wrote (reviewer will ask)
- [x] I kept the PR focused — no unrelated changes

## Notes for reviewer

- Query is implemented with Prisma groupBy(authorId) + one batch user lookup to avoid N+1.
- Ranking order:
  - Higher approved submission count first
  - Tie-breaker: earlier approved submission timestamp (_min(createdAt))
  - Stable fallback: authorId ascending
- Month window is UTC: [monthStart, nextMonthStart).
- ISR is enabled via revalidate = 600 on /leaderboard (no client polling).
- Trade-off: at 00:01 UTC on the 1st, query logic targets the new month immediately, but cached HTML may remain stale for up to ~10 minutes until revalidation.
- Lint step was skipped as the base branch contains pre-existing lint errors unrelated to this change.

