### PR TITLE
fix: add character counter to description textarea

### DIFF
--- a/src/components/submit-form.tsx
+++ b/src/components/submit-form.tsx
@@ -13,6 +13,7 @@ export function SubmitForm({ categories }: SubmitFormProps) {
   const router = useRouter();
   const [error, setError] = useState<Record<string, string[]>>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [descriptionLength, setDescriptionLength] = useState(0);
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -59,13 +60,31 @@ export function SubmitForm({ categories }: SubmitFormProps) {
         />
       </Field>
 
-      <Field label="Description" name="description" error={error.description} hint="Max 500 characters">
-        {/* TODO [easy-challenge]: add a live character counter below this textarea */}
+      <Field
+        label="Description"
+        name="description"
+        error={error.description}
+        hint={
+          <div className="flex items-center justify-between gap-3">
+            <span>Max 500 characters</span>
+            <span
+              id="description-counter"
+              aria-live="polite"
+              className={`tabular-nums ${descriptionLength >= 450 ? "text-red-600" : "text-gray-400"}`}
+            >
+              {descriptionLength} / 500
+            </span>
+          </div>
+        }
+      >
         <textarea
+          id="description"
           name="description"
           rows={4}
           placeholder="What does your module do? Who is it for?"
           maxLength={500}
+          aria-describedby="description-counter"
+          onChange={(e) => setDescriptionLength(e.currentTarget.value.length)}
           className={inputClass}
         />
       </Field>
@@ -125,7 +144,7 @@ function Field({
   label: string;
   name: string;
   error?: string[];
-  hint?: string;
+  hint?: React.ReactNode;
   children: React.ReactNode;
 }) {
   return (
@@ -134,7 +153,7 @@ function Field({
         {label}
       </label>
       {children}
-      {hint && <p className="text-xs text-gray-400">{hint}</p>}
+      {hint && <div className="text-xs text-gray-400">{hint}</div>}
       {error && <p className="text-xs text-red-600">{error.join(", ")}</p>}
     </div>
   );


### PR DESCRIPTION
## What does this PR do?

Adds a live character counter to the submit form description textarea so people can track usage against the 500-character limit without layout shift. The counter is wired to the textarea for accessibility and switches to a warning color near the limit.

## Related Issue

Closes #244

## How to test

1. Run `pnpm install` if needed, then start the app with `pnpm dev`.
2. Open `/submit` and type in the Description textarea.
3. Confirm the counter updates live from `0 / 500` up to `500 / 500`.
4. Confirm the counter changes to the warning color at 450+ characters.
5. Confirm the textarea still enforces the 500-character maximum.

## Screenshots / recordings (if UI change)

<img width="522" height="157" alt="image" src="https://github.com/user-attachments/assets/cd6f3cfd-5e35-4a5a-95be-c5b42ad91bb8" />

<img width="523" height="159" alt="image" src="https://github.com/user-attachments/assets/751c3229-64c7-47be-b0c5-f7f7d3726249" />

## Checklist

- [x] I read the relevant code **before** writing my own
- [x] My code follows the existing patterns in the codebase
- [ ] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
- [ ] I added or updated tests where applicable
- [x] I can explain every line of code I wrote (reviewer will ask)
- [x] I kept the PR focused — no unrelated changes

## Notes for reviewer

`pnpm typecheck`, `pnpm test`, and `pnpm build` passed locally.

`pnpm lint` still fails due to pre-existing unrelated repo issues in:
- `src/app/api/modules/[id]/route.ts`
- `src/app/api/modules/route.ts`
- `src/app/modules/[slug]/page.tsx`
- `src/app/page.tsx`

This PR only changes `src/components/submit-form.tsx`.

## AI Usage

- Used Codex to assist with the implementation and code review process.
- Used OpenCode only to automate the GitHub workflow steps for issue and PR creation.
- I reviewed the final changes myself and can explain the implementation decisions.
- I manually tested the affected UI flow locally.
- Manual testing was required for the authenticated flow as the AI agent was not granted access to .env credentials for security reasons.