### PR TITLE
Feat/intern easy UI a11y utils tests

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { generateSlug, makeUniqueSlug, formatRelativeTime } from "@/lib/utils";
 
 // ============================================================
@@ -22,14 +22,21 @@ describe("generateSlug", () => {
     expect(generateSlug("a   b   c")).toBe("a-b-c");
   });
 
-  // TODO [easy-challenge]: Add test cases for the following:
-  // 1. A name that is already a valid slug (no changes needed)
-  // 2. A name with numbers (numbers should be preserved)
-  // 3. An empty string (what should the output be? Check the implementation)
-  // 4. A name with leading/trailing hyphens after special char removal
-  //
-  // Hint: read `src/lib/utils.ts` to understand the exact transformation rules
-  // before writing your assertions.
+  it("leaves an already-valid slug unchanged", () => {
+    expect(generateSlug("my-cool-app")).toBe("my-cool-app");
+  });
+
+  it("preserves digits", () => {
+    expect(generateSlug("App 2 Go v3")).toBe("app-2-go-v3");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(generateSlug("")).toBe("");
+  });
+
+  it("strips leading and trailing hyphens after stripping specials", () => {
+    expect(generateSlug("!!!hello!!!")).toBe("hello");
+  });
 });
 
 // ============================================================
@@ -49,23 +56,52 @@ describe("makeUniqueSlug", () => {
     expect(makeUniqueSlug("my-app", ["my-app", "my-app-1"])).toBe("my-app-2");
   });
 
-  // TODO [easy-challenge]: Add test cases for:
-  // 1. When many suffixed versions already exist (e.g. -1 through -5)
-  // 2. When the existing list contains similar but non-conflicting slugs
-  //    e.g. existing = ["my-app-tool"] should NOT block "my-app"
+  it("finds the next free suffix when many numbered variants exist", () => {
+    const existing = ["my-app", "my-app-1", "my-app-2", "my-app-3", "my-app-4", "my-app-5"];
+    expect(makeUniqueSlug("my-app", existing)).toBe("my-app-6");
+  });
+
+  it("does not treat similar longer slugs as conflicts", () => {
+    expect(makeUniqueSlug("my-app", ["my-app-tool"])).toBe("my-app");
+  });
 });
 
 // ============================================================
-// formatRelativeTime — NOT yet tested, candidate must write all tests
+// formatRelativeTime
 // ============================================================
 
-// TODO [easy-challenge]: Write a full test suite for `formatRelativeTime`.
-// Requirements:
-// - "just now" for dates less than 1 minute ago
-// - "{n}m ago" for dates 1–59 minutes ago
-// - "{n}h ago" for dates 1–23 hours ago
-// - "{n}d ago" for dates 1–29 days ago
-// - toLocaleDateString() format for dates 30+ days ago
-//
-// Hint: You'll need to mock or control `Date.now()` to make these tests
-// deterministic. Look into Vitest's `vi.setSystemTime()`.
+describe("formatRelativeTime", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-08T12:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns "just now" for less than one minute ago', () => {
+    const date = new Date("2026-04-08T11:59:30.000Z");
+    expect(formatRelativeTime(date)).toBe("just now");
+  });
+
+  it('returns "{n}m ago" for 1–59 minutes ago', () => {
+    expect(formatRelativeTime(new Date("2026-04-08T11:58:00.000Z"))).toBe("2m ago");
+    expect(formatRelativeTime(new Date("2026-04-08T11:01:00.000Z"))).toBe("59m ago");
+  });
+
+  it('returns "{n}h ago" for 1–23 hours ago', () => {
+    expect(formatRelativeTime(new Date("2026-04-08T11:00:00.000Z"))).toBe("1h ago");
+    expect(formatRelativeTime(new Date("2026-04-07T13:00:00.000Z"))).toBe("23h ago");
+  });
+
+  it('returns "{n}d ago" for 1–29 days ago', () => {
+    expect(formatRelativeTime(new Date("2026-04-07T12:00:00.000Z"))).toBe("1d ago");
+    expect(formatRelativeTime(new Date("2026-03-10T12:00:00.000Z"))).toBe("29d ago");
+  });
+
+  it("uses toLocaleDateString for 30 or more days ago", () => {
+    const date = new Date("2026-03-08T12:00:00.000Z");
+    expect(formatRelativeTime(date)).toBe(date.toLocaleDateString());
+  });
+});

--- a/src/components/module-card.tsx
+++ b/src/components/module-card.tsx
@@ -17,12 +17,12 @@ export function ModuleCard({ module, hasVoted = false }: ModuleCardProps) {
         >
           {module.name}
         </Link>
-        {/* TODO [easy-challenge]: icon-only buttons need aria-label — add one to the external link below */}
         {module.demoUrl && (
           <a
             href={module.demoUrl}
             target="_blank"
             rel="noopener noreferrer"
+            aria-label={`Open live demo for ${module.name} (opens in new tab)`}
             className="shrink-0 text-gray-400 hover:text-gray-600"
           >
             <ExternalLinkIcon />

--- a/src/components/submit-form.tsx
+++ b/src/components/submit-form.tsx
@@ -13,6 +13,9 @@ export function SubmitForm({ categories }: SubmitFormProps) {
   const router = useRouter();
   const [error, setError] = useState<Record<string, string[]>>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [description, setDescription] = useState("");
+  const descLen = description.length;
+  const descCounterWarn = descLen >= 450;
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -59,15 +62,30 @@ export function SubmitForm({ categories }: SubmitFormProps) {
         />
       </Field>
 
-      <Field label="Description" name="description" error={error.description} hint="Max 500 characters">
-        {/* TODO [easy-challenge]: add a live character counter below this textarea */}
+      <Field label="Description" name="description" error={error.description}>
         <textarea
+          id="description"
           name="description"
           rows={4}
           placeholder="What does your module do? Who is it for?"
           maxLength={500}
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          aria-describedby="description-hint description-counter"
           className={inputClass}
         />
+        <div className="flex min-h-[1.25rem] items-center justify-between gap-2 text-xs">
+          <span id="description-hint" className="text-gray-400">
+            Max 500 characters
+          </span>
+          <span
+            id="description-counter"
+            className={`tabular-nums ${descCounterWarn ? "font-medium text-red-600" : "text-gray-400"}`}
+            aria-live="polite"
+          >
+            {descLen} / 500
+          </span>
+        </div>
       </Field>
 
       <Field label="Category" name="categoryId" error={error.categoryId}>

--- a/src/components/vote-button.tsx
+++ b/src/components/vote-button.tsx
@@ -32,9 +32,17 @@ export function VoteButton({
 
   return (
     <button
+      type="button"
       onClick={toggle}
       disabled={isLoading}
-      aria-label={voted ? "Remove vote" : "Upvote this module"}
+      aria-busy={isLoading}
+      aria-label={
+        isLoading
+          ? "Saving vote…"
+          : voted
+            ? "Remove vote"
+            : "Upvote this module"
+      }
       className={`inline-flex items-center gap-1 rounded-md px-2 py-1 text-sm font-medium transition-colors
         ${voted
           ? "bg-orange-100 text-orange-600 hover:bg-orange-200"
@@ -42,10 +50,34 @@ export function VoteButton({
         }
         disabled:opacity-50 disabled:cursor-not-allowed`}
     >
-      {/* TODO [easy-challenge]: this button shows no loading state during API call — add one */}
-      <TriangleIcon filled={voted} />
+      {isLoading ? <LoadingSpinner /> : <TriangleIcon filled={voted} />}
       {count}
     </button>
+  );
+}
+
+function LoadingSpinner() {
+  return (
+    <svg
+      className="size-3 shrink-0 animate-spin text-current"
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+    >
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+      />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+      />
+    </svg>
   );
 }
 


### PR DESCRIPTION
## What does this PR do?

Improves UX and accessibility on the community hub, and locks in behavior of shared helpers with tests. The vote button now shows a clear in-flight state while the API request runs. The submit form shows a live description character count with a warning style near the limit. Module cards expose a descriptive `aria-label` on the icon-only demo link. Unit tests cover `generateSlug`, `makeUniqueSlug`, and `formatRelativeTime` in `src/lib/utils.ts`, following the easy-tier items described in `ISSUES.md`.

## Related Issue

No specific GitHub issue — contribution aligns with the intern challenge workflow in the README and the easy tasks outlined in `ISSUES.md` (vote loading state, description counter, demo link `aria-label`, utils tests).

## How to test

1. `pnpm install` then `pnpm test` — all tests should pass.
2. (Recommended per CONTRIBUTING) `pnpm lint`, `pnpm typecheck`, and `pnpm build`; run `pnpm db:generate` first if Prisma client types are missing.
3. Sign in with GitHub → on a module card, click vote → confirm a loading indicator appears, the button stays disabled during the request, and the count still updates correctly on success.
4. Open `/submit` → type in the description field → confirm `n / 500` updates live, styling turns warning/red from 450 characters, and pasted text cannot exceed 500 (`maxLength`).
5. On a card that has a demo URL, inspect the external link → confirm an accessible name (e.g. screen reader / devtools accessibility tree).

## Screenshots / recordings (if UI change)

(Optional) Short screen capture: vote button in loading state; submit form with counter near/at limit.

## Checklist

- [x] I read the relevant code **before** writing my own
- [x] My code follows the existing patterns in the codebase
- [ ] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
- [x] I added or updated tests where applicable
- [x] I can explain every line of code I wrote (reviewer will ask)
- [x] I kept the PR focused — no unrelated changes

## Notes for reviewer

**Goal (Minimin brief):** Demonstrate a concrete contribution via PR — UI/UX + a11y improvements and expanded test coverage for utilities.

**Implementation:** Reused existing `isLoading` from `useOptimisticVote`; SVG + Tailwind `animate-spin` (no new dependencies). Submit form uses controlled description state, `aria-describedby` for hint + counter. Demo link label includes module name and “opens in new tab”. Tests use Vitest fake timers for deterministic `formatRelativeTime` assertions.

**Testing:** Automated via `pnpm test`; manual steps listed above for vote, form, and link semantics.

**AI use:** Used to cross-check `ISSUES.md` expectations and test structure; all assertions were verified against `src/lib/utils.ts` and the running test suite.