### PR TITLE
fix: add aria-label to module card demo link

### DIFF
--- a/src/components/module-card.tsx
+++ b/src/components/module-card.tsx
@@ -17,12 +17,12 @@ export function ModuleCard({ module, hasVoted = false }: ModuleCardProps) {
         >
           {module.name}
         </Link>
-        {/* TODO [easy-challenge]: icon-only buttons need aria-label — add one to the external link below */}
         {module.demoUrl && (
           <a
             href={module.demoUrl}
             target="_blank"
             rel="noopener noreferrer"
+            aria-label={`Open demo for ${module.name}`}
             className="shrink-0 text-gray-400 hover:text-gray-600"
           >
             <ExternalLinkIcon />


### PR DESCRIPTION
## What does this PR do?
This updates the icon-only demo link in `ModuleCard` with a descriptive accessible name so screen readers can describe its purpose without changing the UI. The SVG remains decorative via `aria-hidden`, keeping the change narrowly focused to the existing accessibility gap.

## Related Issue
Closes #251

## How to test
1. Run `pnpm typecheck`, `pnpm test`, and `pnpm build`.
2. Open a module card that has a demo URL.
3. Inspect the external demo link and confirm it has `aria-label="Open demo for {module name}"`.
4. Confirm the icon SVG still has `aria-hidden="true"`.
5. Verify there are no visual changes to the card.

## Screenshots / recordings (if UI change)
No visual change.

## Checklist
- [x] I read the relevant code **before** writing my own
- [x] My code follows the existing patterns in the codebase
- [ ] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
- [ ] I added or updated tests where applicable
- [x] I can explain every line of code I wrote (reviewer will ask)
- [x] I kept the PR focused — no unrelated changes

## Notes for reviewer
- `pnpm typecheck`, `pnpm test`, and `pnpm build` pass locally.
- `pnpm lint` currently fails due pre-existing unrelated errors in `src/app/api/modules/[id]/route.ts`, `src/app/api/modules/route.ts`, `src/app/modules/[slug]/page.tsx`, and `src/app/page.tsx`.
- The code change in this PR is limited to `src/components/module-card.tsx`.

## AI Usage
- Used Codex to explain the goal this issue which make me quite confuse.
- Used OpenCode only to automate the GitHub workflow steps for issue and PR creation.