### PR TITLE
Feat/issue 177 rate limit postgres

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -124,6 +124,15 @@ model Vote {
   @@map("votes")
 }
 
+model RateLimitEvent{
+  id         String @id @default(cuid())
+  userId     String
+  createdAt  DateTime @default(now())
+
+  @@index([userId, createdAt])
+  @@map("rate_limit_events")
+}
+
 enum SubmissionStatus {
   PENDING
   APPROVED

--- a/src/app/api/votes/route.ts
+++ b/src/app/api/votes/route.ts
@@ -6,7 +6,7 @@ import { db } from "@/lib/db";
 // In production, replace with Redis-backed sliding window (e.g. Upstash).
 // TODO [medium-challenge]: Replace this with a proper rate limiter
 async function checkRateLimit(userId: string): Promise<boolean> {
-  const windowStart = new Date(Date.now() - 60_0000); // 1 minute ago
+  const windowStart = new Date(Date.now() - 60 * 1000); // 1 minute ago
 
   const voteCount = await db.rateLimitEvent.count({
     where: {
@@ -21,7 +21,11 @@ async function checkRateLimit(userId: string): Promise<boolean> {
   }
   // Not Reach Limit -> Allow + Record Event
   await db.rateLimitEvent.create({
-    data: { userId: userId },
+    data: { 
+      userId: userId,
+      createdAt: new Date(),
+    },
+    
   });
   
   return true;

--- a/src/app/api/votes/route.ts
+++ b/src/app/api/votes/route.ts
@@ -5,18 +5,27 @@ import { db } from "@/lib/db";
 // Simple in-memory rate limit: max 10 votes per minute per user.
 // In production, replace with Redis-backed sliding window (e.g. Upstash).
 // TODO [medium-challenge]: Replace this with a proper rate limiter
-const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
+async function checkRateLimit(userId: string): Promise<boolean> {
+  const windowStart = new Date(Date.now() - 60_0000); // 1 minute ago
 
-function checkRateLimit(userId: string): boolean {
-  const now = Date.now();
-  const entry = rateLimitMap.get(userId);
-  if (!entry || entry.resetAt < now) {
-    rateLimitMap.set(userId, { count: 1, resetAt: now + 60_000 });
-    return true;
+  const voteCount = await db.rateLimitEvent.count({
+    where: {
+      userId,
+      createdAt: { gte: windowStart },
+    },
+  });
+  
+  // Reach Limit -> Block
+  if (voteCount >= 10) {
+    return false;
   }
-  if (entry.count >= 10) return false;
-  entry.count++;
+  // Not Reach Limit -> Allow + Record Event
+  await db.rateLimitEvent.create({
+    data: { userId: userId },
+  });
+  
   return true;
+ 
 }
 
 // POST /api/votes — toggle vote on a module
@@ -26,11 +35,9 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  if (!checkRateLimit(session.user.id)) {
-    return NextResponse.json(
-      { error: "Too many votes. Please wait a moment." },
-      { status: 429 }
-    );
+  const allowed = await checkRateLimit(session.user.id);
+  if (!allowed) {
+    return NextResponse.json({ error: "Rate limit exceeded" }, { status: 429 });
   }
 
   const { moduleId } = await req.json();


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change in 1-3 sentences. What problem does it solve? -->
This PR replaces the in-memory 'Map' Rate limiter for 'POST /api/votes', with a persistent PostgreSQL sliding-window solution. This solves the issue of rate limits resetting on server restarts and failing across multiple serverless instance
## Related Issue

Closes #177

## How to test

<!-- Exact steps for the reviewer to verify your change works -->

1. Pull this branch and run 'pnpm db:push' to apply the new 'RateLimitEvent' schema
2. Start the local server with 'pnpm dev' and ensure you are logged in
3. Open the Network tab in your browser's Developer Tools
4. Rapidly click the "Vote" button on any module more then 10 times
5. Verify that the 11th request (and subsquent ones within the 60s window) return an HTTP '429 Too Many Request' status code
6. Wait 60 sec and verify that you can vote again

## Screenshots / recordings (if UI change)

<!-- Drag and drop a screenshot or screen recording here -->

## Checklist

- [x] I read the relevant code **before** writing my own
- [x] My code follows the existing patterns in the codebase
- [x] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
- [x] I added or updated tests where applicable
- [x] I can explain every line of code I wrote (reviewer will ask)
- [x] I kept the PR focused — no unrelated changes

## Notes for reviewer

<!-- Anything you want to highlight, trade-offs you made, or questions you have -->
When i ran 'pnpm lint' and noticed there are 7 existing errors and and 2 warnings in other files (like `app/page.tsx` and `api/modules/...`). To strictly follow the "no unrelated changes" rule, I left them untouched and only focused on `api/votes/route.ts` 