### PR TITLE
fix: show loading state on vote button

### DIFF
--- a/src/components/vote-button.tsx
+++ b/src/components/vote-button.tsx
@@ -36,15 +36,15 @@ export function VoteButton({
       disabled={isLoading}
       aria-label={voted ? "Remove vote" : "Upvote this module"}
       className={`inline-flex items-center gap-1 rounded-md px-2 py-1 text-sm font-medium transition-colors
-        ${voted
-          ? "bg-orange-100 text-orange-600 hover:bg-orange-200"
-          : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+        ${
+          voted
+            ? "bg-orange-100 text-orange-600 hover:bg-orange-200"
+            : "bg-gray-100 text-gray-600 hover:bg-gray-200"
         }
         disabled:opacity-50 disabled:cursor-not-allowed`}
     >
-      {/* TODO [easy-challenge]: this button shows no loading state during API call — add one */}
-      <TriangleIcon filled={voted} />
-      {count}
+      {isLoading ? <SpinnerIcon /> : <TriangleIcon filled={voted} />}
+      <span>{count}</span>
     </button>
   );
 }
@@ -61,6 +61,35 @@ function TriangleIcon({ filled = false }: { filled?: boolean }) {
       aria-hidden="true"
     >
       <path d="M6 1 L11 10 L1 10 Z" />
+    </svg>
+  );
+}
+
+function SpinnerIcon() {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      className="animate-spin"
+      aria-hidden="true"
+    >
+      <circle
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="3"
+        className="opacity-25"
+        fill="none"
+      />
+      <path
+        d="M22 12a10 10 0 0 1-10 10"
+        stroke="currentColor"
+        strokeWidth="3"
+        className="opacity-90"
+        fill="none"
+      />
     </svg>
   );
 }


### PR DESCRIPTION
## What does this PR do?

This updates the vote button to show a spinner while a vote request is in flight, so users get immediate feedback that their click registered. It keeps the existing disabled behavior and stays within the existing component pattern without adding dependencies.

## Related Issue

Closes #260

## How to test

1. Run `pnpm install` if dependencies are not installed, then start the app with `pnpm dev`.
2. Sign in, open a page that renders `VoteButton`, and click the vote button.
3. Confirm the triangle icon changes to a spinner while the request is pending.
4. Confirm the button is disabled during loading and returns to its normal icon after the request resolves.

## Screenshots / recordings (if UI change)
The different color is based on the action up vote or down vote

<img width="499" height="255" alt="image" src="https://github.com/user-attachments/assets/fc634962-d717-4651-b920-9f95259ff2ef" />

<img width="1087" height="342" alt="image" src="https://github.com/user-attachments/assets/1a11f8d6-edc2-4d45-87d4-7afb608e4029" />


## Checklist

- [x] I read the relevant code **before** writing my own
- [x] My code follows the existing patterns in the codebase
- [ ] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
- [ ] I added or updated tests where applicable
- [x] I can explain every line of code I wrote (reviewer will ask)
- [x] I kept the PR focused — no unrelated changes

## Notes for reviewer

- I matched the existing inline-icon button pattern and used a spinner so the loading state is visible without relying only on color.
- Validation run locally: `pnpm lint -- src/components/vote-button.tsx`, `pnpm typecheck`, `pnpm test`, `pnpm build`.

## AI Usage
- Used OpenCode only to automate the GitHub workflow steps for issue and PR creation.
