### PR TITLE
feat: add pagination to admin pending submissions list

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,11 +1,26 @@
 import { redirect } from "next/navigation";
+import Link from "next/link";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { AdminReviewCard } from "@/components/admin-review-card";
 
-export default async function AdminPage() {
+const PAGE_SIZE = 10;
+
+export default async function AdminPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ page?: string }>;
+}) {
   const session = await auth();
   if (!session?.user?.isAdmin) redirect("/");
+
+  const { page } = await searchParams;
+  const pageNumber = Math.max(1, Number.parseInt(page ?? "1", 10) || 1);
+  const skip = (pageNumber - 1) * PAGE_SIZE;
+
+  const pendingTotal = await db.miniApp.count({
+    where: { status: "PENDING" },
+  });
 
   const pending = await db.miniApp.findMany({
     where: { status: "PENDING" },
@@ -14,6 +29,8 @@ export default async function AdminPage() {
       author: { select: { id: true, name: true, image: true } },
     },
     orderBy: { createdAt: "asc" },
+    skip,
+    take: PAGE_SIZE,
   });
 
   const recentlyReviewed = await db.miniApp.findMany({
@@ -26,21 +43,73 @@ export default async function AdminPage() {
     take: 5,
   });
 
+  const totalPages = Math.max(1, Math.ceil(pendingTotal / PAGE_SIZE));
+  const hasPrev = pageNumber > 1;
+  const hasNext = pageNumber < totalPages;
+  const isOutOfRange = pendingTotal > 0 && pending.length === 0;
+
   return (
     <div className="space-y-8">
       <h1 className="text-2xl font-bold text-gray-900">Admin — Module Review</h1>
 
       <section className="space-y-4">
         <h2 className="text-lg font-semibold text-gray-700">
-          Pending ({pending.length})
+          Pending ({pendingTotal})
         </h2>
-        {pending.length === 0 ? (
+        {pendingTotal === 0 ? (
           <p className="text-sm text-gray-400">No pending submissions. 🎉</p>
+        ) : isOutOfRange ? (
+          <div className="space-y-3">
+            <p className="text-sm text-gray-500">
+              No submissions on this page. Try going back to a previous page.
+            </p>
+            <Link
+              href={`/admin?page=${totalPages}`}
+              className="inline-flex rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50"
+            >
+              Go to last page
+            </Link>
+          </div>
         ) : (
-          <div className="grid gap-4 sm:grid-cols-2">
-            {pending.map((module) => (
-              <AdminReviewCard key={module.id} module={module} />
-            ))}
+          <div className="space-y-4">
+            <div className="grid gap-4 sm:grid-cols-2">
+              {pending.map((module) => (
+                <AdminReviewCard key={module.id} module={module} />
+              ))}
+            </div>
+
+            <div className="flex items-center justify-between rounded-lg border border-gray-200 bg-white px-4 py-3">
+              <span className="text-sm text-gray-600">
+                Page {pageNumber} of {totalPages}
+              </span>
+              <div className="flex items-center gap-2">
+                {hasPrev ? (
+                  <Link
+                    href={`/admin?page=${pageNumber - 1}`}
+                    className="rounded-lg border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
+                  >
+                    Prev
+                  </Link>
+                ) : (
+                  <span className="rounded-lg border border-gray-200 px-3 py-1.5 text-sm text-gray-400">
+                    Prev
+                  </span>
+                )}
+
+                {hasNext ? (
+                  <Link
+                    href={`/admin?page=${pageNumber + 1}`}
+                    className="rounded-lg border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
+                  >
+                    Next
+                  </Link>
+                ) : (
+                  <span className="rounded-lg border border-gray-200 px-3 py-1.5 text-sm text-gray-400">
+                    Next
+                  </span>
+                )}
+              </div>
+            </div>
           </div>
         )}
       </section>


### PR DESCRIPTION
## What does this PR do?

Adds pagination to the admin pending submissions list on `/admin`.

- Limits pending submissions to 10 items per page
- Adds Prev/Next pagination controls
- Syncs current page via URL query (`?page=`)
- Handles out-of-range page state
- Keeps "Recently Reviewed" section unchanged

## Related Issue

Closes #117

## How to test

1. Run the app:
   - `pnpm dev`
2. Sign in as an admin account and open `/admin`
3. Verify pending list shows at most 10 items per page
4. Click **Next** / **Prev** and verify:
   - URL updates (e.g. `/admin?page=2`)
   - List content updates correctly
5. Visit `/admin?page=999` and verify fallback state appears
6. Verify "Recently Reviewed" section remains unchanged

## Screenshots / recordings (if UI change)
### Screenshots

- Admin pagination (Page 2 of 2):
 <img width="1106" height="600" alt="image" src="https://github.com/user-attachments/assets/569f6801-a5c6-4eed-9ddf-ce0699614e13" />

## Checklist

- [x] I read the relevant code **before** writing my own
- [x] My code follows the existing patterns in the codebase
- [x] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
- [ ] I added or updated tests where applicable
- [x] I can explain every line of code I wrote (reviewer will ask)
- [x] I kept the PR focused — no unrelated changes

## Notes for reviewer

- Pagination uses Prisma `skip/take` in `src/app/admin/page.tsx`.
- Scope is intentionally limited to the `Pending` section only, per issue #117.
- `pnpm lint` currently reports unrelated pre-existing errors in other files; this PR only modifies `src/app/admin/page.tsx`.[](url)