### PR TITLE
feat/issue 181 my submissions page

### DIFF
--- a/src/app/my-submissions/page.tsx
+++ b/src/app/my-submissions/page.tsx
@@ -3,10 +3,18 @@ import Link from "next/link";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 
+import DeleteButton from "@/components/delete-button";
+
 const statusStyles: Record<string, string> = {
   PENDING: "bg-yellow-50 text-yellow-700 border-yellow-200",
   APPROVED: "bg-green-50 text-green-700 border-green-200",
   REJECTED: "bg-red-50 text-red-700 border-red-200",
+};
+
+const statusText: Record<string, string> = {
+  PENDING: "Pending",
+  APPROVED: "Approved",
+  REJECTED: "Rejected",
 };
 
 export default async function MySubmissionsPage() {
@@ -49,7 +57,16 @@ export default async function MySubmissionsPage() {
               className="flex items-start justify-between rounded-xl border border-gray-200 bg-white p-4"
             >
               <div className="space-y-1">
-                <p className="font-medium text-gray-900">{sub.name}</p>
+                {sub.status === "APPROVED" ? (
+                  <Link
+                    href={`/modules/${sub.slug}`}
+                    className="text-base font-semibold text-gray-900 hover:text-blue-600 hover:underline"
+                  >
+                    {sub.name}
+                  </Link>
+                ) : (
+                  <p className="font-medium text-gray-900">{sub.name}</p>
+                )}
                 <p className="text-xs text-gray-400">
                   {sub.category.name} ·{" "}
                   {new Date(sub.createdAt).toLocaleDateString()}
@@ -60,13 +77,18 @@ export default async function MySubmissionsPage() {
                   </p>
                 )}
               </div>
-              <span
-                className={`shrink-0 rounded-full border px-2 py-0.5 text-xs font-medium ${
-                  statusStyles[sub.status]
-                }`}
-              >
-                {sub.status}
-              </span>
+              <div className="flex flex-col items-center gap-2">
+                <span
+                  className={`shrink-0 rounded-full border px-2 py-0.5 text-xs font-medium ${
+                    statusStyles[sub.status]
+                  }`}
+                >
+                  {statusText[sub.status]}
+                </span>
+                {sub.status === "PENDING" && (
+                  <DeleteButton subId={sub.id} subName={sub.name} />
+                )}
+              </div>
             </div>
           ))}
         </div>

--- a/src/components/confirm-dialog.tsx
+++ b/src/components/confirm-dialog.tsx
@@ -1,0 +1,61 @@
+interface ConfirmDialogProps {
+  isOpen: boolean;
+  title: string;
+  description: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  confirmText?: string;
+  cancelText?: string;
+}
+
+const ConfirmDialog = ({
+  isOpen,
+  title,
+  description,
+  onConfirm,
+  onCancel,
+  confirmText = "Confirm",
+  cancelText = "Cancel",
+}: ConfirmDialogProps) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm animate-fadeIn"
+        onClick={onCancel}
+      />
+
+      <div className="relative z-10 w-full max-w-md transform rounded-2xl bg-white border border-white/10 shadow-2xl animate-scaleIn">
+        <div className="p-6">
+          <div className="flex items-start gap-4">
+            <div>
+              <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
+              <p className="mt-2 text-sm text-gray-400 leading-relaxed">
+                {description}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex gap-3 px-6 pb-6 pt-2 justify-end">
+          <button
+            onClick={onCancel}
+            className="rounded-lg px-4 py-2 text-sm font-semibold text-white bg-gray-500 hover:bg-gray-400 transition"
+          >
+            {cancelText}
+          </button>
+
+          <button
+            onClick={onConfirm}
+            className="rounded-lg px-4 py-2 text-sm font-semibold text-white bg-red-500 hover:bg-red-400 transition shadow-lg shadow-red-500/20"
+          >
+            {confirmText}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConfirmDialog;

--- a/src/components/delete-button.tsx
+++ b/src/components/delete-button.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import ConfirmDialog from "./confirm-dialog";
+
+const DeleteButton = ({
+  subId,
+  subName,
+}: {
+  subId: string;
+  subName: string;
+}) => {
+  const router = useRouter();
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleDelete = async () => {
+    setIsDeleting(true);
+    try {
+      const res = await fetch(`/api/modules/${subId}`, {
+        method: "DELETE",
+      });
+
+      if (!res.ok) {
+        alert("Failed to delete submission. Please try again.");
+        return;
+      }
+
+      router.refresh();
+    } finally {
+      setIsDeleting(false);
+      setIsOpen(false);
+    }
+  };
+
+  return (
+    <>
+      <button
+        onClick={() => setIsOpen(true)}
+        className="shrink-0 rounded-full px-2 py-0.5 text-xs font-medium 
+      hover:cursor-pointer hover:bg-red-400 bg-red-500 text-white disabled:opacity-50"
+        disabled={isDeleting}
+      >
+        Delete
+      </button>
+
+      <ConfirmDialog
+        isOpen={isOpen}
+        title="Delete Submission"
+        description={`Are you sure you want to delete "${subName}"?`}
+        onConfirm={handleDelete}
+        onCancel={() => setIsOpen(false)}
+        confirmText="Delete"
+        cancelText="Cancel"
+      />
+    </>
+  );
+};
+
+export default DeleteButton;


### PR DESCRIPTION
## What does this PR do?

Improves the My Submissions page (/my-submissions) with two enhancements: clearer status badges that reflect each submission's state, and the ability for users to delete their own PENDING submissions. A reusable ConfirmDialog component handles the confirmation prompt, while DeleteButton is extracted as a client component to keep the page itself a server component.

## Related Issue

Closes #181

## How to test

<!-- Exact steps for the reviewer to verify your change works -->

1. Sign in and navigate to /my-submissions
2. Verify each submission shows a colored status badge — yellow for Pending, green for Approved, red for Rejected
3. Confirm that APPROVED and REJECTED submissions have no Delete button visible in the UI
4. Click Delete on a PENDING submission → a confirmation dialog appears
5. Confirm the deletion → the item disappears from the list without a full page reload
6. Cancel the dialog → nothing is deleted, dialog closes

## Screenshots / recordings (if UI change)

<img width="1906" height="946" alt="image" src="https://github.com/user-attachments/assets/b42f4cae-8e91-49b8-8da6-ffa7eae565a4" />

<img width="1855" height="931" alt="image" src="https://github.com/user-attachments/assets/ad37e2ce-bb8a-44ed-b74d-df5f8ce9ac40" />



## Checklist

- [x] I read the relevant code **before** writing my own
- [x] My code follows the existing patterns in the codebase
- [x] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
- [ ] I added or updated tests where applicable
- [x] I can explain every line of code I wrote (reviewer will ask)
- [x] I kept the PR focused — no unrelated changes

## Notes for reviewer

- my-submissions/page.tsx remains a server component — data fetching stays on the server. Only the interactive delete action is extracted into <DeleteButton> as a client component.
- After deletion, router.refresh() is called instead of a full reload — this re-runs the server component's data fetch and updates the UI while preserving client state.
- The confirm() check in <DeleteButton> was replaced with a custom <ConfirmDialog> for better UX, but this is not a security boundary — the real guard is server-side authorization in DELETE /api/modules/[id]/route.ts. Even if a user bypasses the dialog, the API will reject unauthorized requests.
- APPROVED and REJECTED submissions have no delete button rendered at all (sub.status === "PENDING" guard in the JSX), but again, the server is the source of truth.
