### PR TITLE
Improve user submission management for pending submissions

### DIFF
--- a/src/app/api/modules/[id]/route.ts
+++ b/src/app/api/modules/[id]/route.ts
@@ -8,7 +8,7 @@ type Params = { params: Promise<{ id: string }> };
 // GET /api/modules/[id]
 export async function GET(_req: NextRequest, { params }: Params) {
   const { id } = await params;
-  const module = await db.miniApp.findUnique({
+  const miniApp = await db.miniApp.findUnique({
     where: { id },
     include: {
       category: true,
@@ -16,8 +16,8 @@ export async function GET(_req: NextRequest, { params }: Params) {
       _count: { select: { votes: true } },
     },
   });
-  if (!module) return NextResponse.json({ error: "Not found" }, { status: 404 });
-  return NextResponse.json(module);
+  if (!miniApp) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  return NextResponse.json(miniApp);
 }
 
 // PATCH /api/modules/[id] — admin approve/reject
@@ -53,11 +53,21 @@ export async function DELETE(_req: NextRequest, { params }: Params) {
   }
 
   const { id } = await params;
-  const module = await db.miniApp.findUnique({ where: { id } });
-  if (!module) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  const miniApp = await db.miniApp.findUnique({ where: { id } });
+  if (!miniApp) return NextResponse.json({ error: "Not found" }, { status: 404 });
 
-  if (module.authorId !== session.user.id && !session.user.isAdmin) {
+  const isAdmin = session.user.isAdmin;
+  const isAuthor = miniApp.authorId === session.user.id;
+
+  if (!isAuthor && !isAdmin) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  if (!isAdmin && miniApp.status !== "PENDING") {
+    return NextResponse.json(
+      { error: "Only pending submissions can be deleted by the author." },
+      { status: 403 }
+    );
   }
 
   await db.miniApp.delete({ where: { id } });

--- a/src/app/my-submissions/page.tsx
+++ b/src/app/my-submissions/page.tsx
@@ -2,12 +2,7 @@ import { redirect } from "next/navigation";
 import Link from "next/link";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
-
-const statusStyles: Record<string, string> = {
-  PENDING: "bg-yellow-50 text-yellow-700 border-yellow-200",
-  APPROVED: "bg-green-50 text-green-700 border-green-200",
-  REJECTED: "bg-red-50 text-red-700 border-red-200",
-};
+import { MySubmissionsList } from "@/components/my-submissions-list";
 
 export default async function MySubmissionsPage() {
   const session = await auth();
@@ -31,46 +26,18 @@ export default async function MySubmissionsPage() {
         </Link>
       </div>
 
-      {submissions.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-gray-300 p-12 text-center">
-          <p className="text-gray-500">No submissions yet.</p>
-          <Link
-            href="/submit"
-            className="mt-2 block text-sm text-blue-600 hover:underline"
-          >
-            Submit your first module →
-          </Link>
-        </div>
-      ) : (
-        <div className="space-y-3">
-          {submissions.map((sub) => (
-            <div
-              key={sub.id}
-              className="flex items-start justify-between rounded-xl border border-gray-200 bg-white p-4"
-            >
-              <div className="space-y-1">
-                <p className="font-medium text-gray-900">{sub.name}</p>
-                <p className="text-xs text-gray-400">
-                  {sub.category.name} ·{" "}
-                  {new Date(sub.createdAt).toLocaleDateString()}
-                </p>
-                {sub.feedback && (
-                  <p className="mt-1 rounded-md bg-gray-50 px-2 py-1 text-xs text-gray-600">
-                    Feedback: {sub.feedback}
-                  </p>
-                )}
-              </div>
-              <span
-                className={`shrink-0 rounded-full border px-2 py-0.5 text-xs font-medium ${
-                  statusStyles[sub.status]
-                }`}
-              >
-                {sub.status}
-              </span>
-            </div>
-          ))}
-        </div>
-      )}
+      <MySubmissionsList
+        initialSubmissions={submissions.map((submission) => ({
+          id: submission.id,
+          name: submission.name,
+          status: submission.status,
+          feedback: submission.feedback,
+          createdAt: submission.createdAt.toISOString(),
+          category: {
+            name: submission.category.name,
+          },
+        }))}
+      />
     </div>
   );
 }

--- a/src/components/my-submissions-list.tsx
+++ b/src/components/my-submissions-list.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { startTransition, useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
+type SubmissionItem = {
+  id: string;
+  name: string;
+  status: "PENDING" | "APPROVED" | "REJECTED";
+  feedback: string | null;
+  createdAt: string;
+  category: {
+    name: string;
+  };
+};
+
+interface MySubmissionsListProps {
+  initialSubmissions: SubmissionItem[];
+}
+
+const statusStyles: Record<SubmissionItem["status"], string> = {
+  PENDING: "bg-yellow-50 text-yellow-700 border-yellow-200",
+  APPROVED: "bg-green-50 text-green-700 border-green-200",
+  REJECTED: "bg-red-50 text-red-700 border-red-200",
+};
+
+export function MySubmissionsList({
+  initialSubmissions,
+}: MySubmissionsListProps) {
+  const router = useRouter();
+  const [submissions, setSubmissions] = useState(initialSubmissions);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const hasSubmissions = submissions.length > 0;
+
+  const submissionCountLabel = useMemo(() => {
+    return `${submissions.length} submission${submissions.length === 1 ? "" : "s"}`;
+  }, [submissions.length]);
+
+  async function handleDelete(id: string, name: string) {
+    const confirmed = window.confirm(
+      `Delete "${name}"? You can only remove pending submissions.`
+    );
+    if (!confirmed) return;
+
+    setDeletingId(id);
+    setError(null);
+
+    try {
+      const res = await fetch(`/api/modules/${id}`, {
+        method: "DELETE",
+      });
+
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as
+          | { error?: string }
+          | null;
+        throw new Error(body?.error ?? "Failed to delete submission.");
+      }
+
+      setSubmissions((current) =>
+        current.filter((submission) => submission.id !== id)
+      );
+      startTransition(() => {
+        router.refresh();
+      });
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Failed to delete submission. Please try again."
+      );
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-sm text-gray-500">{submissionCountLabel}</p>
+        {error && <p className="text-sm text-red-600">{error}</p>}
+      </div>
+
+      {!hasSubmissions ? (
+        <div className="rounded-xl border border-dashed border-gray-300 p-12 text-center">
+          <p className="text-gray-500">No submissions yet.</p>
+          <Link
+            href="/submit"
+            className="mt-2 block text-sm text-blue-600 hover:underline"
+          >
+            Submit your first module {"->"}
+          </Link>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {submissions.map((submission) => {
+            const isDeleting = deletingId === submission.id;
+            const canDelete = submission.status === "PENDING";
+
+            return (
+              <div
+                key={submission.id}
+                className="flex flex-col gap-4 rounded-xl border border-gray-200 bg-white p-4 sm:flex-row sm:items-start sm:justify-between"
+              >
+                <div className="space-y-1">
+                  <p className="font-medium text-gray-900">{submission.name}</p>
+                  <p className="text-xs text-gray-400">
+                    {submission.category.name} - {new Date(submission.createdAt).toLocaleDateString()}
+                  </p>
+                  {submission.feedback && (
+                    <p className="mt-1 rounded-md bg-gray-50 px-2 py-1 text-xs text-gray-600">
+                      Feedback: {submission.feedback}
+                    </p>
+                  )}
+                  {canDelete ? (
+                    <p className="text-xs text-gray-500">
+                      Pending submissions can be deleted before review.
+                    </p>
+                  ) : (
+                    <p className="text-xs text-gray-500">
+                      Reviewed submissions are kept for admin history.
+                    </p>
+                  )}
+                </div>
+
+                <div className="flex items-center gap-3 sm:flex-col sm:items-end">
+                  <span
+                    className={`shrink-0 rounded-full border px-2 py-0.5 text-xs font-medium ${
+                      statusStyles[submission.status]
+                    }`}
+                  >
+                    {submission.status}
+                  </span>
+
+                  {canDelete && (
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(submission.id, submission.name)}
+                      disabled={isDeleting}
+                      className="rounded-lg border border-red-200 px-3 py-2 text-xs font-medium text-red-600 transition-colors hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {isDeleting ? "Deleting..." : "Delete"}
+                    </button>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Goal

This PR improves user submission management by allowing contributors to delete their own pending submissions from the **My Submissions** page.

It also tightens the backend deletion rules so that authors can no longer delete submissions that have already been reviewed (`APPROVED` or `REJECTED`), while admins still retain full delete access.

## Implementation

### Frontend
- Added a dedicated client-side submission management flow for the **My Submissions** page
- Added a delete action for `PENDING` submissions only
- Added a confirmation prompt before deletion
- Added loading and disabled states while deletion is in progress
- Added inline error feedback when deletion fails
- Updated the UI optimistically after a successful deletion and refreshed the route data

### Backend
- Updated `DELETE /api/modules/[id]` authorization/business rules:
  - authors can delete only their own `PENDING` submissions
  - authors cannot delete `APPROVED` or `REJECTED` submissions
  - admins can still delete any submission

## Testing

Manual test cases covered:
- authenticated author can delete their own `PENDING` submission
- authenticated author cannot delete their own `APPROVED` or `REJECTED` submission
- non-author cannot delete another user's submission
- delete action shows confirmation and loading state
- submission list updates correctly after deletion
- empty state is shown when no submissions remain

Validation performed:
- `pnpm typecheck`

Note:
- Full repo lint still reports unrelated pre-existing issues outside the files changed in this PR.

## AI Usage

I used AI as a development assistant to:
- review the existing submission flow
- identify business rule gaps in the delete endpoint
- help structure the implementation plan
- sanity-check edge cases and the final PR write-up

All code changes were reviewed and verified manually in the local app before submission.
