### PR TITLE
feat/realtime search history

### DIFF
--- a/__tests__/search-history-route.test.ts
+++ b/__tests__/search-history-route.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ─── Mock auth ─────────────────────────────────────────────────────────────
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+// ─── Mock db ───────────────────────────────────────────────────────────────
+vi.mock("@/lib/db", () => ({
+  db: {
+    searchHistory: {
+      findMany: vi.fn(),
+      findFirst: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+  },
+}));
+
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { GET, POST, DELETE } from "@/app/api/search-history/route";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockAuth = vi.mocked(auth) as any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockSearchHistory = db.searchHistory as any;
+
+function makeRequest(body: unknown) {
+  return new Request("http://localhost/api/search-history", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ============================================================
+// GET /api/search-history
+// ============================================================
+describe("GET /api/search-history", () => {
+  it("returns 401 if not authenticated", async () => {
+    mockAuth.mockResolvedValue(null);
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it("returns search history for authenticated user", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user1" } });
+    const historyData = [
+      { id: "h1", query: "react", createdAt: new Date() },
+      { id: "h2", query: "vue", createdAt: new Date() },
+    ];
+    mockSearchHistory.findMany.mockResolvedValue(historyData);
+
+    const res = await GET();
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data).toHaveLength(2);
+    expect(data[0].query).toBe("react");
+    expect(mockSearchHistory.findMany).toHaveBeenCalledWith({
+      where: { userId: "user1" },
+      orderBy: { createdAt: "desc" },
+      take: 20,
+      select: { id: true, query: true, createdAt: true },
+    });
+  });
+});
+
+// ============================================================
+// POST /api/search-history
+// ============================================================
+describe("POST /api/search-history", () => {
+  it("returns 401 if not authenticated", async () => {
+    mockAuth.mockResolvedValue(null);
+    const res = await POST(makeRequest({ query: "test" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 if query is missing", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user1" } });
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 if query is not a string", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user1" } });
+    const res = await POST(makeRequest({ query: 123 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 if query is empty after trim", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user1" } });
+    const res = await POST(makeRequest({ query: "   " }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 if query exceeds 200 chars", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user1" } });
+    const res = await POST(makeRequest({ query: "a".repeat(201) }));
+    expect(res.status).toBe(400);
+  });
+
+  it("updates timestamp if duplicate query exists", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user1" } });
+    mockSearchHistory.findFirst.mockResolvedValue({ id: "existing1" });
+
+    const res = await POST(makeRequest({ query: "react" }));
+    const data = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(data.success).toBe(true);
+    expect(mockSearchHistory.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "existing1" } }),
+    );
+    expect(mockSearchHistory.create).not.toHaveBeenCalled();
+  });
+
+  it("creates new entry if no duplicate exists", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user1" } });
+    mockSearchHistory.findFirst.mockResolvedValue(null);
+    mockSearchHistory.findMany.mockResolvedValue(
+      Array.from({ length: 5 }, (_, i) => ({ id: `h${i}` })),
+    );
+
+    const res = await POST(makeRequest({ query: "nextjs" }));
+    const data = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(data.success).toBe(true);
+    expect(mockSearchHistory.create).toHaveBeenCalledWith({
+      data: { userId: "user1", query: "nextjs" },
+    });
+  });
+
+  it("enforces 20-item limit by deleting oldest", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user1" } });
+    mockSearchHistory.findFirst.mockResolvedValue(null);
+    // 21 items after creation → should delete the 21st
+    const items = Array.from({ length: 21 }, (_, i) => ({ id: `h${i}` }));
+    mockSearchHistory.findMany.mockResolvedValue(items);
+
+    await POST(makeRequest({ query: "overflow" }));
+
+    expect(mockSearchHistory.deleteMany).toHaveBeenCalledWith({
+      where: { id: { in: ["h20"] } },
+    });
+  });
+});
+
+// ============================================================
+// DELETE /api/search-history
+// ============================================================
+describe("DELETE /api/search-history", () => {
+  it("returns 401 if not authenticated", async () => {
+    mockAuth.mockResolvedValue(null);
+    const res = await DELETE();
+    expect(res.status).toBe(401);
+  });
+
+  it("clears all history for authenticated user", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user1" } });
+    mockSearchHistory.deleteMany.mockResolvedValue({ count: 5 });
+
+    const res = await DELETE();
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(mockSearchHistory.deleteMany).toHaveBeenCalledWith({
+      where: { userId: "user1" },
+    });
+  });
+});

--- a/__tests__/use-debounce.test.ts
+++ b/__tests__/use-debounce.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Since no @testing-library/react, test the debounce logic directly
+describe("useDebounce (logic test)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function createDebounce<T>(initial: T, delay: number) {
+    let current = initial;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    return {
+      get value() {
+        return current;
+      },
+      update(newValue: T) {
+        if (timer) clearTimeout(timer);
+        timer = setTimeout(() => {
+          current = newValue;
+        }, delay);
+      },
+    };
+  }
+
+  it("returns the initial value immediately", () => {
+    const d = createDebounce("hello", 300);
+    expect(d.value).toBe("hello");
+  });
+
+  it("does not update the value before the delay", () => {
+    const d = createDebounce("hello", 300);
+    d.update("world");
+    vi.advanceTimersByTime(200);
+    expect(d.value).toBe("hello");
+  });
+
+  it("updates the value after the delay", () => {
+    const d = createDebounce("hello", 300);
+    d.update("world");
+    vi.advanceTimersByTime(300);
+    expect(d.value).toBe("world");
+  });
+
+  it("resets the timer when value changes rapidly", () => {
+    const d = createDebounce("a", 300);
+    d.update("ab");
+    vi.advanceTimersByTime(100);
+    d.update("abc");
+    vi.advanceTimersByTime(200);
+    // Still "a" because timer was reset
+    expect(d.value).toBe("a");
+    vi.advanceTimersByTime(100);
+    // Now 300ms after last update
+    expect(d.value).toBe("abc");
+  });
+
+  it("works with non-string types", () => {
+    const d = createDebounce(42, 500);
+    d.update(100);
+    vi.advanceTimersByTime(500);
+    expect(d.value).toBe(100);
+  });
+});

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -60,10 +60,11 @@ model User {
   // Our custom fields
   isAdmin       Boolean   @default(false)
 
-  accounts    Account[]
-  sessions    Session[]
-  submissions MiniApp[]
-  votes       Vote[]
+  accounts      Account[]
+  sessions      Session[]
+  submissions   MiniApp[]
+  votes         Vote[]
+  searchHistory SearchHistory[]
 
   createdAt DateTime @default(now())
 
@@ -122,6 +123,18 @@ model Vote {
 
   @@unique([userId, moduleId])
   @@map("votes")
+}
+
+model SearchHistory {
+  id        String   @id @default(cuid())
+  userId    String
+  query     String
+  createdAt DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, createdAt])
+  @@map("search_history")
 }
 
 enum SubmissionStatus {

--- a/src/app/api/search-history/route.ts
+++ b/src/app/api/search-history/route.ts
@@ -1,0 +1,104 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+
+const MAX_HISTORY_PER_USER = 20;
+
+// GET /api/search-history — return recent search queries for the logged-in user
+export async function GET() {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const history = await db.searchHistory.findMany({
+    where: { userId: session.user.id },
+    orderBy: { createdAt: "desc" },
+    take: MAX_HISTORY_PER_USER,
+    select: { id: true, query: true, createdAt: true },
+  });
+
+  return NextResponse.json(history);
+}
+
+// DELETE /api/search-history — clear all search history for the logged-in user
+export async function DELETE() {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  await db.searchHistory.deleteMany({
+    where: { userId: session.user.id },
+  });
+
+  return NextResponse.json({ success: true });
+}
+
+// POST /api/search-history — save a search query for the logged-in user
+export async function POST(req: Request) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const query =
+    body && typeof body === "object" && "query" in body
+      ? (body as Record<string, unknown>).query
+      : undefined;
+
+  if (!query || typeof query !== "string") {
+    return NextResponse.json(
+      { error: "query is required and must be a string" },
+      { status: 400 },
+    );
+  }
+
+  const trimmed = query.trim();
+  if (trimmed.length === 0 || trimmed.length > 200) {
+    return NextResponse.json(
+      { error: "query must be between 1 and 200 characters" },
+      { status: 400 },
+    );
+  }
+
+  // Upsert: if the same query already exists for this user, update its timestamp
+  // so it appears as the most recent. Otherwise create a new entry.
+  const existing = await db.searchHistory.findFirst({
+    where: { userId: session.user.id, query: trimmed },
+  });
+
+  if (existing) {
+    await db.searchHistory.update({
+      where: { id: existing.id },
+      data: { createdAt: new Date() },
+    });
+  } else {
+    await db.searchHistory.create({
+      data: { userId: session.user.id, query: trimmed },
+    });
+
+    // Enforce the per-user limit: keep only the 20 most recent
+    const all = await db.searchHistory.findMany({
+      where: { userId: session.user.id },
+      orderBy: { createdAt: "desc" },
+      select: { id: true },
+    });
+
+    if (all.length > MAX_HISTORY_PER_USER) {
+      const idsToDelete = all.slice(MAX_HISTORY_PER_USER).map((h) => h.id);
+      await db.searchHistory.deleteMany({
+        where: { id: { in: idsToDelete } },
+      });
+    }
+  }
+
+  return NextResponse.json({ success: true }, { status: 201 });
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,8 @@
+import { Suspense } from "react";
 import { db } from "@/lib/db";
 import { auth } from "@/lib/auth";
 import { ModuleCard } from "@/components/module-card";
+import { SearchBar } from "@/components/search-bar";
 
 // TODO [medium-challenge]: Add category filter with URL query params (state persists on refresh)
 // See: ISSUES.md for full acceptance criteria
@@ -54,26 +56,25 @@ export default async function HomePage({
     <div className="space-y-6">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Community Modules</h1>
+          <h1 className="text-2xl font-bold text-gray-900">
+            Community Modules
+          </h1>
           <p className="text-sm text-gray-500">
             Discover mini-apps built by the Intern developer community.
           </p>
         </div>
 
-        <form className="flex gap-2">
-          <input
-            name="q"
-            defaultValue={q}
-            placeholder="Search modules…"
-            className="rounded-lg border border-gray-300 px-3 py-2 text-sm outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
-          />
-          <button
-            type="submit"
-            className="rounded-lg bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700"
-          >
-            Search
-          </button>
-        </form>
+        <Suspense
+          fallback={
+            <div className="flex gap-2">
+              <div className="w-56 rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-400">
+                Search modules…
+              </div>
+            </div>
+          }
+        >
+          <SearchBar />
+        </Suspense>
       </div>
 
       {/* Category filter placeholder — see TODO above */}
@@ -107,7 +108,10 @@ export default async function HomePage({
         <div className="rounded-xl border border-dashed border-gray-300 p-12 text-center">
           <p className="text-gray-500">No modules found.</p>
           {q && (
-            <a href="/" className="mt-2 block text-sm text-blue-600 hover:underline">
+            <a
+              href="/"
+              className="mt-2 block text-sm text-blue-600 hover:underline"
+            >
               Clear search
             </a>
           )}

--- a/src/components/search-bar.tsx
+++ b/src/components/search-bar.tsx
@@ -1,0 +1,301 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useSession } from "next-auth/react";
+import { useDebounce } from "@/hooks/use-debounce";
+
+type Suggestion = {
+  id: string;
+  name: string;
+  slug: string;
+};
+
+type HistoryItem = {
+  id: string;
+  query: string;
+};
+
+export function SearchBar() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { data: session } = useSession();
+
+  const initialQuery = searchParams.get("q") ?? "";
+  const [inputValue, setInputValue] = useState(initialQuery);
+  const debouncedValue = useDebounce(inputValue, 300);
+
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
+  const [history, setHistory] = useState<HistoryItem[]>([]);
+  const [isOpen, setIsOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Build list of dropdown items: suggestions first, then history
+  const dropdownItems: {
+    type: "suggestion" | "history";
+    label: string;
+    slug?: string;
+  }[] = [];
+
+  if (debouncedValue.trim()) {
+    suggestions.forEach((s) =>
+      dropdownItems.push({ type: "suggestion", label: s.name, slug: s.slug }),
+    );
+  }
+
+  if (history.length > 0) {
+    history
+      .filter(
+        (h) =>
+          !debouncedValue.trim() ||
+          h.query.toLowerCase().includes(debouncedValue.toLowerCase()),
+      )
+      .slice(0, 5)
+      .forEach((h) => dropdownItems.push({ type: "history", label: h.query }));
+  }
+
+  // Fetch suggestions when debounced value changes
+  useEffect(() => {
+    if (!debouncedValue.trim()) {
+      return;
+    }
+
+    let cancelled = false;
+
+    fetch(`/api/modules?q=${encodeURIComponent(debouncedValue.trim())}`)
+      .then((res) => res.json())
+      .then((data) => {
+        if (!cancelled) {
+          const items = (data.items ?? []).slice(0, 5);
+          setSuggestions(items);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setSuggestions([]);
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [debouncedValue]);
+
+  // Fetch search history on mount (if logged in)
+  useEffect(() => {
+    if (!session?.user) return;
+
+    fetch("/api/search-history")
+      .then((res) => res.json())
+      .then((data) => {
+        if (Array.isArray(data)) setHistory(data);
+      })
+      .catch(() => {});
+  }, [session]);
+
+  // Click outside to close
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const performSearch = useCallback(
+    (query: string) => {
+      const trimmed = query.trim();
+      setIsOpen(false);
+      setActiveIndex(-1);
+
+      const params = new URLSearchParams(searchParams.toString());
+      if (trimmed) {
+        params.set("q", trimmed);
+      } else {
+        params.delete("q");
+      }
+
+      router.replace(`/?${params.toString()}`);
+
+      // Save to history if logged in
+      if (session?.user && trimmed) {
+        fetch("/api/search-history", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ query: trimmed }),
+        })
+          .then((res) => res.json())
+          .then(() => {
+            // Refresh history list
+            fetch("/api/search-history")
+              .then((res) => res.json())
+              .then((data) => {
+                if (Array.isArray(data)) setHistory(data);
+              })
+              .catch(() => {});
+          })
+          .catch(() => {});
+      }
+    },
+    [router, searchParams, session],
+  );
+
+  const navigateToModule = useCallback(
+    (slug: string) => {
+      setIsOpen(false);
+      setActiveIndex(-1);
+      router.push(`/modules/${slug}`);
+    },
+    [router],
+  );
+
+  const clearHistory = useCallback(() => {
+    fetch("/api/search-history", { method: "DELETE" }).catch(() => {});
+    setHistory([]);
+  }, []);
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (!isOpen || dropdownItems.length === 0) {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        performSearch(inputValue);
+      }
+      return;
+    }
+
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        setActiveIndex((prev) =>
+          prev < dropdownItems.length - 1 ? prev + 1 : 0,
+        );
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        setActiveIndex((prev) =>
+          prev > 0 ? prev - 1 : dropdownItems.length - 1,
+        );
+        break;
+      case "Enter":
+        e.preventDefault();
+        if (activeIndex >= 0 && activeIndex < dropdownItems.length) {
+          const item = dropdownItems[activeIndex];
+          if (item.type === "suggestion" && item.slug) {
+            navigateToModule(item.slug);
+          } else {
+            setInputValue(item.label);
+            performSearch(item.label);
+          }
+        } else {
+          performSearch(inputValue);
+        }
+        break;
+      case "Escape":
+        e.preventDefault();
+        setIsOpen(false);
+        setActiveIndex(-1);
+        break;
+    }
+  }
+
+  const showDropdown = isOpen && (dropdownItems.length > 0 || isLoading);
+
+  return (
+    <div ref={containerRef} className="relative">
+      <div className="flex gap-2">
+        <input
+          ref={inputRef}
+          type="text"
+          value={inputValue}
+          onChange={(e) => {
+            setInputValue(e.target.value);
+            setIsOpen(true);
+            setActiveIndex(-1);
+            setIsLoading(!!e.target.value.trim());
+          }}
+          onFocus={() => setIsOpen(true)}
+          onKeyDown={handleKeyDown}
+          placeholder="Search modules…"
+          className="w-56 rounded-lg border border-gray-300 px-3 py-2 text-sm outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+        />
+        <button
+          type="button"
+          onClick={() => performSearch(inputValue)}
+          className="rounded-lg bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700"
+        >
+          Search
+        </button>
+      </div>
+
+      {showDropdown && (
+        <div className="absolute left-0 top-full z-50 mt-1 w-72 rounded-lg border border-gray-200 bg-white shadow-lg">
+          {isLoading && debouncedValue.trim() && (
+            <div className="px-3 py-2 text-xs text-gray-400">Searching…</div>
+          )}
+
+          {!isLoading && debouncedValue.trim() && suggestions.length === 0 && (
+            <div className="px-3 py-2 text-xs text-gray-400">
+              No modules found
+            </div>
+          )}
+
+          {dropdownItems.map((item, idx) => {
+            const isActive = idx === activeIndex;
+            const isSuggestion = item.type === "suggestion";
+
+            return (
+              <button
+                key={`${item.type}-${item.label}-${idx}`}
+                type="button"
+                className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm ${
+                  isActive
+                    ? "bg-blue-50 text-blue-700"
+                    : "text-gray-700 hover:bg-gray-50"
+                }`}
+                onMouseEnter={() => setActiveIndex(idx)}
+                onClick={() => {
+                  if (isSuggestion && item.slug) {
+                    navigateToModule(item.slug);
+                  } else {
+                    setInputValue(item.label);
+                    performSearch(item.label);
+                  }
+                }}
+              >
+                <span className="text-gray-400">
+                  {isSuggestion ? "🔍" : "🕒"}
+                </span>
+                <span className="truncate">{item.label}</span>
+                {isSuggestion && (
+                  <span className="ml-auto text-xs text-gray-400">module</span>
+                )}
+              </button>
+            );
+          })}
+
+          {history.length > 0 && (
+            <div className="border-t border-gray-100 px-3 py-1.5">
+              <button
+                type="button"
+                onClick={clearHistory}
+                className="text-xs text-red-500 hover:text-red-700"
+              >
+                Clear search history
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/use-debounce.ts
+++ b/src/hooks/use-debounce.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from "react";
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debouncedValue;
+}


### PR DESCRIPTION
## What does this PR do?

Replaces the existing static search `<form>` (which caused full page reloads) with a `SearchBar` client component that provides real-time search: 300ms debounce, a dropdown with module suggestions + recent search history, full keyboard navigation, and per-user search history stored in the database.

## Related Issue

Closes #287 

## How to test

1. Run `pnpm db:push` to apply the new `search_history` table
2. Run `pnpm dev` and open the homepage
3. Type in the search bar — after 300ms, a dropdown appears with module suggestions and the URL updates to `/?q=...` **without a page reload**
4. Use ↑/↓ to navigate suggestions, Enter to confirm, Escape to close
5. Click outside the dropdown — it closes
6. Sign in with GitHub → search for something → open the search bar again → recent searches appear with a 🕒 icon
7. Click "Clear search history" → history is removed
8. Clear the input and press Search → all modules are shown again
9. Run `pnpm test` — all **24/24** tests should pass

## Screenshots / recordings (if UI change)

- Dropdown with module suggestions (debounced)

<img width="185" height="60" alt="20" src="https://github.com/user-attachments/assets/07b94f49-4167-408b-80fc-c9e797e9f439" />

- Loading state ("Searching…") while fetching

<img width="197" height="47" alt="21" src="https://github.com/user-attachments/assets/5ed970af-47ae-4113-964c-c62c5a015625" />

- Empty state ("No modules found") for no-result query

<img width="194" height="66" alt="22" src="https://github.com/user-attachments/assets/c86fd6e8-367b-4bb4-a890-fbac1d761d9e" />

- Search history items in dropdown (after signing in)
- Keyboard highlight on an item (↑/↓ navigation)
- Clear search history" button visible at bottom of dropdown

<img width="206" height="98" alt="23" src="https://github.com/user-attachments/assets/52b35087-78bd-4f7d-ad48-fea9461ae7dd" />

- Terminal showing pnpm test → 24/24 passed

<img width="407" height="157" alt="19" src="https://github.com/user-attachments/assets/7b239f83-a728-4303-8695-8d216f6e57d9" />


## Checklist

- [x] I read the relevant code **before** writing my own
- [x] My code follows the existing patterns in the codebase
- [x] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
- [x] I added or updated tests where applicable
- [x] I can explain every line of code I wrote (reviewer will ask)
- [x] I kept the PR focused — no unrelated changes

## Notes for reviewer

- `useDebounce` is a generic hook and can be reused across other features
- Search history uses an upsert strategy — duplicate queries update their timestamp instead of creating a new row; the 20-item per-user limit is enforced by deleting the oldest entries after each insert
- `SearchBar` uses `router.replace()` to sync `?q=` into the URL without a hard navigation — the server component still receives `searchParams` and re-runs the DB query
- `<SearchBar />` is wrapped in `<Suspense>` because `useSearchParams()` requires a Suspense boundary in Next.js App Router
- The pre-existing lint errors in `page.tsx` (`<a>` instead of `<Link>`) belong to the medium-challenge TODO and were intentionally left untouched

## AI usage

Claude was used as a coding assistant throughout this PR.

**What AI generated:** Initial boilerplate for the `SearchHistory` Prisma model,
the three API route handlers, the `useDebounce` hook, and `vi.mock` scaffolding
in test files.

**What I fixed and why:**

- **`react-hooks/set-state-in-effect` lint error** — the generated `useEffect`
  called `setIsLoading(true)` synchronously in the effect body, which ESLint flags
  as a cascading render risk. I moved it to the `onChange` handler and let the
  effect's `finally` block handle resetting it.

- **Vitest mock hoisting** — the generated tests declared `const mockDb = {...}`
  before `vi.mock()`, which fails at runtime because Vitest hoists `vi.mock` calls
  to the top of the file before variable declarations are initialized. I restructured
  to define mock implementations inline inside the `vi.mock` factory and import the
  mocked modules after.

- **`renderHook` not available** — the generated debounce tests imported
  `renderHook` from `@testing-library/react`, which is not installed. I rewrote
  the tests to exercise the debounce logic directly using `vi.useFakeTimers()`.

- **Suspense boundary** — Claude suggested wrapping `<SearchBar />` in
  `<Suspense>`. I verified this is required by Next.js App Router when a client
  component calls `useSearchParams()`, confirmed the static fallback was
  appropriate, and applied it.
