### PR TITLE
feat: add in-app submission notifications

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -63,6 +63,7 @@ model User {
   accounts    Account[]
   sessions    Session[]
   submissions MiniApp[]
+  notifications Notification[]
   votes       Vote[]
 
   createdAt DateTime @default(now())
@@ -99,6 +100,7 @@ model MiniApp {
   authorId String
 
   votes     Vote[]
+  notifications Notification[]
   // Denormalized for read performance on the browse page.
   // DO NOT remove this field and replace with COUNT(*) without running EXPLAIN ANALYZE first.
   voteCount Int    @default(0)
@@ -107,6 +109,25 @@ model MiniApp {
   updatedAt DateTime @updatedAt
 
   @@map("mini_apps")
+}
+
+model Notification {
+  id       String           @id @default(cuid())
+  type     NotificationType
+  message  String
+  readAt   DateTime?
+
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId String
+
+  module   MiniApp? @relation(fields: [moduleId], references: [id], onDelete: SetNull)
+  moduleId String?
+
+  createdAt DateTime @default(now())
+
+  @@index([userId, readAt, createdAt])
+  @@index([userId, createdAt])
+  @@map("notifications")
 }
 
 model Vote {
@@ -128,4 +149,9 @@ enum SubmissionStatus {
   PENDING
   APPROVED
   REJECTED
+}
+
+enum NotificationType {
+  SUBMISSION_APPROVED
+  SUBMISSION_REJECTED
 }

--- a/src/app/api/modules/[id]/route.ts
+++ b/src/app/api/modules/[id]/route.ts
@@ -2,6 +2,10 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { adminReviewSchema } from "@/lib/validations";
+import {
+  getSubmissionStatusNotificationData,
+  isNotifiableSubmissionStatus,
+} from "@/lib/notifications";
 
 type Params = { params: Promise<{ id: string }> };
 
@@ -34,12 +38,37 @@ export async function PATCH(req: NextRequest, { params }: Params) {
     return NextResponse.json({ error: parsed.error.flatten() }, { status: 422 });
   }
 
-  const updated = await db.miniApp.update({
-    where: { id },
-    data: {
-      status: parsed.data.status,
-      feedback: parsed.data.feedback,
-    },
+  const existing = await db.miniApp.findUnique({ where: { id } });
+  if (!existing) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const shouldNotify =
+    existing.status !== parsed.data.status &&
+    isNotifiableSubmissionStatus(parsed.data.status);
+
+  const updated = await db.$transaction(async (tx) => {
+    const nextModule = await tx.miniApp.update({
+      where: { id },
+      data: {
+        status: parsed.data.status,
+        feedback: parsed.data.feedback,
+      },
+    });
+
+    if (shouldNotify) {
+      const notification = getSubmissionStatusNotificationData(parsed.data.status);
+      await tx.notification.create({
+        data: {
+          userId: existing.authorId,
+          moduleId: existing.id,
+          type: notification.type,
+          message: `${existing.name} was ${notification.verb}`,
+        },
+      });
+    }
+
+    return nextModule;
   });
 
   return NextResponse.json(updated);

--- a/src/app/api/notifications/[id]/route.ts
+++ b/src/app/api/notifications/[id]/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function PATCH(_req: Request, { params }: Params) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+  const notification = await db.notification.findUnique({ where: { id } });
+  if (!notification) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  if (notification.userId !== session.user.id) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  if (notification.readAt) {
+    return NextResponse.json(notification);
+  }
+
+  const updated = await db.notification.update({
+    where: { id },
+    data: { readAt: new Date() },
+  });
+
+  return NextResponse.json(updated);
+}

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+
+export async function GET(req: Request) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const limitParam = searchParams.get("limit");
+  const limit = Math.max(1, Math.min(Number(limitParam) || 20, 100));
+
+  const [items, unreadCount] = await Promise.all([
+    db.notification.findMany({
+      where: { userId: session.user.id },
+      include: {
+        module: {
+          select: { id: true, slug: true, name: true, status: true },
+        },
+      },
+      orderBy: { createdAt: "desc" },
+      take: limit,
+    }),
+    db.notification.count({
+      where: {
+        userId: session.user.id,
+        readAt: null,
+      },
+    }),
+  ]);
+
+  return NextResponse.json({ items, unreadCount });
+}
+
+export async function PATCH() {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const now = new Date();
+  const result = await db.notification.updateMany({
+    where: {
+      userId: session.user.id,
+      readAt: null,
+    },
+    data: { readAt: now },
+  });
+
+  return NextResponse.json({ updatedCount: result.count, readAt: now.toISOString() });
+}

--- a/src/app/notifications/page.tsx
+++ b/src/app/notifications/page.tsx
@@ -1,0 +1,32 @@
+import { redirect } from "next/navigation";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { NotificationsList } from "@/components/notifications-list";
+
+export default async function NotificationsPage() {
+  const session = await auth();
+  if (!session?.user) redirect("/api/auth/signin");
+
+  const notifications = await db.notification.findMany({
+    where: { userId: session.user.id },
+    include: {
+      module: {
+        select: { id: true, slug: true, name: true, status: true },
+      },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Notifications</h1>
+        <p className="text-sm text-gray-500">
+          Review status updates for your submissions.
+        </p>
+      </div>
+
+      <NotificationsList initialNotifications={notifications} />
+    </div>
+  );
+}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useSession, signIn, signOut } from "next-auth/react";
+import { NotificationLink } from "@/components/notification-link";
 
 export function Navbar() {
   const { data: session } = useSession();
@@ -22,6 +23,7 @@ export function Navbar() {
               <Link href="/my-submissions" className="text-sm text-gray-600 hover:text-gray-900">
                 My Submissions
               </Link>
+              <NotificationLink />
               {session.user.isAdmin && (
                 <Link href="/admin" className="text-sm font-medium text-orange-600 hover:text-orange-700">
                   Admin

--- a/src/components/notification-link.tsx
+++ b/src/components/notification-link.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+
+const NOTIFICATIONS_CHANGED_EVENT = "notifications:changed";
+
+export function NotificationLink() {
+  const [unreadCount, setUnreadCount] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function syncUnreadCount() {
+      try {
+        const response = await fetch("/api/notifications?limit=1", {
+          cache: "no-store",
+        });
+        if (!response.ok) return;
+
+        const data = (await response.json()) as { unreadCount?: number };
+        if (!cancelled) {
+          setUnreadCount(data.unreadCount ?? 0);
+        }
+      } catch {
+        // Keep the navbar resilient to temporary network errors.
+      }
+    }
+
+    const handleRefresh = () => {
+      void syncUnreadCount();
+    };
+
+    void syncUnreadCount();
+    window.addEventListener("focus", handleRefresh);
+    window.addEventListener(NOTIFICATIONS_CHANGED_EVENT, handleRefresh);
+
+    return () => {
+      cancelled = true;
+      window.removeEventListener("focus", handleRefresh);
+      window.removeEventListener(NOTIFICATIONS_CHANGED_EVENT, handleRefresh);
+    };
+  }, []);
+
+  return (
+    <Link href="/notifications" className="relative text-sm text-gray-600 hover:text-gray-900">
+      Notifications
+      {unreadCount > 0 && (
+        <span className="ml-1 inline-flex min-w-5 items-center justify-center rounded-full bg-red-600 px-1.5 py-0.5 text-[11px] font-semibold text-white">
+          {unreadCount > 99 ? "99+" : unreadCount}
+        </span>
+      )}
+    </Link>
+  );
+}

--- a/src/components/notifications-list.tsx
+++ b/src/components/notifications-list.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { formatRelativeTime } from "@/lib/utils";
+import type { UserNotification } from "@/types";
+
+const NOTIFICATIONS_CHANGED_EVENT = "notifications:changed";
+
+interface NotificationsListProps {
+  initialNotifications: UserNotification[];
+}
+
+export function NotificationsList({
+  initialNotifications,
+}: NotificationsListProps) {
+  const router = useRouter();
+  const [notifications, setNotifications] = useState(initialNotifications);
+  const [isMarkingAll, setIsMarkingAll] = useState(false);
+  const [pendingIds, setPendingIds] = useState<string[]>([]);
+
+  const unreadCount = notifications.filter(
+    (notification) => !notification.readAt
+  ).length;
+
+  async function markOneAsRead(id: string) {
+    const target = notifications.find((notification) => notification.id === id);
+    if (!target || target.readAt || pendingIds.includes(id)) return;
+
+    setPendingIds((current) => [...current, id]);
+
+    try {
+      const response = await fetch(`/api/notifications/${id}`, { method: "PATCH" });
+      if (!response.ok) return;
+
+      const readAt = new Date();
+      setNotifications((current) =>
+        current.map((notification) =>
+          notification.id === id ? { ...notification, readAt } : notification
+        )
+      );
+      window.dispatchEvent(new Event(NOTIFICATIONS_CHANGED_EVENT));
+      router.refresh();
+    } finally {
+      setPendingIds((current) => current.filter((pendingId) => pendingId !== id));
+    }
+  }
+
+  async function markAllAsRead() {
+    if (unreadCount === 0 || isMarkingAll) return;
+
+    setIsMarkingAll(true);
+
+    try {
+      const response = await fetch("/api/notifications", { method: "PATCH" });
+      if (!response.ok) return;
+
+      const readAt = new Date();
+      setNotifications((current) =>
+        current.map((notification) => ({
+          ...notification,
+          readAt: notification.readAt ?? readAt,
+        }))
+      );
+      window.dispatchEvent(new Event(NOTIFICATIONS_CHANGED_EVENT));
+      router.refresh();
+    } finally {
+      setIsMarkingAll(false);
+    }
+  }
+
+  if (notifications.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed border-gray-300 p-12 text-center">
+        <p className="text-gray-500">No notifications yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-gray-500">
+          {unreadCount} unread of {notifications.length} total
+        </p>
+        <button
+          type="button"
+          onClick={markAllAsRead}
+          disabled={unreadCount === 0 || isMarkingAll}
+          className="rounded-lg border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Mark all as read
+        </button>
+      </div>
+
+      <div className="space-y-3">
+        {notifications.map((notification) => {
+          const isPending = pendingIds.includes(notification.id);
+          const isUnread = !notification.readAt;
+
+          return (
+            <article
+              key={notification.id}
+              className={`rounded-xl border bg-white p-4 transition-colors ${
+                isUnread
+                  ? "border-blue-200 bg-blue-50/40"
+                  : "border-gray-200"
+              }`}
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div className="space-y-1">
+                  <p className="font-medium text-gray-900">{notification.message}</p>
+                  <p className="text-sm text-gray-500">
+                    {formatRelativeTime(new Date(notification.createdAt))}
+                  </p>
+                  {notification.module?.status === "APPROVED" && (
+                    <Link
+                      href={`/modules/${notification.module.slug}`}
+                      className="inline-block text-sm text-blue-600 hover:underline"
+                    >
+                      View module
+                    </Link>
+                  )}
+                </div>
+
+                <div className="flex items-center gap-2">
+                  {isUnread && (
+                    <span className="rounded-full bg-blue-600 px-2 py-0.5 text-[11px] font-semibold text-white">
+                      New
+                    </span>
+                  )}
+                  <button
+                    type="button"
+                    onClick={() => markOneAsRead(notification.id)}
+                    disabled={!isUnread || isPending}
+                    className="rounded-lg border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {isUnread ? "Mark read" : "Read"}
+                  </button>
+                </div>
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,0 +1,46 @@
+import type { NotificationType, SubmissionStatus } from "@prisma/client";
+import { db } from "@/lib/db";
+
+const statusNotificationMap: Record<
+  Extract<SubmissionStatus, "APPROVED" | "REJECTED">,
+  { type: NotificationType; verb: string }
+> = {
+  APPROVED: {
+    type: "SUBMISSION_APPROVED",
+    verb: "approved",
+  },
+  REJECTED: {
+    type: "SUBMISSION_REJECTED",
+    verb: "rejected",
+  },
+};
+
+export function isNotifiableSubmissionStatus(
+  status: SubmissionStatus
+): status is Extract<SubmissionStatus, "APPROVED" | "REJECTED"> {
+  return status === "APPROVED" || status === "REJECTED";
+}
+
+export function getSubmissionStatusNotificationData(
+  status: Extract<SubmissionStatus, "APPROVED" | "REJECTED">
+) {
+  return statusNotificationMap[status];
+}
+
+export async function createSubmissionStatusNotification(input: {
+  userId: string;
+  moduleId: string;
+  moduleName: string;
+  status: Extract<SubmissionStatus, "APPROVED" | "REJECTED">;
+}) {
+  const config = statusNotificationMap[input.status];
+
+  return db.notification.create({
+    data: {
+      userId: input.userId,
+      moduleId: input.moduleId,
+      type: config.type,
+      message: `${input.moduleName} was ${config.verb}`,
+    },
+  });
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,10 @@
-import type { MiniApp, Category, User, SubmissionStatus } from "@prisma/client";
+import type {
+  MiniApp,
+  Category,
+  User,
+  SubmissionStatus,
+  Notification,
+} from "@prisma/client";
 
 // "Module" is the UI-facing term for a MiniApp DB record.
 // The naming difference is intentional — keep it consistent.
@@ -10,5 +16,9 @@ export type Module = MiniApp & {
 };
 
 export type ModuleStatus = SubmissionStatus;
+
+export type UserNotification = Notification & {
+  module: Pick<MiniApp, "id" | "slug" | "name" | "status"> | null;
+};
 
 export type { Category, User };


### PR DESCRIPTION
## What does this PR do?

This PR implements the in-app notification system for submission review outcomes.

When a maintainer approves or rejects a submission, the author now receives a persisted in-app notification. Users can see an unread count in the navbar, open a notifications page, and mark notifications as read.

## Related Issue

Closes #291

<!-- Replace the line above with `Closes #<issue-number>` once the GitHub issue exists -->

## How to test

1. Run the app and database locally:
   - `docker compose up -d`
   - `pnpm install`
   - `pnpm db:push`
   - `pnpm db:seed`
   - `pnpm dev`
2. Sign in with a contributor account and create a new submission, or use an existing `PENDING` submission from seed data.
3. Sign in as an admin user and open `/admin`.
4. Approve or reject a pending submission.
5. Switch back to the submission author account.
6. Confirm a notification badge appears in the navbar.
7. Open `/notifications` and verify:
   - the new notification is listed
   - the message matches the review outcome
   - the timestamp is shown
8. Click `Mark read` on one notification and verify the unread badge updates.
9. Click `Mark all as read` and verify all unread notifications are cleared.
10. Refresh the page and confirm notifications persist across sessions.

## Screenshots / recordings (if UI change)

<img width="951" height="822" alt="image" src="https://github.com/user-attachments/assets/e7748b38-eaf3-41ae-9a45-59001bc72eb1" />

## Checklist

- [x] I read the relevant code **before** writing my own
- [x] My code follows the existing patterns in the codebase
- [ ] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
- [x] I added or updated tests where applicable
- [x] I can explain every line of code I wrote (reviewer will ask)
- [x] I kept the PR focused — no unrelated changes

## Notes for reviewer

## Notes for reviewer

- I reused the existing admin review flow in `PATCH /api/modules/[id]` instead of introducing a separate approval API.
- Notifications are stored in the database so they persist across sessions.
- The navbar unread count uses lightweight polling on page focus rather than websockets, which matches the issue scope.
- I added indexes to support the main notification access patterns:
  - listing notifications by user ordered by newest first
  - checking unread notifications for a specific user
- My goal with these indexes was to keep the common per-user reads efficient without overcomplicating the schema for the initial implementation.
- For larger scale, I would likely revisit this with cursor pagination, a more dedicated unread-count path, and possibly a partial index or caching layer for unread notifications if notification traffic becomes high.
- For the “10,000 users checking notifications simultaneously” case, this implementation should still work functionally, but it would put more read pressure on the database because the navbar count is fetched through API polling. At that scale, I would consider reducing polling frequency, separating unread count from full notification list queries, and introducing caching or a push-based strategy if needed.
- `pnpm typecheck`, `pnpm test`, and `pnpm build` passed locally.
- `pnpm lint` still reports existing repo issues outside the scope of this PR, so I did not include unrelated cleanup here.

## AI Usage

I used AI assistance during development for implementation support, explanation, and drafting parts of the PR description.

All code changes were reviewed, adapted, and verified locally by me, and I can explain the final implementation and trade-offs.
