### PR TITLE
feat/issue 250 module analytics view tracking

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -136,12 +136,17 @@ model ModuleView {
   module   MiniApp @relation(fields: [moduleId], references: [id], onDelete: Cascade)
   moduleId String
 
+  // SHA-256 hash of IP + User-Agent for anonymous dedup (never stores raw IP).
+  ipHash String?
+
   viewedAt DateTime @default(now())
 
   // Index for trending queries: count views in last 7 days per module.
   @@index([moduleId, viewedAt])
-  // Index for deduplication: one tracked view per user per module per day.
+  // Index for deduplication: logged-in users.
   @@index([userId, moduleId, viewedAt])
+  // Index for deduplication: anonymous visitors by IP fingerprint.
+  @@index([ipHash, moduleId, viewedAt])
   @@map("module_views")
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -64,6 +64,7 @@ model User {
   sessions    Session[]
   submissions MiniApp[]
   votes       Vote[]
+  moduleViews ModuleView[]
 
   createdAt DateTime @default(now())
 
@@ -99,9 +100,11 @@ model MiniApp {
   authorId String
 
   votes     Vote[]
+  views     ModuleView[]
   // Denormalized for read performance on the browse page.
   // DO NOT remove this field and replace with COUNT(*) without running EXPLAIN ANALYZE first.
   voteCount Int    @default(0)
+  viewCount Int    @default(0)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -122,6 +125,24 @@ model Vote {
 
   @@unique([userId, moduleId])
   @@map("votes")
+}
+
+model ModuleView {
+  id String @id @default(cuid())
+
+  user   User?   @relation(fields: [userId], references: [id])
+  userId String?
+
+  module   MiniApp @relation(fields: [moduleId], references: [id], onDelete: Cascade)
+  moduleId String
+
+  viewedAt DateTime @default(now())
+
+  // Index for trending queries: count views in last 7 days per module.
+  @@index([moduleId, viewedAt])
+  // Index for deduplication: one tracked view per user per module per day.
+  @@index([userId, moduleId, viewedAt])
+  @@map("module_views")
 }
 
 enum SubmissionStatus {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -70,6 +70,7 @@ async function main() {
       categoryId: categories.find((c) => c.slug === "productivity")!.id,
       authorId: contributor.id,
       voteCount: 24,
+      viewCount: 150,
     },
     {
       slug: "expense-tracker",
@@ -82,6 +83,7 @@ async function main() {
       categoryId: categories.find((c) => c.slug === "finance")!.id,
       authorId: contributor.id,
       voteCount: 18,
+      viewCount: 89,
     },
     {
       slug: "2048-game",
@@ -94,6 +96,7 @@ async function main() {
       categoryId: categories.find((c) => c.slug === "game")!.id,
       authorId: contributor.id,
       voteCount: 41,
+      viewCount: 312,
     },
   ];
 
@@ -139,6 +142,29 @@ async function main() {
       update: {},
       create: mod,
     });
+  }
+
+  // Seed demo module views (spread across last 7 days for trending demo)
+  const approvedApps = await prisma.miniApp.findMany({
+    where: { status: SubmissionStatus.APPROVED },
+    select: { id: true, slug: true },
+  });
+
+  for (const app of approvedApps) {
+    const existingViews = await prisma.moduleView.count({
+      where: { moduleId: app.id },
+    });
+    if (existingViews > 0) continue; // Skip if already seeded
+
+    const viewCount = app.slug === "2048-game" ? 15 : app.slug === "pomodoro-timer" ? 8 : 4;
+    const views = [];
+    for (let i = 0; i < viewCount; i++) {
+      const daysAgo = Math.floor(Math.random() * 7);
+      const viewedAt = new Date();
+      viewedAt.setDate(viewedAt.getDate() - daysAgo);
+      views.push({ moduleId: app.id, userId: contributor.id, viewedAt });
+    }
+    await prisma.moduleView.createMany({ data: views });
   }
 
   console.log("✅ Seed complete");

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -1,0 +1,21 @@
+import { redirect } from "next/navigation";
+import { auth } from "@/lib/auth";
+import { AnalyticsDashboard } from "@/components/analytics-dashboard";
+
+export default async function AdminAnalyticsPage() {
+  const session = await auth();
+  if (!session?.user?.isAdmin) redirect("/");
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Module Analytics</h1>
+        <p className="text-sm text-gray-500">
+          View tracking insights and engagement metrics across all modules.
+        </p>
+      </div>
+
+      <AnalyticsDashboard />
+    </div>
+  );
+}

--- a/src/app/api/admin/analytics/route.ts
+++ b/src/app/api/admin/analytics/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+
+// GET /api/admin/analytics — aggregate analytics for admin dashboard
+export async function GET() {
+  const session = await auth();
+  if (!session?.user?.isAdmin) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const now = new Date();
+  const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+  const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+
+  // Parallel queries for dashboard stats
+  const [
+    totalModules,
+    totalViews,
+    totalVotes,
+    views24h,
+    views7d,
+    topModules,
+    dailyViews,
+  ] = await Promise.all([
+    db.miniApp.count({ where: { status: "APPROVED" } }),
+    db.moduleView.count(),
+    db.vote.count(),
+    db.moduleView.count({ where: { viewedAt: { gte: oneDayAgo } } }),
+    db.moduleView.count({ where: { viewedAt: { gte: sevenDaysAgo } } }),
+
+    // Top 10 modules by views with vote-to-view ratio
+    db.miniApp.findMany({
+      where: { status: "APPROVED" },
+      select: {
+        id: true,
+        name: true,
+        slug: true,
+        voteCount: true,
+        viewCount: true,
+        _count: {
+          select: {
+            views: { where: { viewedAt: { gte: sevenDaysAgo } } },
+          },
+        },
+      },
+      orderBy: { viewCount: "desc" },
+      take: 10,
+    }),
+
+    // Views per day for last 7 days (raw SQL for date grouping)
+    db.$queryRaw<Array<{ day: string; count: bigint }>>`
+      SELECT
+        TO_CHAR("viewedAt", 'YYYY-MM-DD') AS day,
+        COUNT(*) AS count
+      FROM module_views
+      WHERE "viewedAt" >= ${sevenDaysAgo}
+      GROUP BY day
+      ORDER BY day ASC
+    `,
+  ]);
+
+  return NextResponse.json({
+    summary: {
+      totalModules,
+      totalViews,
+      totalVotes,
+      views24h,
+      views7d,
+    },
+    topModules: topModules.map((m) => ({
+      id: m.id,
+      name: m.name,
+      slug: m.slug,
+      voteCount: m.voteCount,
+      viewCount: m.viewCount,
+      views7d: m._count.views,
+      // Vote-to-view ratio: how engaging is this module?
+      engagementRate:
+        m.viewCount > 0
+          ? Math.round((m.voteCount / m.viewCount) * 10000) / 100
+          : 0,
+    })),
+    dailyViews: dailyViews.map((d) => ({
+      day: d.day,
+      count: Number(d.count),
+    })),
+  });
+}

--- a/src/app/api/modules/trending/route.ts
+++ b/src/app/api/modules/trending/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { auth } from "@/lib/auth";
+
+// GET /api/modules/trending — return top trending modules
+// Trending score = votes × 0.4 + views_7d × 0.3 + recency × 0.3
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const limit = Math.min(Number(searchParams.get("limit")) || 10, 50);
+
+  const sevenDaysAgo = new Date();
+  sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+
+  // Get approved modules with their 7-day view counts
+  const modules = await db.miniApp.findMany({
+    where: { status: "APPROVED" },
+    include: {
+      category: true,
+      author: { select: { id: true, name: true, image: true } },
+      _count: {
+        select: {
+          views: { where: { viewedAt: { gte: sevenDaysAgo } } },
+        },
+      },
+    },
+  });
+
+  // Calculate trending score for each module
+  const now = Date.now();
+  const maxAge = 30 * 24 * 60 * 60 * 1000; // 30 days in ms
+
+  const scored = modules.map((m) => {
+    const views7d = m._count.views;
+    const ageMs = now - m.createdAt.getTime();
+    // Recency: 1.0 for brand new, 0.0 for 30+ days old
+    const recency = Math.max(0, 1 - ageMs / maxAge);
+
+    const score = m.voteCount * 0.4 + views7d * 0.3 + recency * 0.3;
+
+    return { ...m, views7d, trendingScore: Math.round(score * 100) / 100 };
+  });
+
+  // Sort by trending score descending
+  scored.sort((a, b) => b.trendingScore - a.trendingScore);
+  const top = scored.slice(0, limit);
+
+  // Fetch voted status for current user
+  const session = await auth();
+  let votedIds = new Set<string>();
+  if (session?.user) {
+    const votes = await db.vote.findMany({
+      where: {
+        userId: session.user.id,
+        moduleId: { in: top.map((m) => m.id) },
+      },
+      select: { moduleId: true },
+    });
+    votedIds = new Set(votes.map((v) => v.moduleId));
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const items = top.map(({ _count, ...m }) => ({
+    ...m,
+    hasVoted: votedIds.has(m.id),
+  }));
+
+  return NextResponse.json({ items });
+}

--- a/src/app/api/modules/trending/route.ts
+++ b/src/app/api/modules/trending/route.ts
@@ -4,6 +4,7 @@ import { auth } from "@/lib/auth";
 
 // GET /api/modules/trending — return top trending modules
 // Trending score = votes × 0.4 + views_7d × 0.3 + recency × 0.3
+// Uses raw SQL to compute scores in the database instead of loading all rows into JS.
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
   const limit = Math.min(Number(searchParams.get("limit")) || 10, 50);
@@ -11,38 +12,62 @@ export async function GET(req: NextRequest) {
   const sevenDaysAgo = new Date();
   sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
 
-  // Get approved modules with their 7-day view counts
-  const modules = await db.miniApp.findMany({
-    where: { status: "APPROVED" },
-    include: {
-      category: true,
-      author: { select: { id: true, name: true, image: true } },
-      _count: {
-        select: {
-          views: { where: { viewedAt: { gte: sevenDaysAgo } } },
-        },
-      },
-    },
-  });
+  // Compute trending score entirely in PostgreSQL:
+  // - LEFT JOIN to count 7-day views per module (avoids loading all rows)
+  // - Recency: linear decay from 1.0 (new) to 0.0 (30+ days old)
+  // - Final score sorted and limited in DB — O(n log n) in DB vs O(n) memory in JS
+  const trending: Array<{
+    id: string;
+    slug: string;
+    name: string;
+    description: string;
+    repoUrl: string;
+    demoUrl: string | null;
+    voteCount: number;
+    viewCount: number;
+    createdAt: Date;
+    categoryId: string;
+    authorId: string;
+    views7d: bigint;
+    trendingScore: number;
+  }> = await db.$queryRaw`
+    SELECT
+      m.id, m.slug, m.name, m.description,
+      m."repoUrl", m."demoUrl",
+      m."voteCount", m."viewCount", m."createdAt",
+      m."categoryId", m."authorId",
+      COALESCE(v.cnt, 0) AS "views7d",
+      (
+        m."voteCount" * 0.4
+        + COALESCE(v.cnt, 0) * 0.3
+        + GREATEST(0, 1.0 - EXTRACT(EPOCH FROM (NOW() - m."createdAt")) / ${30 * 24 * 3600}) * 0.3
+      ) AS "trendingScore"
+    FROM mini_apps m
+    LEFT JOIN (
+      SELECT "moduleId", COUNT(*)::int AS cnt
+      FROM module_views
+      WHERE "viewedAt" >= ${sevenDaysAgo}
+      GROUP BY "moduleId"
+    ) v ON v."moduleId" = m.id
+    WHERE m.status = 'APPROVED'
+    ORDER BY "trendingScore" DESC
+    LIMIT ${limit}
+  `;
 
-  // Calculate trending score for each module
-  const now = Date.now();
-  const maxAge = 30 * 24 * 60 * 60 * 1000; // 30 days in ms
+  // Batch-fetch related category + author to avoid N+1
+  const categoryIds = [...new Set(trending.map((m) => m.categoryId))];
+  const authorIds = [...new Set(trending.map((m) => m.authorId))];
 
-  const scored = modules.map((m) => {
-    const views7d = m._count.views;
-    const ageMs = now - m.createdAt.getTime();
-    // Recency: 1.0 for brand new, 0.0 for 30+ days old
-    const recency = Math.max(0, 1 - ageMs / maxAge);
+  const [categories, authors] = await Promise.all([
+    db.category.findMany({ where: { id: { in: categoryIds } } }),
+    db.user.findMany({
+      where: { id: { in: authorIds } },
+      select: { id: true, name: true, image: true },
+    }),
+  ]);
 
-    const score = m.voteCount * 0.4 + views7d * 0.3 + recency * 0.3;
-
-    return { ...m, views7d, trendingScore: Math.round(score * 100) / 100 };
-  });
-
-  // Sort by trending score descending
-  scored.sort((a, b) => b.trendingScore - a.trendingScore);
-  const top = scored.slice(0, limit);
+  const categoryMap = new Map(categories.map((c) => [c.id, c]));
+  const authorMap = new Map(authors.map((a) => [a.id, a]));
 
   // Fetch voted status for current user
   const session = await auth();
@@ -51,16 +76,27 @@ export async function GET(req: NextRequest) {
     const votes = await db.vote.findMany({
       where: {
         userId: session.user.id,
-        moduleId: { in: top.map((m) => m.id) },
+        moduleId: { in: trending.map((m) => m.id) },
       },
       select: { moduleId: true },
     });
     votedIds = new Set(votes.map((v) => v.moduleId));
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const items = top.map(({ _count, ...m }) => ({
-    ...m,
+  const items = trending.map((m) => ({
+    id: m.id,
+    slug: m.slug,
+    name: m.name,
+    description: m.description,
+    repoUrl: m.repoUrl,
+    demoUrl: m.demoUrl,
+    voteCount: m.voteCount,
+    viewCount: m.viewCount,
+    createdAt: m.createdAt,
+    views7d: Number(m.views7d),
+    trendingScore: Math.round(Number(m.trendingScore) * 100) / 100,
+    category: categoryMap.get(m.categoryId)!,
+    author: authorMap.get(m.authorId)!,
     hasVoted: votedIds.has(m.id),
   }));
 

--- a/src/app/api/views/route.ts
+++ b/src/app/api/views/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+
+// POST /api/views — record a module page view
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const { moduleId } = body;
+
+  if (!moduleId || typeof moduleId !== "string") {
+    return NextResponse.json(
+      { error: "moduleId is required" },
+      { status: 400 },
+    );
+  }
+
+  // Verify module exists and is approved
+  const miniApp = await db.miniApp.findUnique({
+    where: { id: moduleId, status: "APPROVED" },
+    select: { id: true },
+  });
+
+  if (!miniApp) {
+    return NextResponse.json({ error: "Module not found" }, { status: 404 });
+  }
+
+  const session = await auth();
+  const userId = session?.user?.id ?? null;
+
+  // Deduplicate: one tracked view per user per module per day (logged-in users only)
+  if (userId) {
+    const startOfDay = new Date();
+    startOfDay.setHours(0, 0, 0, 0);
+
+    const existing = await db.moduleView.findFirst({
+      where: {
+        userId,
+        moduleId,
+        viewedAt: { gte: startOfDay },
+      },
+    });
+
+    if (existing) {
+      return NextResponse.json({
+        tracked: false,
+        reason: "already_viewed_today",
+      });
+    }
+  }
+
+  // Record view and increment denormalized counter atomically
+  await db.$transaction([
+    db.moduleView.create({
+      data: { userId, moduleId },
+    }),
+    db.miniApp.update({
+      where: { id: moduleId },
+      data: { viewCount: { increment: 1 } },
+    }),
+  ]);
+
+  return NextResponse.json({ tracked: true });
+}

--- a/src/app/api/views/route.ts
+++ b/src/app/api/views/route.ts
@@ -2,6 +2,18 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 
+/**
+ * Create a SHA-256 hash of the visitor's IP + User-Agent.
+ * This fingerprint is used to deduplicate anonymous views without storing PII.
+ */
+async function hashFingerprint(ip: string, ua: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(`${ip}:${ua}`);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
 // POST /api/views — record a module page view
 export async function POST(req: NextRequest) {
   const body = await req.json();
@@ -27,11 +39,11 @@ export async function POST(req: NextRequest) {
   const session = await auth();
   const userId = session?.user?.id ?? null;
 
-  // Deduplicate: one tracked view per user per module per day (logged-in users only)
-  if (userId) {
-    const startOfDay = new Date();
-    startOfDay.setHours(0, 0, 0, 0);
+  const startOfDay = new Date();
+  startOfDay.setHours(0, 0, 0, 0);
 
+  // Deduplicate: one tracked view per user per module per day (logged-in users)
+  if (userId) {
     const existing = await db.moduleView.findFirst({
       where: {
         userId,
@@ -48,10 +60,34 @@ export async function POST(req: NextRequest) {
     }
   }
 
+  // Deduplicate anonymous visitors by IP fingerprint (hashed, no raw IP stored)
+  let ipHash: string | null = null;
+  if (!userId) {
+    const forwarded = req.headers.get("x-forwarded-for");
+    const ip = forwarded?.split(",")[0]?.trim() ?? "unknown";
+    const ua = req.headers.get("user-agent") ?? "unknown";
+    ipHash = await hashFingerprint(ip, ua);
+
+    const existing = await db.moduleView.findFirst({
+      where: {
+        ipHash,
+        moduleId,
+        viewedAt: { gte: startOfDay },
+      },
+    });
+
+    if (existing) {
+      return NextResponse.json({
+        tracked: false,
+        reason: "already_viewed_today",
+      });
+    }
+  }
+
   // Record view and increment denormalized counter atomically
   await db.$transaction([
     db.moduleView.create({
-      data: { userId, moduleId },
+      data: { userId, moduleId, ipHash },
     }),
     db.miniApp.update({
       where: { id: moduleId },

--- a/src/app/modules/[slug]/page.tsx
+++ b/src/app/modules/[slug]/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { db } from "@/lib/db";
 import { auth } from "@/lib/auth";
 import { VoteButton } from "@/components/vote-button";
+import { ViewTracker } from "@/components/view-tracker";
 
 type Props = { params: Promise<{ slug: string }> };
 
@@ -42,6 +43,8 @@ export default async function ModuleDetailPage({ params }: Props) {
         ← Back to modules
       </Link>
 
+      <ViewTracker moduleId={module.id} />
+
       <div className="space-y-2">
         <div className="flex items-start justify-between gap-4">
           <h1 className="text-2xl font-bold text-gray-900">{module.name}</h1>
@@ -52,7 +55,8 @@ export default async function ModuleDetailPage({ params }: Props) {
           />
         </div>
         <p className="text-sm text-gray-500">
-          by {module.author.name} · {module.category.name}
+          by {module.author.name} · {module.category.name} ·{" "}
+          {module.viewCount} {module.viewCount === 1 ? "view" : "views"}
         </p>
       </div>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { db } from "@/lib/db";
 import { auth } from "@/lib/auth";
 import { ModuleCard } from "@/components/module-card";
+import { TrendingModules } from "@/components/trending-modules";
 
 // TODO [medium-challenge]: Add category filter with URL query params (state persists on refresh)
 // See: ISSUES.md for full acceptance criteria
@@ -31,7 +32,7 @@ export default async function HomePage({
       category: true,
       author: { select: { id: true, name: true, image: true } },
     },
-    orderBy: sort === "views" ? { viewCount: "desc" } : { voteCount: "desc" },
+    orderBy: { voteCount: "desc" },
     take: 12,
   });
 
@@ -111,7 +112,7 @@ export default async function HomePage({
         <a
           href={`/?${new URLSearchParams({ ...(q ? { q } : {}), ...(category ? { category } : {}) }).toString()}`}
           className={`rounded-full px-3 py-1 font-medium transition-colors ${
-            sort !== "views"
+            !sort
               ? "bg-gray-800 text-white"
               : "bg-gray-100 text-gray-600 hover:bg-gray-200"
           }`}
@@ -119,18 +120,20 @@ export default async function HomePage({
           Most Voted
         </a>
         <a
-          href={`/?${new URLSearchParams({ ...(q ? { q } : {}), ...(category ? { category } : {}), sort: "views" }).toString()}`}
+          href={`/?${new URLSearchParams({ ...(q ? { q } : {}), ...(category ? { category } : {}), sort: "trending" }).toString()}`}
           className={`rounded-full px-3 py-1 font-medium transition-colors ${
-            sort === "views"
+            sort === "trending"
               ? "bg-gray-800 text-white"
               : "bg-gray-100 text-gray-600 hover:bg-gray-200"
           }`}
         >
-          Most Viewed
+          🔥 Trending
         </a>
       </div>
 
-      {modules.length === 0 ? (
+      {sort === "trending" ? (
+        <TrendingModules />
+      ) : modules.length === 0 ? (
         <div className="rounded-xl border border-dashed border-gray-300 p-12 text-center">
           <p className="text-gray-500">No modules found.</p>
           {q && (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,9 +8,9 @@ import { ModuleCard } from "@/components/module-card";
 export default async function HomePage({
   searchParams,
 }: {
-  searchParams: Promise<{ q?: string; category?: string }>;
+  searchParams: Promise<{ q?: string; category?: string; sort?: string }>;
 }) {
-  const { q, category } = await searchParams;
+  const { q, category, sort } = await searchParams;
   const session = await auth();
 
   const modules = await db.miniApp.findMany({
@@ -31,7 +31,7 @@ export default async function HomePage({
       category: true,
       author: { select: { id: true, name: true, image: true } },
     },
-    orderBy: { voteCount: "desc" },
+    orderBy: sort === "views" ? { viewCount: "desc" } : { voteCount: "desc" },
     take: 12,
   });
 
@@ -54,7 +54,9 @@ export default async function HomePage({
     <div className="space-y-6">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Community Modules</h1>
+          <h1 className="text-2xl font-bold text-gray-900">
+            Community Modules
+          </h1>
           <p className="text-sm text-gray-500">
             Discover mini-apps built by the Intern developer community.
           </p>
@@ -103,11 +105,39 @@ export default async function HomePage({
         ))}
       </div>
 
+      {/* Sort toggle */}
+      <div className="flex items-center gap-2 text-xs">
+        <span className="text-gray-500">Sort by:</span>
+        <a
+          href={`/?${new URLSearchParams({ ...(q ? { q } : {}), ...(category ? { category } : {}) }).toString()}`}
+          className={`rounded-full px-3 py-1 font-medium transition-colors ${
+            sort !== "views"
+              ? "bg-gray-800 text-white"
+              : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+          }`}
+        >
+          Most Voted
+        </a>
+        <a
+          href={`/?${new URLSearchParams({ ...(q ? { q } : {}), ...(category ? { category } : {}), sort: "views" }).toString()}`}
+          className={`rounded-full px-3 py-1 font-medium transition-colors ${
+            sort === "views"
+              ? "bg-gray-800 text-white"
+              : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+          }`}
+        >
+          Most Viewed
+        </a>
+      </div>
+
       {modules.length === 0 ? (
         <div className="rounded-xl border border-dashed border-gray-300 p-12 text-center">
           <p className="text-gray-500">No modules found.</p>
           {q && (
-            <a href="/" className="mt-2 block text-sm text-blue-600 hover:underline">
+            <a
+              href="/"
+              className="mt-2 block text-sm text-blue-600 hover:underline"
+            >
               Clear search
             </a>
           )}

--- a/src/components/analytics-dashboard.tsx
+++ b/src/components/analytics-dashboard.tsx
@@ -69,7 +69,7 @@ export function AnalyticsDashboard() {
 
       {/* Daily views bar chart */}
       <section className="rounded-xl border border-gray-200 bg-white p-6">
-        <h2 className="mb-4 text-sm font-semibold text-gray-700">
+        <h2 className="mb-4 text-sm font-semibold text-gray-900">
           Views — Last 7 Days
         </h2>
         {data.dailyViews.length === 0 ? (
@@ -78,7 +78,7 @@ export function AnalyticsDashboard() {
           <div className="flex items-end gap-2" style={{ height: 160 }}>
             {data.dailyViews.map((d) => (
               <div key={d.day} className="flex flex-1 flex-col items-center">
-                <span className="mb-1 text-xs font-medium text-gray-600">
+                <span className="mb-1 text-xs font-semibold text-gray-800">
                   {d.count}
                 </span>
                 <div
@@ -88,7 +88,7 @@ export function AnalyticsDashboard() {
                     minHeight: d.count > 0 ? 4 : 0,
                   }}
                 />
-                <span className="mt-1 text-[10px] text-gray-400">
+                <span className="mt-1 text-xs text-gray-600">
                   {d.day.slice(5)}
                 </span>
               </div>
@@ -99,19 +99,19 @@ export function AnalyticsDashboard() {
 
       {/* Top modules table */}
       <section className="rounded-xl border border-gray-200 bg-white p-6">
-        <h2 className="mb-4 text-sm font-semibold text-gray-700">
+        <h2 className="mb-4 text-sm font-semibold text-gray-900">
           Top Modules by Views
         </h2>
         <div className="overflow-x-auto">
-          <table className="w-full text-left text-sm">
+          <table className="w-full text-left text-sm text-gray-900">
             <thead>
-              <tr className="border-b border-gray-100 text-xs text-gray-500">
-                <th className="pb-2 font-medium">#</th>
-                <th className="pb-2 font-medium">Module</th>
-                <th className="pb-2 text-right font-medium">Views</th>
-                <th className="pb-2 text-right font-medium">7d Views</th>
-                <th className="pb-2 text-right font-medium">Votes</th>
-                <th className="pb-2 text-right font-medium">Engagement</th>
+              <tr className="border-b border-gray-200 text-xs text-gray-900">
+                <th className="pb-2 font-semibold">#</th>
+                <th className="pb-2 font-semibold">Module</th>
+                <th className="pb-2 text-right font-semibold">Views</th>
+                <th className="pb-2 text-right font-semibold">7d Views</th>
+                <th className="pb-2 text-right font-semibold">Votes</th>
+                <th className="pb-2 text-right font-semibold">Engagement</th>
               </tr>
             </thead>
             <tbody>
@@ -120,13 +120,15 @@ export function AnalyticsDashboard() {
                   key={m.id}
                   className="border-b border-gray-50 last:border-0"
                 >
-                  <td className="py-2 text-gray-400">{i + 1}</td>
-                  <td className="py-2 font-medium text-gray-800">{m.name}</td>
-                  <td className="py-2 text-right tabular-nums">
+                  <td className="py-2 font-medium text-gray-700">{i + 1}</td>
+                  <td className="py-2 font-semibold text-gray-900">{m.name}</td>
+                  <td className="py-2 text-right font-medium tabular-nums text-gray-900">
                     {m.viewCount}
                   </td>
-                  <td className="py-2 text-right tabular-nums">{m.views7d}</td>
-                  <td className="py-2 text-right tabular-nums">
+                  <td className="py-2 text-right font-medium tabular-nums text-gray-900">
+                    {m.views7d}
+                  </td>
+                  <td className="py-2 text-right font-medium tabular-nums text-gray-900">
                     {m.voteCount}
                   </td>
                   <td className="py-2 text-right">
@@ -167,7 +169,7 @@ function StatCard({
         highlight ? "border-blue-200 bg-blue-50" : "border-gray-200 bg-white"
       }`}
     >
-      <p className="text-xs text-gray-500">{label}</p>
+      <p className="text-xs font-medium text-gray-700">{label}</p>
       <p className="mt-1 text-2xl font-bold tabular-nums text-gray-900">
         {value.toLocaleString()}
       </p>

--- a/src/components/analytics-dashboard.tsx
+++ b/src/components/analytics-dashboard.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface Analytics {
+  summary: {
+    totalModules: number;
+    totalViews: number;
+    totalVotes: number;
+    views24h: number;
+    views7d: number;
+  };
+  topModules: Array<{
+    id: string;
+    name: string;
+    slug: string;
+    voteCount: number;
+    viewCount: number;
+    views7d: number;
+    engagementRate: number;
+  }>;
+  dailyViews: Array<{ day: string; count: number }>;
+}
+
+export function AnalyticsDashboard() {
+  const [data, setData] = useState<Analytics | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch("/api/admin/analytics")
+      .then((res) => {
+        if (!res.ok) throw new Error("Failed to load analytics");
+        return res.json();
+      })
+      .then(setData)
+      .catch((e) => setError(e.message));
+  }, []);
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+        {error}
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="space-y-4">
+        {[...Array(3)].map((_, i) => (
+          <div key={i} className="h-24 animate-pulse rounded-lg bg-gray-200" />
+        ))}
+      </div>
+    );
+  }
+
+  const maxDailyCount = Math.max(...data.dailyViews.map((d) => d.count), 1);
+
+  return (
+    <div className="space-y-8">
+      {/* Summary cards */}
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-5">
+        <StatCard label="Total Modules" value={data.summary.totalModules} />
+        <StatCard label="Total Views" value={data.summary.totalViews} />
+        <StatCard label="Total Votes" value={data.summary.totalVotes} />
+        <StatCard label="Views (24h)" value={data.summary.views24h} highlight />
+        <StatCard label="Views (7d)" value={data.summary.views7d} highlight />
+      </div>
+
+      {/* Daily views bar chart */}
+      <section className="rounded-xl border border-gray-200 bg-white p-6">
+        <h2 className="mb-4 text-sm font-semibold text-gray-700">
+          Views — Last 7 Days
+        </h2>
+        {data.dailyViews.length === 0 ? (
+          <p className="text-sm text-gray-400">No view data yet.</p>
+        ) : (
+          <div className="flex items-end gap-2" style={{ height: 160 }}>
+            {data.dailyViews.map((d) => (
+              <div key={d.day} className="flex flex-1 flex-col items-center">
+                <span className="mb-1 text-xs font-medium text-gray-600">
+                  {d.count}
+                </span>
+                <div
+                  className="w-full rounded-t bg-blue-500 transition-all"
+                  style={{
+                    height: `${(d.count / maxDailyCount) * 120}px`,
+                    minHeight: d.count > 0 ? 4 : 0,
+                  }}
+                />
+                <span className="mt-1 text-[10px] text-gray-400">
+                  {d.day.slice(5)}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Top modules table */}
+      <section className="rounded-xl border border-gray-200 bg-white p-6">
+        <h2 className="mb-4 text-sm font-semibold text-gray-700">
+          Top Modules by Views
+        </h2>
+        <div className="overflow-x-auto">
+          <table className="w-full text-left text-sm">
+            <thead>
+              <tr className="border-b border-gray-100 text-xs text-gray-500">
+                <th className="pb-2 font-medium">#</th>
+                <th className="pb-2 font-medium">Module</th>
+                <th className="pb-2 text-right font-medium">Views</th>
+                <th className="pb-2 text-right font-medium">7d Views</th>
+                <th className="pb-2 text-right font-medium">Votes</th>
+                <th className="pb-2 text-right font-medium">Engagement</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.topModules.map((m, i) => (
+                <tr
+                  key={m.id}
+                  className="border-b border-gray-50 last:border-0"
+                >
+                  <td className="py-2 text-gray-400">{i + 1}</td>
+                  <td className="py-2 font-medium text-gray-800">{m.name}</td>
+                  <td className="py-2 text-right tabular-nums">
+                    {m.viewCount}
+                  </td>
+                  <td className="py-2 text-right tabular-nums">{m.views7d}</td>
+                  <td className="py-2 text-right tabular-nums">
+                    {m.voteCount}
+                  </td>
+                  <td className="py-2 text-right">
+                    <span
+                      className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                        m.engagementRate >= 20
+                          ? "bg-green-50 text-green-700"
+                          : m.engagementRate >= 10
+                            ? "bg-yellow-50 text-yellow-700"
+                            : "bg-gray-50 text-gray-500"
+                      }`}
+                    >
+                      {m.engagementRate}%
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  highlight = false,
+}: {
+  label: string;
+  value: number;
+  highlight?: boolean;
+}) {
+  return (
+    <div
+      className={`rounded-xl border p-4 ${
+        highlight ? "border-blue-200 bg-blue-50" : "border-gray-200 bg-white"
+      }`}
+    >
+      <p className="text-xs text-gray-500">{label}</p>
+      <p className="mt-1 text-2xl font-bold tabular-nums text-gray-900">
+        {value.toLocaleString()}
+      </p>
+    </div>
+  );
+}

--- a/src/components/module-card.tsx
+++ b/src/components/module-card.tsx
@@ -33,9 +33,14 @@ export function ModuleCard({ module, hasVoted = false }: ModuleCardProps) {
       <p className="line-clamp-2 text-sm text-gray-600">{module.description}</p>
 
       <div className="mt-auto flex items-center justify-between">
-        <span className="rounded-full bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-700">
-          {module.category.name}
-        </span>
+        <div className="flex items-center gap-2">
+          <span className="rounded-full bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-700">
+            {module.category.name}
+          </span>
+          <span className="text-xs text-gray-400" title="Views">
+            👁 {module.viewCount}
+          </span>
+        </div>
 
         <VoteButton
           moduleId={module.id}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -16,16 +16,33 @@ export function Navbar() {
         <div className="flex items-center gap-4">
           {session ? (
             <>
-              <Link href="/submit" className="text-sm text-gray-600 hover:text-gray-900">
+              <Link
+                href="/submit"
+                className="text-sm text-gray-600 hover:text-gray-900"
+              >
                 Submit Module
               </Link>
-              <Link href="/my-submissions" className="text-sm text-gray-600 hover:text-gray-900">
+              <Link
+                href="/my-submissions"
+                className="text-sm text-gray-600 hover:text-gray-900"
+              >
                 My Submissions
               </Link>
               {session.user.isAdmin && (
-                <Link href="/admin" className="text-sm font-medium text-orange-600 hover:text-orange-700">
-                  Admin
-                </Link>
+                <>
+                  <Link
+                    href="/admin"
+                    className="text-sm font-medium text-orange-600 hover:text-orange-700"
+                  >
+                    Admin
+                  </Link>
+                  <Link
+                    href="/admin/analytics"
+                    className="text-sm font-medium text-orange-600 hover:text-orange-700"
+                  >
+                    Analytics
+                  </Link>
+                </>
               )}
               <button
                 onClick={() => signOut()}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -38,7 +38,7 @@ export function Navbar() {
                   </Link>
                   <Link
                     href="/admin/analytics"
-                    className="text-sm font-medium text-orange-600 hover:text-orange-700"
+                    className="text-sm text-gray-600 hover:text-gray-900"
                   >
                     Analytics
                   </Link>

--- a/src/components/trending-modules.tsx
+++ b/src/components/trending-modules.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ModuleCard } from "@/components/module-card";
+import type { Module } from "@/types";
+
+type TrendingModule = Module & {
+  views7d: number;
+  trendingScore: number;
+};
+
+export function TrendingModules() {
+  const [modules, setModules] = useState<TrendingModule[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch("/api/modules/trending?limit=12")
+      .then((res) => res.json())
+      .then((data) => setModules(data.items ?? []))
+      .catch(() => setModules([]))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {[...Array(6)].map((_, i) => (
+          <div key={i} className="h-40 animate-pulse rounded-xl bg-gray-200" />
+        ))}
+      </div>
+    );
+  }
+
+  if (modules.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed border-gray-300 p-12 text-center">
+        <p className="text-gray-500">No trending modules yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {modules.map((m) => (
+        <ModuleCard key={m.id} module={m} hasVoted={m.hasVoted ?? false} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/view-tracker.tsx
+++ b/src/components/view-tracker.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+interface ViewTrackerProps {
+  moduleId: string;
+}
+
+/**
+ * Fires a single POST /api/views on mount to record a page view.
+ * Uses a ref guard to prevent double-firing in React StrictMode.
+ */
+export function ViewTracker({ moduleId }: ViewTrackerProps) {
+  const hasFired = useRef(false);
+
+  useEffect(() => {
+    if (hasFired.current) return;
+    hasFired.current = true;
+
+    fetch("/api/views", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ moduleId }),
+    }).catch(() => {
+      // Silently ignore — view tracking is non-critical
+    });
+  }, [moduleId]);
+
+  return null;
+}


### PR DESCRIPTION
## What does this PR do?

Implements a complete Module Analytics system: view tracking with anonymous deduplication (SHA-256 IP fingerprint), a trending algorithm computed in PostgreSQL via raw SQL, an admin analytics dashboard with data visualization, and a homepage trending tab. Closes the gap between vote-only popularity signals and actual engagement metrics.

## Related Issue

Closes #250

## How I implemented it

1. **Database design**: Added `ModuleView` model with nullable `userId` (for anonymous visitors) and `ipHash` (SHA-256 fingerprint). Added 3 indexes targeting the exact query patterns: trending aggregation, logged-in dedup, and anonymous dedup. Added denormalized `viewCount` on `MiniApp` following the existing `voteCount` pattern.

2. **View tracking API** (`POST /api/views`): Validates moduleId + checks APPROVED status. Two dedup paths:
   - Logged-in users: query `[userId, moduleId, viewedAt >= startOfDay]`
   - Anonymous: hash `IP:UserAgent` with `crypto.subtle.digest("SHA-256")`, query `[ipHash, moduleId, viewedAt >= startOfDay]`
   - Both paths end in `db.$transaction` to atomically create view + increment counter

3. **Trending API** (`GET /api/modules/trending`): Prisma's query builder can't express `LEFT JOIN + EXTRACT(EPOCH) + weighted formula`, so I used `db.$queryRaw` with tagged template literals (parameterized — no SQL injection). Weighted score: `votes × 0.4 + views_7d × 0.3 + recency × 0.3`. Batch-fetches categories + authors with `findMany({ where: { id: { in: [...] } } })` to avoid N+1.

4. **Admin analytics** (`/admin/analytics`): Server component checks `isAdmin` → redirects if not. Client component fetches `/api/admin/analytics` which runs 7 parallel queries via `Promise.all`. Bar chart is pure CSS (dynamic `height` style, normalized to max value). No external charting library.

5. **Homepage trending tab**: Added `TrendingModules` client component that fetches `/api/modules/trending?limit=12`. Sort toggle switches between "Most Voted" (server-rendered) and "🔥 Trending" (client-fetched).

## How to test

1. `pnpm db:push && pnpm prisma generate && pnpm db:seed`
2. `pnpm dev` → open `http://localhost:3000`

**View Tracking:**
3. Click any module → view count increments (visible on detail page subtitle and card badge)
4. Refresh the same module page → view count does NOT increment (dedup: once per day)
5. Open a different browser/incognito → view count increments again (different IP hash)

**Trending Tab:**
6. On homepage, click "🔥 Trending" sort toggle → shows modules ranked by trending score
7. Click "Most Voted" → returns to default vote-based sort

**Admin Dashboard:**
8. Sign in as admin → click "Analytics" in navbar
9. Verify: 5 summary cards, daily views bar chart, top modules table with engagement rates

## Screenshots / Recordings

Homepage Trending Tab
<img width="590" height="536" alt="7" src="https://github.com/user-attachments/assets/8340f7c4-fbb9-4603-be4a-2ddc1930647d" />

Module Card (with View Badge)
<img width="425" height="192" alt="8" src="https://github.com/user-attachments/assets/c060896f-2269-44f4-b618-24396f4919c3" />

Admin Analytics Dashboard
<img width="596" height="590" alt="9" src="https://github.com/user-attachments/assets/96a2435a-525a-4328-803a-27631d864595" />

Deduplication Proof
- First time to click this "Snake Game" in day -> View_count +1
<img width="1141" height="261" alt="10" src="https://github.com/user-attachments/assets/107df70e-f152-49d1-b47e-9f4a5f80675e" />

- Second time to click this "Snake Game" in day -> View_count not change
<img width="1139" height="301" alt="11" src="https://github.com/user-attachments/assets/80e11f7e-10cb-4b63-8f5c-00e964788458" />

Prisma Studio
<img width="614" height="545" alt="12" src="https://github.com/user-attachments/assets/eb2dd437-440e-460d-bb44-d0f5cd5673be" />

---

## Checklist
- [x] I read the relevant code before writing my own
- [x] My code follows the existing patterns in the codebase
- [x] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
- [x] I added or updated tests where applicable
- [x] I can explain every line of code I wrote (reviewer will ask)
- [x] I kept the PR focused — no unrelated changes

> **Note on lint:** `pnpm typecheck` and `pnpm build` pass cleanly. `pnpm lint` reports 9 pre-existing errors (e.g. module variable assignment in API routes, `<a>` tags instead of `<Link>` on browse page) — all present on master before this PR. This PR introduces zero new lint errors.

---

## Notes for Reviewer

### Design Decisions
* **SHA-256 IP fingerprint (`crypto.subtle.digest`)**: Hashes `IP:UserAgent` for anonymous dedup. Never stores raw IP.
    * *Trade-off*: Different browsers on same device count as separate views, which is acceptable for analytics granularity.
* **Raw SQL for trending**: Prisma can't express `LEFT JOIN` + `EXTRACT(EPOCH)` + weighted score in its query builder. Using `$queryRaw` with tagged template literals (parameterized, no SQL injection risk).
    * *Trade-off*: Less type-safe than Prisma queries, but $O(n \log n)$ in DB vs loading all rows into JS memory.
* **Denormalized `viewCount`**: Follows the existing `voteCount` pattern. Incremented atomically via `db.$transaction`.
    * *Trade-off*: Slight write overhead, but avoids `COUNT(*)` on every page load.
* **CSS bar chart**: No external charting library. Bars are `div` elements with dynamic height style.
    * *Trade-off*: Less fancy than Chart.js, but zero bundle impact and sufficient for admin use.
* **Engagement rate**: Can exceed 100% for legacy modules that had votes before view tracking existed. This is expected and self-corrects as views accumulate.

---

## AI Usage

* **API Guidance**: Asked Claude to explain the `crypto.subtle.digest` API for SHA-256 hashing in edge runtime — confirmed it's available in Next.js API routes without polyfill.
* **SQL Optimization**: Asked Claude to help write the raw SQL trending query — specifically the `EXTRACT(EPOCH FROM (NOW() - timestamp))` syntax for PostgreSQL recency calculation.
* **Security Review**: Asked Claude to review whether Prisma's `$queryRaw` tagged template literals are parameterized — confirmed they are.
* **UI Scaffolding**: Used Claude to scaffold the analytics dashboard layout (stat cards grid, bar chart structure, table columns) — then manually adjusted styling and data mapping.
* **Logic Consultation**: Asked Claude about React StrictMode double-mount behavior and the `useRef` guard pattern for the `ViewTracker` component.