### PR TITLE
feat: harden POST /api/votes with DB rate limit, validation, concurrency safety, and tests

### DIFF
--- a/__tests__/votes-route.test.ts
+++ b/__tests__/votes-route.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ─── Mocks ─────────────────────────────────────────────────────────────────
+
+// Mock auth — returns null by default (unauthenticated)
+const mockAuth = vi.fn();
+vi.mock("@/lib/auth", () => ({ auth: () => mockAuth() }));
+
+// Mock Prisma db
+const mockDb = {
+  rateLimitEvent: {
+    count: vi.fn(),
+    create: vi.fn(),
+  },
+  miniApp: {
+    findUnique: vi.fn(),
+    update: vi.fn(),
+  },
+  vote: {
+    findUnique: vi.fn(),
+    create: vi.fn(),
+    delete: vi.fn(),
+  },
+  $transaction: vi.fn(),
+};
+vi.mock("@/lib/db", () => ({ db: mockDb }));
+
+// Helper to build a NextRequest-like object for the POST handler
+function buildRequest(body?: unknown): Request {
+  if (body === undefined) {
+    // Simulate invalid JSON
+    return new Request("http://localhost/api/votes", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json",
+    });
+  }
+  return new Request("http://localhost/api/votes", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// Dynamically import the handler after mocks are set up
+async function getHandler() {
+  const mod = await import("@/app/api/votes/route");
+  return mod.POST;
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default: authenticated user
+  mockAuth.mockResolvedValue({ user: { id: "user-1" } });
+  // Default: rate limit passes
+  mockDb.rateLimitEvent.count.mockResolvedValue(0);
+  mockDb.rateLimitEvent.create.mockResolvedValue({});
+  // Default: module exists and is APPROVED
+  mockDb.miniApp.findUnique.mockResolvedValue({
+    id: "mod-1",
+    status: "APPROVED",
+  });
+});
+
+describe("POST /api/votes", () => {
+  // ── Auth ────────────────────────────────────────────────────────────────
+
+  it("returns 401 when user is not authenticated", async () => {
+    mockAuth.mockResolvedValue(null);
+    const POST = await getHandler();
+
+    const res = await POST(buildRequest({ moduleId: "mod-1" }) as never);
+    expect(res.status).toBe(401);
+
+    const data = await res.json();
+    expect(data.error).toBe("Unauthorized");
+  });
+
+  // ── Validation ──────────────────────────────────────────────────────────
+
+  it("returns 400 for invalid JSON body", async () => {
+    const POST = await getHandler();
+
+    const res = await POST(buildRequest(undefined) as never);
+    expect(res.status).toBe(400);
+
+    const data = await res.json();
+    expect(data.error).toContain("Invalid JSON");
+  });
+
+  it("returns 400 when moduleId is missing", async () => {
+    const POST = await getHandler();
+
+    const res = await POST(buildRequest({}) as never);
+    expect(res.status).toBe(400);
+
+    const data = await res.json();
+    expect(data.error).toContain("moduleId");
+  });
+
+  it("returns 400 when moduleId is not a string", async () => {
+    const POST = await getHandler();
+
+    const res = await POST(buildRequest({ moduleId: 123 }) as never);
+    expect(res.status).toBe(400);
+  });
+
+  // ── Module validation ──────────────────────────────────────────────────
+
+  it("returns 404 when module does not exist", async () => {
+    mockDb.miniApp.findUnique.mockResolvedValue(null);
+    const POST = await getHandler();
+
+    const res = await POST(buildRequest({ moduleId: "nonexistent" }) as never);
+    expect(res.status).toBe(404);
+
+    const data = await res.json();
+    expect(data.error).toContain("not found");
+  });
+
+  it("returns 403 when module is not APPROVED", async () => {
+    mockDb.miniApp.findUnique.mockResolvedValue({
+      id: "mod-1",
+      status: "PENDING",
+    });
+    const POST = await getHandler();
+
+    const res = await POST(buildRequest({ moduleId: "mod-1" }) as never);
+    expect(res.status).toBe(403);
+
+    const data = await res.json();
+    expect(data.error).toContain("approved");
+  });
+
+  // ── Rate limiting ──────────────────────────────────────────────────────
+
+  it("returns 429 when rate limit is exceeded", async () => {
+    mockDb.rateLimitEvent.count.mockResolvedValue(10);
+    const POST = await getHandler();
+
+    const res = await POST(buildRequest({ moduleId: "mod-1" }) as never);
+    expect(res.status).toBe(429);
+
+    const data = await res.json();
+    expect(data.error).toContain("Too many votes");
+  });
+
+  it("allows request when under rate limit", async () => {
+    mockDb.rateLimitEvent.count.mockResolvedValue(5);
+    mockDb.vote.findUnique.mockResolvedValue(null);
+    mockDb.$transaction.mockResolvedValue([]);
+    const POST = await getHandler();
+
+    const res = await POST(buildRequest({ moduleId: "mod-1" }) as never);
+    expect(res.status).toBe(200);
+    expect(mockDb.rateLimitEvent.create).toHaveBeenCalled();
+  });
+
+  // ── Vote / Unvote ─────────────────────────────────────────────────────
+
+  it("creates a vote when user has not voted", async () => {
+    mockDb.vote.findUnique.mockResolvedValue(null);
+    mockDb.$transaction.mockResolvedValue([]);
+    const POST = await getHandler();
+
+    const res = await POST(buildRequest({ moduleId: "mod-1" }) as never);
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(data.voted).toBe(true);
+    expect(mockDb.$transaction).toHaveBeenCalled();
+  });
+
+  it("removes a vote when user has already voted", async () => {
+    mockDb.vote.findUnique.mockResolvedValue({ id: "vote-1" });
+    mockDb.$transaction.mockResolvedValue([]);
+    const POST = await getHandler();
+
+    const res = await POST(buildRequest({ moduleId: "mod-1" }) as never);
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(data.voted).toBe(false);
+    expect(mockDb.$transaction).toHaveBeenCalled();
+  });
+
+  // ── Concurrency (P2002 unique constraint race) ────────────────────────
+
+  it("handles P2002 unique constraint race gracefully", async () => {
+    mockDb.vote.findUnique.mockResolvedValue(null);
+    mockDb.$transaction.mockRejectedValue({ code: "P2002" });
+    const POST = await getHandler();
+
+    const res = await POST(buildRequest({ moduleId: "mod-1" }) as never);
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(data.voted).toBe(true);
+  });
+
+  it("re-throws non-P2002 errors", async () => {
+    mockDb.vote.findUnique.mockResolvedValue(null);
+    mockDb.$transaction.mockRejectedValue(new Error("DB connection lost"));
+    const POST = await getHandler();
+
+    await expect(
+      POST(buildRequest({ moduleId: "mod-1" }) as never)
+    ).rejects.toThrow("DB connection lost");
+  });
+});

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -129,3 +129,15 @@ enum SubmissionStatus {
   APPROVED
   REJECTED
 }
+
+// ─── Rate limiting (DB-backed, works across multiple instances) ────────────
+
+model RateLimitEvent {
+  id        String   @id @default(cuid())
+  userId    String
+  action    String
+  createdAt DateTime @default(now())
+
+  @@index([userId, action, createdAt])
+  @@map("rate_limit_events")
+}

--- a/src/app/api/votes/route.ts
+++ b/src/app/api/votes/route.ts
@@ -2,20 +2,30 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 
-// Simple in-memory rate limit: max 10 votes per minute per user.
-// In production, replace with Redis-backed sliding window (e.g. Upstash).
-// TODO [medium-challenge]: Replace this with a proper rate limiter
-const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
+const RATE_LIMIT_MAX = 10;
+const RATE_LIMIT_WINDOW_MS = 60_000;
 
-function checkRateLimit(userId: string): boolean {
-  const now = Date.now();
-  const entry = rateLimitMap.get(userId);
-  if (!entry || entry.resetAt < now) {
-    rateLimitMap.set(userId, { count: 1, resetAt: now + 60_000 });
-    return true;
-  }
-  if (entry.count >= 10) return false;
-  entry.count++;
+/**
+ * DB-backed rate limiter — works across multiple server instances.
+ * Counts recent RateLimitEvent rows for this user+action within the window.
+ */
+async function checkRateLimit(userId: string): Promise<boolean> {
+  const windowStart = new Date(Date.now() - RATE_LIMIT_WINDOW_MS);
+
+  const count = await db.rateLimitEvent.count({
+    where: {
+      userId,
+      action: "vote",
+      createdAt: { gte: windowStart },
+    },
+  });
+
+  if (count >= RATE_LIMIT_MAX) return false;
+
+  await db.rateLimitEvent.create({
+    data: { userId, action: "vote" },
+  });
+
   return true;
 }
 
@@ -26,16 +36,49 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  if (!checkRateLimit(session.user.id)) {
+  // Parse and validate request body
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const moduleId =
+    typeof body === "object" && body !== null && "moduleId" in body
+      ? (body as Record<string, unknown>).moduleId
+      : undefined;
+
+  if (!moduleId || typeof moduleId !== "string") {
+    return NextResponse.json(
+      { error: "moduleId is required and must be a string" },
+      { status: 400 }
+    );
+  }
+
+  // Verify module exists and is APPROVED
+  const targetModule = await db.miniApp.findUnique({
+    where: { id: moduleId },
+    select: { id: true, status: true },
+  });
+
+  if (!targetModule) {
+    return NextResponse.json({ error: "Module not found" }, { status: 404 });
+  }
+
+  if (targetModule.status !== "APPROVED") {
+    return NextResponse.json(
+      { error: "Can only vote on approved modules" },
+      { status: 403 }
+    );
+  }
+
+  // Rate limit check (DB-backed)
+  if (!(await checkRateLimit(session.user.id))) {
     return NextResponse.json(
       { error: "Too many votes. Please wait a moment." },
       { status: 429 }
     );
-  }
-
-  const { moduleId } = await req.json();
-  if (!moduleId || typeof moduleId !== "string") {
-    return NextResponse.json({ error: "moduleId is required" }, { status: 400 });
   }
 
   const existing = await db.vote.findUnique({
@@ -53,16 +96,30 @@ export async function POST(req: NextRequest) {
     ]);
     return NextResponse.json({ voted: false });
   } else {
-    // Vote
-    await db.$transaction([
-      db.vote.create({
-        data: { userId: session.user.id, moduleId },
-      }),
-      db.miniApp.update({
-        where: { id: moduleId },
-        data: { voteCount: { increment: 1 } },
-      }),
-    ]);
-    return NextResponse.json({ voted: true });
+    // Vote — handle race condition where two concurrent requests
+    // both pass the findUnique check and try to create simultaneously.
+    try {
+      await db.$transaction([
+        db.vote.create({
+          data: { userId: session.user.id, moduleId },
+        }),
+        db.miniApp.update({
+          where: { id: moduleId },
+          data: { voteCount: { increment: 1 } },
+        }),
+      ]);
+      return NextResponse.json({ voted: true });
+    } catch (error: unknown) {
+      // P2002 = unique constraint violation — treat as already voted
+      if (
+        typeof error === "object" &&
+        error !== null &&
+        "code" in error &&
+        (error as { code: string }).code === "P2002"
+      ) {
+        return NextResponse.json({ voted: true });
+      }
+      throw error;
+    }
   }
 }


### PR DESCRIPTION

## What does this PR do?

Hardens `POST /api/votes` for production readiness by replacing the in-memory rate limiter with a PostgreSQL-backed solution that works across multiple server instances, adding strict input validation and business rule checks (module existence + approval status), handling race conditions gracefully via P2002 unique constraint catch, and adding 12 automated tests covering all branches.

## Related Issue

Closes #55

## How to test

1. `docker compose up -d` (start PostgreSQL)
2. `pnpm db:generate` then `pnpm db:push` (apply new `rate_limit_events` table)
3. `pnpm test` — 19 tests pass (12 new for votes route)
4. `pnpm typecheck` — no errors
5. `pnpm dev` — start dev server and test manually:
   - **401:** Sign out → attempt vote via API → returns 401
   - **400:** Send `POST /api/votes` with empty body or invalid moduleId → returns 400
   - **404:** Send vote with non-existent moduleId → returns 404
   - **403:** Send vote for a PENDING module → returns 403
   - **429:** Rapidly vote 11+ times within 60 seconds → 11th returns 429
   - **Vote/unvote:** Click vote button → toggles correctly, voteCount updates

## Screenshots

All 19 tests passing (including 12 new votes-route tests)

<img width="685" height="270" alt="image" src="https://github.com/user-attachments/assets/f5edd6e1-ce2c-4af0-9d14-2eb1b87d82b3" />


## Checklist

- [x] I read the relevant code **before** writing my own
- [x] My code follows the existing patterns in the codebase
- [x] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
- [x] I added or updated tests where applicable
- [x] I can explain every line of code I wrote (reviewer will ask)
- [x] I kept the PR focused — no unrelated changes

## Notes for reviewer

**Changes summary (3 files):**

| File | Change |
|---|---|
| schema.prisma | Added `RateLimitEvent` model with composite index on `[userId, action, createdAt]` |
| route.ts | Replaced in-memory rate limiter with DB-backed; added validation + business rules + P2002 handling |
| votes-route.test.ts | 12 new tests covering auth, validation, rate limiting, vote/unvote, and concurrency |

**Key design decisions:**

1. **PostgreSQL rate limiter over Redis** — Issue specifies "works across multiple server instances (not in-memory)". Chose PostgreSQL (`rate_limit_events` table) over Redis to avoid adding a new infrastructure dependency. The indexed query `COUNT(*) WHERE createdAt >= windowStart` is efficient for this scale. Trade-off: slightly more DB load than Redis, but eliminates operational complexity.

2. **P2002 unique constraint handling** — When two concurrent requests both pass the `findUnique` check and race to `vote.create`, one will hit the unique constraint `[userId, moduleId]`. Instead of returning a 500 error, we catch P2002 and return `{ voted: true }` — treating it as a successful vote since the intent was fulfilled.

3. **Validation order** — Auth → JSON parse → moduleId validation → module existence → module status → rate limit → vote toggle. This ensures we fail fast with the most specific error code before touching the rate limiter or vote logic.

**AI usage:** Used GitHub Copilot (Claude) to analyze the existing codebase patterns and help implement the solution. All code was reviewed manually and I can explain every line — the mock strategy for tests, the P2002 race condition pattern, and the rate limiter window query.