### PR TITLE
fix(vote-button): show loading spinner and disable button while voting

### DIFF
--- a/src/components/vote-button.tsx
+++ b/src/components/vote-button.tsx
@@ -21,6 +21,8 @@ export function VoteButton({
     initialCount,
   });
 
+  const ariaLabel = isLoading ? "Updating vote" : voted ? "Remove vote" : "Upvote this module";
+
   if (!session) {
     return (
       <span className="inline-flex items-center gap-1 text-sm text-gray-400">
@@ -34,7 +36,8 @@ export function VoteButton({
     <button
       onClick={toggle}
       disabled={isLoading}
-      aria-label={voted ? "Remove vote" : "Upvote this module"}
+      aria-label={ariaLabel}
+      aria-busy={isLoading}
       className={`inline-flex items-center gap-1 rounded-md px-2 py-1 text-sm font-medium transition-colors
         ${voted
           ? "bg-orange-100 text-orange-600 hover:bg-orange-200"
@@ -43,7 +46,7 @@ export function VoteButton({
         disabled:opacity-50 disabled:cursor-not-allowed`}
     >
       {/* TODO [easy-challenge]: this button shows no loading state during API call — add one */}
-      <TriangleIcon filled={voted} />
+      {isLoading ? <SpinnerIcon /> : <TriangleIcon filled={voted} />}
       {count}
     </button>
   );
@@ -61,6 +64,24 @@ function TriangleIcon({ filled = false }: { filled?: boolean }) {
       aria-hidden="true"
     >
       <path d="M6 1 L11 10 L1 10 Z" />
+    </svg>
+  );
+}
+
+function SpinnerIcon() {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      className="animate-spin"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      aria-hidden="true"
+    >
+      <path d="M12 2 A10 10 0 0 1 22 12" />
     </svg>
   );
 }


### PR DESCRIPTION
## What does this PR do?

This PR adds a loading state to the Vote button to provide immediate visual feedback during API calls. It improves the UX by letting users know their action was registered and prevents spam-clicking while the request is being processed.

## Related Issue

Closes #307 

## How to test

1. Click the Vote button in a normal environment and verify that the triangle icon swaps to a spinner and back correctly.
2. Open your browser's DevTools, navigate to the **Network** tab, and throttle the connection to **Slow 3G**.
3. Click the Vote button again to verify that the loading state remains stable and the button is properly disabled (unclickable) while waiting for the API response.

## Screenshots / recordings (if UI change)
Render Spinner when loading
<img width="881" height="429" alt="image" src="https://github.com/user-attachments/assets/1badd5d6-8b6f-46ab-b1c0-232c6f506f8d" />

<img width="936" height="383" alt="image" src="https://github.com/user-attachments/assets/2745723e-6b7b-487e-856b-9ded423fd5b5" />


## Checklist

- [x] I read the relevant code **before** writing my own
- [x] My code follows the existing patterns in the codebase
- [x] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
- [ ] I added or updated tests where applicable
- [x] I can explain every line of code I wrote (reviewer will ask)
- [x] I kept the PR focused — no unrelated changes

## Notes for reviewer

**Implementation details:**
* Leveraged the `isLoading` state from the `useOptimisticVote` hook to control the UI transitions.
* Disabled the button during the loading phase to block spam clicks and ensure data consistency.
* Improved screen reader accessibility by adding the `aria-busy` attribute and dynamically updating the `aria-label` based on the current state.
* Swapped the default triangle icon with a new `SpinnerIcon` component while loading.

**AI Usage:**
* I used AI to quickly generate the boilerplate code for the `SpinnerIcon` component.
