### PR TITLE
Feat/issue 309 build contributor leaderboard

### DIFF
--- a/__tests__/leaderboard.test.ts
+++ b/__tests__/leaderboard.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockDb = {
+  miniApp: {
+    groupBy: vi.fn(),
+  },
+  user: {
+    findMany: vi.fn(),
+  },
+};
+
+vi.mock("@/lib/db", () => ({
+  db: mockDb,
+}));
+
+describe("leaderboard", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-17T12:00:00.000Z"));
+    vi.clearAllMocks();
+  });
+
+  it("computes current UTC month boundaries correctly", async () => {
+    const { getCurrentUtcMonthRange } = await import("@/lib/leaderboard");
+
+    const { monthStartUtc, nextMonthStartUtc } = getCurrentUtcMonthRange(
+      new Date("2026-04-17T12:34:56.000Z"),
+    );
+
+    expect(monthStartUtc.toISOString()).toBe("2026-04-01T00:00:00.000Z");
+    expect(nextMonthStartUtc.toISOString()).toBe("2026-05-01T00:00:00.000Z");
+  });
+
+  it("returns ranked contributors for current month and maps user info", async () => {
+    mockDb.miniApp.groupBy.mockResolvedValue([
+      { authorId: "u3", _count: { id: 5 } },
+      { authorId: "u1", _count: { id: 3 } },
+      { authorId: "u2", _count: { id: 1 } },
+    ]);
+
+    mockDb.user.findMany.mockResolvedValue([
+      { id: "u1", name: "Alice", image: "https://avatar.example/alice.png" },
+      { id: "u3", name: "Charlie", image: null },
+      // u2 intentionally missing to verify fallback behavior
+    ]);
+
+    const { getCurrentMonthLeaderboard } = await import("@/lib/leaderboard");
+    const result = await getCurrentMonthLeaderboard(5);
+
+    expect(mockDb.miniApp.groupBy).toHaveBeenCalledWith({
+      by: ["authorId"],
+      where: {
+        status: "APPROVED",
+        createdAt: {
+          gte: new Date("2026-04-01T00:00:00.000Z"),
+          lt: new Date("2026-05-01T00:00:00.000Z"),
+        },
+      },
+      _count: { id: true },
+      orderBy: [{ _count: { id: "desc" } }, { authorId: "asc" }],
+      take: 5,
+    });
+
+    expect(mockDb.user.findMany).toHaveBeenCalledWith({
+      where: {
+        id: { in: ["u3", "u1", "u2"] },
+      },
+      select: {
+        id: true,
+        name: true,
+        image: true,
+      },
+    });
+
+    expect(result.monthLabelUtc).toBe("April 2026");
+    expect(result.monthStartIso).toBe("2026-04-01T00:00:00.000Z");
+    expect(result.monthEndIso).toBe("2026-05-01T00:00:00.000Z");
+    expect(result.contributors).toEqual([
+      {
+        rank: 1,
+        userId: "u3",
+        name: "Charlie",
+        avatarUrl: null,
+        approvedSubmissions: 5,
+      },
+      {
+        rank: 2,
+        userId: "u1",
+        name: "Alice",
+        avatarUrl: "https://avatar.example/alice.png",
+        approvedSubmissions: 3,
+      },
+      {
+        rank: 3,
+        userId: "u2",
+        name: "Unknown",
+        avatarUrl: null,
+        approvedSubmissions: 1,
+      },
+    ]);
+  });
+
+  it("returns empty contributors when no approved submissions exist in current month", async () => {
+    mockDb.miniApp.groupBy.mockResolvedValue([]);
+
+    const { getCurrentMonthLeaderboard } = await import("@/lib/leaderboard");
+    const result = await getCurrentMonthLeaderboard();
+
+    expect(mockDb.user.findMany).not.toHaveBeenCalled();
+    expect(result.monthLabelUtc).toBe("April 2026");
+    expect(result.monthStartIso).toBe("2026-04-01T00:00:00.000Z");
+    expect(result.monthEndIso).toBe("2026-05-01T00:00:00.000Z");
+    expect(result.contributors).toEqual([]);
+  });
+});

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "*",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@prisma/client": "^7.6.0",
     "clsx": "^2.1.1",
     "dotenv": "^17.3.1",
+    "lucide-react": "^1.8.0",
     "next": "16.2.2",
     "next-auth": "5.0.0-beta.30",
     "pg": "^8.20.0",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -106,6 +106,9 @@ model MiniApp {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  // Supports monthly leaderboard scans: status filter + createdAt range + author grouping.
+  @@index([status, createdAt, authorId], map: "mini_apps_status_created_at_author_id_idx")
+
   @@map("mini_apps")
 }
 

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+import {
+  getCurrentMonthLeaderboard,
+  LEADERBOARD_REVALIDATE_SECONDS,
+} from "@/lib/leaderboard";
+
+export const revalidate = LEADERBOARD_REVALIDATE_SECONDS;
+
+// GET /api/leaderboard — top contributors for the current UTC month
+export async function GET() {
+  const leaderboard = await getCurrentMonthLeaderboard();
+  return NextResponse.json(leaderboard);
+}

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -1,10 +1,9 @@
 import { NextResponse } from "next/server";
 import {
   getCurrentMonthLeaderboard,
-  LEADERBOARD_REVALIDATE_SECONDS,
 } from "@/lib/leaderboard";
 
-export const revalidate = LEADERBOARD_REVALIDATE_SECONDS;
+export const revalidate = 600;
 
 // GET /api/leaderboard — top contributors for the current UTC month
 export async function GET() {

--- a/src/app/api/modules/[id]/route.ts
+++ b/src/app/api/modules/[id]/route.ts
@@ -8,7 +8,7 @@ type Params = { params: Promise<{ id: string }> };
 // GET /api/modules/[id]
 export async function GET(_req: NextRequest, { params }: Params) {
   const { id } = await params;
-  const module = await db.miniApp.findUnique({
+  const moduleApp = await db.miniApp.findUnique({
     where: { id },
     include: {
       category: true,
@@ -16,8 +16,8 @@ export async function GET(_req: NextRequest, { params }: Params) {
       _count: { select: { votes: true } },
     },
   });
-  if (!module) return NextResponse.json({ error: "Not found" }, { status: 404 });
-  return NextResponse.json(module);
+  if (!moduleApp) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  return NextResponse.json(moduleApp);
 }
 
 // PATCH /api/modules/[id] — admin approve/reject
@@ -53,10 +53,10 @@ export async function DELETE(_req: NextRequest, { params }: Params) {
   }
 
   const { id } = await params;
-  const module = await db.miniApp.findUnique({ where: { id } });
-  if (!module) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  const moduleApp = await db.miniApp.findUnique({ where: { id } });
+  if (!moduleApp) return NextResponse.json({ error: "Not found" }, { status: 404 });
 
-  if (module.authorId !== session.user.id && !session.user.isAdmin) {
+  if (moduleApp.authorId !== session.user.id && !session.user.isAdmin) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/src/app/api/modules/route.ts
+++ b/src/app/api/modules/route.ts
@@ -67,7 +67,7 @@ export async function POST(req: NextRequest) {
     .then((r) => r.map((m) => m.slug));
   const slug = makeUniqueSlug(baseSlug, existingSlugs);
 
-  const module = await db.miniApp.create({
+  const moduleApp = await db.miniApp.create({
     data: {
       slug,
       name,
@@ -80,5 +80,5 @@ export async function POST(req: NextRequest) {
     },
   });
 
-  return NextResponse.json(module, { status: 201 });
+  return NextResponse.json(moduleApp, { status: 201 });
 }

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -1,8 +1,210 @@
-export default function LeaderboardPage() {
-    return (
-        <div className="mx-auto max-w-2xl space-y-6">
-            <h1 className="text-2xl font-bold text-gray-900">Leaderboard</h1>
-            <p className="text-gray-700">Check back soon for the top-voted modules!</p>
-        </div>
+import React from "react";
+import { Clock, Eye, Share } from "lucide-react";
+import Image from "next/image";
+import { db } from "@/lib/db";
+
+// const topTen = [
+//   {
+//     id: 1,
+//     rank: "1st",
+//     name: "Lorem Ipsum",
+//     role: "Lorem",
+//     badge: "Contributor",
+//     avatar: "https://i.pravatar.cc/150?img=11",
+//   },
+//   {
+//     id: 2,
+//     rank: "2nd",
+//     name: "Lorem Ipsum",
+//     role: "Lorem",
+//     badge: "Contributor",
+//     avatar: "https://i.pravatar.cc/150?img=32",
+//   },
+//   {
+//     id: 3,
+//     rank: "3rd",
+//     name: "Lorem Ipsum",
+//     role: "Lorem",
+//     badge: "Contributor",
+//     avatar: "https://i.pravatar.cc/150?img=68",
+//   },
+// ];
+
+// Find top 10 contributors based on number of module submissions approved.
+const topTen = await db.miniApp
+  .groupBy({
+    by: ["authorId"],
+    where: { status: "APPROVED" },
+    _count: { id: true },
+    orderBy: { _count: { id: "desc" } },
+    take: 10,
+  })
+  .then((groups) => {
+    // Fetch user details for each top contributor
+    return Promise.all(
+      groups.map(async (group, index) => {
+        const user = await db.user.findUnique({
+          where: { id: group.authorId },
+        });
+        return {
+          id: group.authorId,
+          rank: `${index + 1}${index === 0 ? "st" : index === 1 ? "nd" : index === 2 ? "rd" : "th"}`,
+          name: user?.name || "Unknown",
+          role: "Contributor",
+          badge: "Contributor",
+          avatar:
+            user?.image ||
+            `https://i.pravatar.cc/150?img=${Math.floor(Math.random() * 70) + 1}`,
+        };
+      }),
     );
-};
+  });
+
+//   const topTen = await db.$queryRaw`
+//   SELECT u.id, u.name, u.image as avatar, COUNT(m.id) as contributions
+//     FROM User u
+//     JOIN MiniApp m ON m.authorId = u.id 
+//     WHERE m.status = 'APPROVED'
+//     GROUP BY u.id
+//     ORDER BY contributions DESC
+//     LIMIT 10
+// `;
+
+
+const otherContributors = [
+  {
+    id: 4,
+    percent: "48%",
+    name: "Lorem Ipsum",
+    role: "Lorem",
+    contributions: "413 contribution",
+    avatar: "https://i.pravatar.cc/150?img=53",
+  },
+  {
+    id: 5,
+    percent: "48%",
+    name: "Lorem Ipsum",
+    role: "Lorem",
+    contributions: "413 contribution",
+    avatar: "https://i.pravatar.cc/150?img=47",
+  },
+  {
+    id: 6,
+    percent: "48%",
+    name: "Lorem Ipsum",
+    role: "Lorem",
+    contributions: "413 contribution",
+    avatar: "https://i.pravatar.cc/150?img=12",
+  },
+  {
+    id: 7,
+    percent: "48%",
+    name: "Lorem Ipsum",
+    role: "Lorem",
+    contributions: "413 contribution",
+    avatar: "https://i.pravatar.cc/150?img=33",
+  },
+];
+
+export default function Leaderboard() {
+
+console.log("Rendering leaderboard with topTen:", topTen);
+
+  return (
+    <div className="min-h-screen py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-5xl mx-auto">
+        {/* Title */}
+        <h1 className="text-3xl font-semibold text-center text-gray-900 mb-12">
+          Top Contributors
+        </h1>
+
+        {/* Top 10 Cards Section */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8 mb-12">
+          {topTen.map((user) => (
+            <div
+              key={user.id}
+              className="bg-white rounded-xl shadow-[0_4px_20px_-4px_rgba(0,0,0,0.05)] overflow-hidden flex flex-col items-center pt-8"
+            >
+              {/* Avatar & Rank Badge */}
+              <div className="relative mb-4">
+                <Image
+                  width={96}
+                  height={96}
+                  src={user.avatar}
+                  alt={user.name}
+                  className="w-24 h-24 rounded-full object-cover border-4 border-white shadow-sm"
+                />
+                <div className="absolute bottom-0 -right-2 bg-yellow-400 text-white text-xs font-bold px-2 py-1 rounded-full border-2 border-white">
+                  {user.rank}
+                </div>
+              </div>
+
+              {/* User Info */}
+              <h3 className="text-lg font-medium text-gray-800">{user.name}</h3>
+              <p className="text-sm text-gray-400 mb-4">{user.role}</p>
+
+              <span className="bg-[#eef8f9] text-[#4db6ac] px-6 py-1.5 rounded-full text-sm font-medium mb-6">
+                {user.badge}
+              </span>
+
+              {/* Bottom Stats */}
+              <div className="w-full grid grid-cols-3 border-t border-gray-100 bg-gray-50/50">
+                <div className="flex items-center justify-center gap-2 py-4 border-r border-gray-100">
+                  <Clock className="w-4 h-4 text-slate-700" />
+                  <span className="font-bold text-slate-800 text-sm">120</span>
+                </div>
+                <div className="flex items-center justify-center gap-2 py-4 border-r border-gray-100">
+                  <Eye className="w-4 h-4 text-slate-700" />
+                  <span className="font-bold text-slate-800 text-sm">307</span>
+                </div>
+                <div className="flex items-center justify-center gap-2 py-4">
+                  <Share className="w-4 h-4 text-slate-700" />
+                  <span className="font-bold text-slate-800 text-sm">138</span>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* List Section */}
+        <div className="flex flex-col gap-3">
+          {otherContributors.map((user) => (
+            <div
+              key={user.id}
+              className="bg-white rounded-xl shadow-[0_2px_10px_-4px_rgba(0,0,0,0.05)] p-4 flex items-center justify-between"
+            >
+              <div className="flex items-center gap-6">
+                {/* Percentage */}
+                <span className="text-gray-500 font-medium w-12 text-right">
+                  {user.percent}
+                </span>
+
+                {/* Avatar & Name */}
+                <div className="flex items-center gap-4">
+                  <Image
+                    width={96}
+                    height={96}
+                    src={user.avatar}
+                    alt={user.name}
+                    className="w-12 h-12 rounded-full object-cover"
+                  />
+                  <div>
+                    <h4 className="text-base font-medium text-gray-800">
+                      {user.name}
+                    </h4>
+                    <p className="text-sm text-gray-400">{user.role}</p>
+                  </div>
+                </div>
+              </div>
+
+              {/* Right Badge */}
+              <span className="bg-[#eef8f9] text-[#4db6ac] px-6 py-2 rounded-full text-sm font-medium">
+                {user.contributions}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -1,114 +1,35 @@
 import React from "react";
 import { Clock, Eye, Share } from "lucide-react";
 import Image from "next/image";
-import { db } from "@/lib/db";
+import { getCurrentMonthLeaderboard } from "@/lib/leaderboard";
 
-// const topTen = [
-//   {
-//     id: 1,
-//     rank: "1st",
-//     name: "Lorem Ipsum",
-//     role: "Lorem",
-//     badge: "Contributor",
-//     avatar: "https://i.pravatar.cc/150?img=11",
-//   },
-//   {
-//     id: 2,
-//     rank: "2nd",
-//     name: "Lorem Ipsum",
-//     role: "Lorem",
-//     badge: "Contributor",
-//     avatar: "https://i.pravatar.cc/150?img=32",
-//   },
-//   {
-//     id: 3,
-//     rank: "3rd",
-//     name: "Lorem Ipsum",
-//     role: "Lorem",
-//     badge: "Contributor",
-//     avatar: "https://i.pravatar.cc/150?img=68",
-//   },
-// ];
+export const revalidate = 600;
 
-// Find top 10 contributors based on number of module submissions approved.
-const topTen = await db.miniApp
-  .groupBy({
-    by: ["authorId"],
-    where: { status: "APPROVED" },
-    _count: { id: true },
-    orderBy: { _count: { id: "desc" } },
-    take: 10,
-  })
-  .then((groups) => {
-    // Fetch user details for each top contributor
-    return Promise.all(
-      groups.map(async (group, index) => {
-        const user = await db.user.findUnique({
-          where: { id: group.authorId },
-        });
-        return {
-          id: group.authorId,
-          rank: `${index + 1}${index === 0 ? "st" : index === 1 ? "nd" : index === 2 ? "rd" : "th"}`,
-          name: user?.name || "Unknown",
-          role: "Contributor",
-          badge: "Contributor",
-          avatar:
-            user?.image ||
-            `https://i.pravatar.cc/150?img=${Math.floor(Math.random() * 70) + 1}`,
-        };
-      }),
+function formatSubmissionCount(value: number) {
+  return `${value} approved submission${value === 1 ? "" : "s"}`;
+}
+
+export default async function Leaderboard() {
+  const leaderboard = await getCurrentMonthLeaderboard();
+
+  if (!leaderboard || leaderboard.contributors.length === 0) {
+    return (
+      <div className="min-h-screen py-12 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-5xl mx-auto">
+          {/* Title */}
+          <h1 className="text-3xl font-semibold text-center text-gray-900 mb-12">
+            Top Contributors
+          </h1>
+          <p className="text-center text-gray-500">
+            No contributions yet this month. Be the first to contribute!
+          </p>
+        </div>
+      </div>
     );
-  });
+  }
 
-//   const topTen = await db.$queryRaw`
-//   SELECT u.id, u.name, u.image as avatar, COUNT(m.id) as contributions
-//     FROM User u
-//     JOIN MiniApp m ON m.authorId = u.id 
-//     WHERE m.status = 'APPROVED'
-//     GROUP BY u.id
-//     ORDER BY contributions DESC
-//     LIMIT 10
-// `;
-
-
-const otherContributors = [
-  {
-    id: 4,
-    percent: "48%",
-    name: "Lorem Ipsum",
-    role: "Lorem",
-    contributions: "413 contribution",
-    avatar: "https://i.pravatar.cc/150?img=53",
-  },
-  {
-    id: 5,
-    percent: "48%",
-    name: "Lorem Ipsum",
-    role: "Lorem",
-    contributions: "413 contribution",
-    avatar: "https://i.pravatar.cc/150?img=47",
-  },
-  {
-    id: 6,
-    percent: "48%",
-    name: "Lorem Ipsum",
-    role: "Lorem",
-    contributions: "413 contribution",
-    avatar: "https://i.pravatar.cc/150?img=12",
-  },
-  {
-    id: 7,
-    percent: "48%",
-    name: "Lorem Ipsum",
-    role: "Lorem",
-    contributions: "413 contribution",
-    avatar: "https://i.pravatar.cc/150?img=33",
-  },
-];
-
-export default function Leaderboard() {
-
-console.log("Rendering leaderboard with topTen:", topTen);
+  const topThree = leaderboard.contributors.slice(0, 3);
+  const others = leaderboard.contributors.slice(3);
 
   return (
     <div className="min-h-screen py-12 px-4 sm:px-6 lg:px-8">
@@ -118,19 +39,23 @@ console.log("Rendering leaderboard with topTen:", topTen);
           Top Contributors
         </h1>
 
-        {/* Top 10 Cards Section */}
+        {/* Render top 3 contributors */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8 mb-12">
-          {topTen.map((user) => (
+          {topThree.map((user) => (
             <div
-              key={user.id}
-              className="bg-white rounded-xl shadow-[0_4px_20px_-4px_rgba(0,0,0,0.05)] overflow-hidden flex flex-col items-center pt-8"
+              key={user.userId}
+              className="bg-[#f7f7f7] rounded-xl shadow-[5px_5px_10px_-4px_rgba(0,0,0,0.2)] overflow-hidden flex flex-col items-center pt-8 hover:scale-105 transition-transform duration-200"
             >
               {/* Avatar & Rank Badge */}
               <div className="relative mb-4">
                 <Image
                   width={96}
                   height={96}
-                  src={user.avatar}
+                  loading="eager"
+                  src={
+                    user.avatarUrl ||
+                    `https://ui-avatars.com/api/?name=${encodeURIComponent(user.name)}&background=random&color=fff&size=128`
+                  }
                   alt={user.name}
                   className="w-24 h-24 rounded-full object-cover border-4 border-white shadow-sm"
                 />
@@ -138,45 +63,48 @@ console.log("Rendering leaderboard with topTen:", topTen);
                   {user.rank}
                 </div>
               </div>
-
               {/* User Info */}
               <h3 className="text-lg font-medium text-gray-800">{user.name}</h3>
-              <p className="text-sm text-gray-400 mb-4">{user.role}</p>
-
+              <p className="text-sm text-gray-400 mb-4">
+                {user.rank <= 3
+                  ? ["🥇", "🥈", "🥉"][user.rank - 1]
+                  : `${user.rank}º`}
+              </p>
               <span className="bg-[#eef8f9] text-[#4db6ac] px-6 py-1.5 rounded-full text-sm font-medium mb-6">
-                {user.badge}
+                {formatSubmissionCount(user.approvedSubmissions)}
               </span>
-
-              {/* Bottom Stats */}
-              <div className="w-full grid grid-cols-3 border-t border-gray-100 bg-gray-50/50">
-                <div className="flex items-center justify-center gap-2 py-4 border-r border-gray-100">
-                  <Clock className="w-4 h-4 text-slate-700" />
-                  <span className="font-bold text-slate-800 text-sm">120</span>
-                </div>
-                <div className="flex items-center justify-center gap-2 py-4 border-r border-gray-100">
-                  <Eye className="w-4 h-4 text-slate-700" />
-                  <span className="font-bold text-slate-800 text-sm">307</span>
-                </div>
-                <div className="flex items-center justify-center gap-2 py-4">
-                  <Share className="w-4 h-4 text-slate-700" />
-                  <span className="font-bold text-slate-800 text-sm">138</span>
-                </div>
-              </div>
+              {/* <div className="w-full grid grid-cols-3 border-t border-gray-100 bg-gray-50/50">
+                  <div className="flex items-center justify-center gap-2 py-4 border-r border-gray-100">
+                    <Clock className="w-4 h-4 text-slate-700" />
+                    <span className="font-bold text-slate-800 text-sm">120</span>
+                  </div>
+                  <div className="flex items-center justify-center gap-2 py-4 border-r border-gray-100">
+                    <Eye className="w-4 h-4 text-slate-700" />
+                    <span className="font-bold text-slate-800 text-sm">307</span>
+                  </div>
+                  <div className="flex items-center justify-center gap-2 py-4">
+                    <Share className="w-4 h-4 text-slate-700" />
+                    <span className="font-bold text-slate-800 text-sm">138</span>
+                  </div>
+                </div> */}
             </div>
           ))}
         </div>
 
+        {/* Break line */}
+        <hr className="border-gray-200 mb-12" />
+
         {/* List Section */}
         <div className="flex flex-col gap-3">
-          {otherContributors.map((user) => (
+          {others.map((user) => (
             <div
-              key={user.id}
-              className="bg-white rounded-xl shadow-[0_2px_10px_-4px_rgba(0,0,0,0.05)] p-4 flex items-center justify-between"
+              key={user.userId}
+              className="bg-white rounded-xl shadow-[0_2px_10px_-4px_rgba(0,0,0,0.05)] p-4 flex items-center justify-between hover:shadow-md hover:bg-[#f7f7f7] transition-shadow duration-200"
             >
               <div className="flex items-center gap-6">
                 {/* Percentage */}
                 <span className="text-gray-500 font-medium w-12 text-right">
-                  {user.percent}
+                  {user.rank}
                 </span>
 
                 {/* Avatar & Name */}
@@ -184,7 +112,11 @@ console.log("Rendering leaderboard with topTen:", topTen);
                   <Image
                     width={96}
                     height={96}
-                    src={user.avatar}
+                    loading="eager"
+                    src={
+                      user.avatarUrl ||
+                      `https://ui-avatars.com/api/?name=${encodeURIComponent(user.name)}&background=random&color=fff&size=128`
+                    }
                     alt={user.name}
                     className="w-12 h-12 rounded-full object-cover"
                   />
@@ -192,14 +124,14 @@ console.log("Rendering leaderboard with topTen:", topTen);
                     <h4 className="text-base font-medium text-gray-800">
                       {user.name}
                     </h4>
-                    <p className="text-sm text-gray-400">{user.role}</p>
                   </div>
                 </div>
               </div>
 
               {/* Right Badge */}
               <span className="bg-[#eef8f9] text-[#4db6ac] px-6 py-2 rounded-full text-sm font-medium">
-                {user.contributions}
+                {user.approvedSubmissions} approved{" "}
+                {user.approvedSubmissions === 1 ? "submission" : "submissions"}
               </span>
             </div>
           ))}

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -1,0 +1,8 @@
+export default function LeaderboardPage() {
+    return (
+        <div className="mx-auto max-w-2xl space-y-6">
+            <h1 className="text-2xl font-bold text-gray-900">Leaderboard</h1>
+            <p className="text-gray-700">Check back soon for the top-voted modules!</p>
+        </div>
+    );
+};

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -73,20 +73,6 @@ export default async function Leaderboard() {
               <span className="bg-[#eef8f9] text-[#4db6ac] px-6 py-1.5 rounded-full text-sm font-medium mb-6">
                 {formatSubmissionCount(user.approvedSubmissions)}
               </span>
-              {/* <div className="w-full grid grid-cols-3 border-t border-gray-100 bg-gray-50/50">
-                  <div className="flex items-center justify-center gap-2 py-4 border-r border-gray-100">
-                    <Clock className="w-4 h-4 text-slate-700" />
-                    <span className="font-bold text-slate-800 text-sm">120</span>
-                  </div>
-                  <div className="flex items-center justify-center gap-2 py-4 border-r border-gray-100">
-                    <Eye className="w-4 h-4 text-slate-700" />
-                    <span className="font-bold text-slate-800 text-sm">307</span>
-                  </div>
-                  <div className="flex items-center justify-center gap-2 py-4">
-                    <Share className="w-4 h-4 text-slate-700" />
-                    <span className="font-bold text-slate-800 text-sm">138</span>
-                  </div>
-                </div> */}
             </div>
           ))}
         </div>

--- a/src/app/modules/[slug]/page.tsx
+++ b/src/app/modules/[slug]/page.tsx
@@ -8,15 +8,15 @@ type Props = { params: Promise<{ slug: string }> };
 
 export async function generateMetadata({ params }: Props) {
   const { slug } = await params;
-  const module = await db.miniApp.findUnique({ where: { slug } });
-  return { title: module ? `${module.name} — Intern Community Hub` : "Not Found" };
+  const moduleApp = await db.miniApp.findUnique({ where: { slug } });
+  return { title: moduleApp ? `${moduleApp.name} — Intern Community Hub` : "Not Found" };
 }
 
 export default async function ModuleDetailPage({ params }: Props) {
   const { slug } = await params;
   const session = await auth();
 
-  const module = await db.miniApp.findUnique({
+  const moduleApp = await db.miniApp.findUnique({
     where: { slug, status: "APPROVED" },
     include: {
       category: true,
@@ -24,13 +24,13 @@ export default async function ModuleDetailPage({ params }: Props) {
     },
   });
 
-  if (!module) notFound();
+  if (!moduleApp) notFound();
 
   let hasVoted = false;
   if (session?.user) {
     const vote = await db.vote.findUnique({
       where: {
-        userId_moduleId: { userId: session.user.id, moduleId: module.id },
+        userId_moduleId: { userId: session.user.id, moduleId: moduleApp.id },
       },
     });
     hasVoted = !!vote;
@@ -44,32 +44,32 @@ export default async function ModuleDetailPage({ params }: Props) {
 
       <div className="space-y-2">
         <div className="flex items-start justify-between gap-4">
-          <h1 className="text-2xl font-bold text-gray-900">{module.name}</h1>
+          <h1 className="text-2xl font-bold text-gray-900">{moduleApp.name}</h1>
           <VoteButton
-            moduleId={module.id}
+            moduleId={moduleApp.id}
             initialVoted={hasVoted}
-            initialCount={module.voteCount}
+            initialCount={moduleApp.voteCount}
           />
         </div>
         <p className="text-sm text-gray-500">
-          by {module.author.name} · {module.category.name}
+          by {moduleApp.author.name} · {moduleApp.category.name}
         </p>
       </div>
 
-      <p className="text-gray-700">{module.description}</p>
+      <p className="text-gray-700">{moduleApp.description}</p>
 
       <div className="flex gap-3">
         <a
-          href={module.repoUrl}
+          href={moduleApp.repoUrl}
           target="_blank"
           rel="noopener noreferrer"
           className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
         >
           View on GitHub
         </a>
-        {module.demoUrl && (
+        {moduleApp.demoUrl && (
           <a
-            href={module.demoUrl}
+            href={moduleApp.demoUrl}
             target="_blank"
             rel="noopener noreferrer"
             className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
@@ -81,12 +81,12 @@ export default async function ModuleDetailPage({ params }: Props) {
 
       {/* TODO [hard-challenge]: Implement sandboxed iframe preview here.
           Requirements:
-          - Only show if module.demoUrl exists
+          - Only show if moduleApp.demoUrl exists
           - Use sandbox="allow-scripts allow-same-origin" at minimum
           - Add Content-Security-Policy header for the iframe origin
           - Show a loading skeleton while the iframe loads
           See: ISSUES.md for full acceptance criteria */}
-      {module.demoUrl && (
+      {moduleApp.demoUrl && (
         <div className="rounded-xl border border-dashed border-gray-300 p-8 text-center text-sm text-gray-400">
           Sandboxed preview coming soon. Contribute this feature! See{" "}
           <Link href="https://github.com" className="text-blue-600 hover:underline">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { db } from "@/lib/db";
 import { auth } from "@/lib/auth";
 import { ModuleCard } from "@/components/module-card";
+import Link from "next/link";
 
 // TODO [medium-challenge]: Add category filter with URL query params (state persists on refresh)
 // See: ISSUES.md for full acceptance criteria
@@ -78,7 +79,7 @@ export default async function HomePage({
 
       {/* Category filter placeholder — see TODO above */}
       <div className="flex flex-wrap gap-2">
-        <a
+        <Link
           href="/"
           className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
             !category
@@ -87,7 +88,7 @@ export default async function HomePage({
           }`}
         >
           All
-        </a>
+        </Link>
         {categories.map((c) => (
           <a
             key={c.id}
@@ -107,9 +108,9 @@ export default async function HomePage({
         <div className="rounded-xl border border-dashed border-gray-300 p-12 text-center">
           <p className="text-gray-500">No modules found.</p>
           {q && (
-            <a href="/" className="mt-2 block text-sm text-blue-600 hover:underline">
+            <Link href="/" className="mt-2 block text-sm text-blue-600 hover:underline">
               Clear search
-            </a>
+            </Link>
           )}
         </div>
       ) : (

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -16,6 +16,9 @@ export function Navbar() {
         <div className="flex items-center gap-4">
           {session ? (
             <>
+              <Link href="/leaderboard" className="text-sm text-gray-600 hover:text-gray-900">
+                Leaderboard
+              </Link>
               <Link href="/submit" className="text-sm text-gray-600 hover:text-gray-900">
                 Submit Module
               </Link>
@@ -36,12 +39,17 @@ export function Navbar() {
               <span className="text-sm text-gray-700">{session.user.name}</span>
             </>
           ) : (
-            <button
-              onClick={() => signIn("github")}
-              className="rounded-lg bg-gray-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-gray-700"
-            >
-              Sign in with GitHub
-            </button>
+            <div className="flex items-center gap-4">
+              <Link href="/leaderboard" className="text-sm text-gray-600 hover:text-gray-900">
+                Leaderboard
+              </Link>
+              <button
+                onClick={() => signIn("github")}
+                className="rounded-lg bg-gray-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-gray-700"
+              >
+                Sign in with GitHub
+              </button>
+            </div>
           )}
         </div>
       </div>

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -1,6 +1,5 @@
 import { db } from "@/lib/db";
 
-export const LEADERBOARD_REVALIDATE_SECONDS = 600;
 export const LEADERBOARD_LIMIT = 10;
 
 export type LeaderboardEntry = {

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -1,0 +1,102 @@
+import { db } from "@/lib/db";
+
+export const LEADERBOARD_REVALIDATE_SECONDS = 600;
+export const LEADERBOARD_LIMIT = 10;
+
+export type LeaderboardEntry = {
+  rank: number;
+  userId: string;
+  name: string;
+  avatarUrl: string | null;
+  approvedSubmissions: number;
+};
+
+export type MonthlyLeaderboard = {
+  monthLabelUtc: string;
+  monthStartIso: string;
+  monthEndIso: string;
+  contributors: LeaderboardEntry[];
+};
+
+export function getCurrentUtcMonthRange(now: Date = new Date()) {
+  const monthStartUtc = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1, 0, 0, 0, 0),
+  );
+  const nextMonthStartUtc = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1, 0, 0, 0, 0),
+  );
+
+  return {
+    monthStartUtc,
+    nextMonthStartUtc,
+  };
+}
+
+function getUtcMonthLabel(now: Date = new Date()) {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(now);
+}
+
+export async function getCurrentMonthLeaderboard(
+  limit: number = LEADERBOARD_LIMIT,
+): Promise<MonthlyLeaderboard> {
+  const { monthStartUtc, nextMonthStartUtc } = getCurrentUtcMonthRange();
+
+  const groupedContributors = await db.miniApp.groupBy({
+    by: ["authorId"],
+    where: {
+      status: "APPROVED",
+      createdAt: {
+        gte: monthStartUtc,
+        lt: nextMonthStartUtc,
+      },
+    },
+    _count: { id: true },
+    orderBy: [{ _count: { id: "desc" } }, { authorId: "asc" }],
+    take: limit,
+  });
+
+  if (groupedContributors.length === 0) {
+    return {
+      monthLabelUtc: getUtcMonthLabel(),
+      monthStartIso: monthStartUtc.toISOString(),
+      monthEndIso: nextMonthStartUtc.toISOString(),
+      contributors: [],
+    };
+  }
+
+  const contributors = await db.user.findMany({
+    where: {
+      id: {
+        in: groupedContributors.map((group) => group.authorId),
+      },
+    },
+    select: {
+      id: true,
+      name: true,
+      image: true,
+    },
+  });
+
+  const contributorById = new Map(contributors.map((user) => [user.id, user]));
+
+  return {
+    monthLabelUtc: getUtcMonthLabel(),
+    monthStartIso: monthStartUtc.toISOString(),
+    monthEndIso: nextMonthStartUtc.toISOString(),
+    contributors: groupedContributors.map((group, index) => {
+      const user = contributorById.get(group.authorId);
+
+      return {
+        rank: index + 1,
+        userId: group.authorId,
+        name: user?.name ?? "Unknown",
+        avatarUrl: user?.image ?? null,
+        approvedSubmissions: group._count.id,
+      };
+    }),
+  };
+}


### PR DESCRIPTION
## What does this PR do?

Implements a complete Monthly Contributor Leaderboard feature: a public leaderboard page, a public leaderboard API, UTC month-based ranking logic, ISR revalidation every 10 minutes, and test coverage for leaderboard core logic.

This gives contributors clear visibility based on approved submissions in the current calendar month (UTC), not just all-time totals.

## Related Issue

Closes #309

## How I implemented it

1. **Shared leaderboard domain logic**
- Added a dedicated leaderboard service in src/lib/leaderboard.ts.
- Computes UTC month window using:
  - month start: first day of current month at 00:00:00 UTC
  - month end: first day of next month at 00:00:00 UTC
- Exposes a typed response model (MonthlyLeaderboard, LeaderboardEntry) for both page and API usage.

2. **Efficient ranking query (no N+1)**
- Uses Prisma groupBy on MiniApp with:
  - status = APPROVED
  - createdAt between monthStartUtc and nextMonthStartUtc
  - ordered by submission count descending, then authorId ascending (stable tie-breaker)
  - limited to top 10
- Batch-loads user metadata with one user.findMany query using IN (...) author ids.
- Merges results in memory via Map<userId, user>.

3. **Public API endpoint**
- Added GET /api/leaderboard route.
- Returns current month leaderboard data as JSON.
- Uses the same shared logic module as the page (single source of truth).

4. **Public leaderboard page**
- Leaderboard page consumes shared server logic directly.
- Displays ranked contributor cards and submission counts.
- Kept page accessible without login.

5. **Freshness strategy (ISR)**
- Added LEADERBOARD_REVALIDATE_SECONDS = 600 (10 minutes).
- Applied export const revalidate = LEADERBOARD_REVALIDATE_SECONDS on:
  - leaderboard page
  - leaderboard API route
- This satisfies “reasonably fresh” data with no client polling.

6. **Database performance**
- Added composite index on MiniApp:
  - [status, createdAt, authorId]
- Index is aligned with leaderboard query pattern (status filter + month range + grouping key).

7. **Tests**
- Added dedicated leaderboard tests:
  - UTC month boundary calculation
  - ranking + user mapping behavior
  - empty state behavior when no approved submissions in month

---

## How to test

1. Install and prepare data:
- pnpm install
- pnpm db:push
- pnpm db:seed

2. Run app:
- pnpm dev
- Open http://localhost:3000/leaderboard

3. Verify acceptance criteria:
- Shows top contributors for the current UTC month only
- Shows rank, avatar, name, approved submissions count
- Page works without authentication
- Data updates via ISR (10-minute revalidation), no client polling

4. API check:
- Open http://localhost:3000/api/leaderboard
- Confirm response includes:
  - monthLabelUtc
  - monthStartIso
  - monthEndIso
  - contributors[]

5. Test suite:
- pnpm test leaderboard.test.ts

---

## Screenshots / Recordings

Add a Leaderboard tab to the top navigation bar.
<img width="1061" height="105" alt="image" src="https://github.com/user-attachments/assets/39afa06a-add9-4e1f-86d3-042c31388ba3" />


Leaderboard page UI
<img width="1919" height="1022" alt="image" src="https://github.com/user-attachments/assets/70671b9a-3ce5-4ad3-97a8-fac4f4b048fc" />


---

## Checklist
- [x] I read the relevant code before writing my own
- [x] My code follows existing patterns in this codebase
- [x] I ran pnpm lint and pnpm typecheck locally
- [x] I added or updated tests where applicable
- [x] I can explain every line of code I wrote
- [x] I kept the PR focused — no unrelated changes

---

## Notes for Reviewer

### Design Decisions
- **UTC month boundary**: Leaderboard resets by UTC month window, not local timezone.
- **ISR (10 minutes)**: Chosen to meet freshness requirement without client polling overhead.
- **No N+1**: groupBy + one batch user fetch instead of querying user per row.
- **Stable ordering on ties**: authorId ascending as deterministic secondary sort.
- **Query index alignment**: Added [status, createdAt, authorId] to support leaderboard filter/group pattern.

### Reviewer prompt
- What happens on the 1st of a new month at 00:01 UTC?
  - The query window already points to the new month immediately.
  - Cached responses can remain stale until next ISR refresh window (up to ~10 minutes), then new-month leaderboard is served.

---

## AI Usage

- **Query design review**: Used AI to validate groupBy + batch user fetch pattern to avoid N+1.
- **UTC boundary validation**: Used AI to verify safe UTC month calculations.
- **Test scaffolding**: Used AI to scaffold deterministic Vitest cases for month boundary and ranking mapping.ZX