### PR TITLE
feat: add aria-label to modulecard icon

### DIFF
--- a/src/components/module-card.tsx
+++ b/src/components/module-card.tsx
@@ -24,6 +24,7 @@ export function ModuleCard({ module, hasVoted = false }: ModuleCardProps) {
             target="_blank"
             rel="noopener noreferrer"
             className="shrink-0 text-gray-400 hover:text-gray-600"
+            aria-label={`Open demo for ${module.name}`}
           >
             <ExternalLinkIcon />
           </a>


### PR DESCRIPTION
## What does this PR do?

Based on the required assessment, this PR resolves an accessibility issue in the ModuleCard component. Specifically, it adds a dynamic aria-label to the external link button which previously only contained an SVG icon without visible text. This ensures screen readers can correctly interpret the button's purpose for visually impaired users without modifying any CSS or layout.

## Related Issue

Closes #313

## How to test

1. Run pnpm lint and pnpm typecheck locally to verify that no new syntax or type errors have been introduced.
2. Run pnpm test to ensure existing unit tests still pass without regression.
3. Open the browser (DevTools Inspect) on the page rendering the module list. Verify that the <a> tag of the external link correctly renders the dynamic aria-label string matching the respective Module Name.

## Screenshots / recordings (if UI change)

## Checklist

- [x] I read the relevant code **before** writing my own
- [x] My code follows the existing patterns in the codebase
- [x] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
- [ ] I added or updated tests where applicable
- [x] I can explain every line of code I wrote (reviewer will ask)
- [x] I kept the PR focused — no unrelated changes

## Notes for reviewer

I did not use any AI tools for this specific PR.
