### PR TITLE
feat: implement my-submissions delete button for pending modules

### DIFF
--- a/src/app/my-submissions/page.tsx
+++ b/src/app/my-submissions/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation";
 import Link from "next/link";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
+import { DeleteSubmissionButton } from "@/components/delete-submission-button";
 
 const statusStyles: Record<string, string> = {
   PENDING: "bg-yellow-50 text-yellow-700 border-yellow-200",
@@ -60,13 +61,18 @@ export default async function MySubmissionsPage() {
                   </p>
                 )}
               </div>
-              <span
-                className={`shrink-0 rounded-full border px-2 py-0.5 text-xs font-medium ${
-                  statusStyles[sub.status]
-                }`}
-              >
-                {sub.status}
-              </span>
+              <div className="flex flex-col items-end gap-2">
+                <span
+                  className={`shrink-0 rounded-full border px-2 py-0.5 text-xs font-medium ${
+                    statusStyles[sub.status]
+                  }`}
+                >
+                  {sub.status}
+                </span>
+                {sub.status === "PENDING" && (
+                  <DeleteSubmissionButton submissionId={sub.id} />
+                )}
+              </div>
             </div>
           ))}
         </div>

--- a/src/components/delete-submission-button.tsx
+++ b/src/components/delete-submission-button.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+interface DeleteSubmissionButtonProps {
+  submissionId: string;
+}
+
+export function DeleteSubmissionButton({ submissionId }: DeleteSubmissionButtonProps) {
+  const [isDeleting, setIsDeleting] = useState(false);
+  const router = useRouter();
+
+  const handleDelete = async () => {
+    if (!window.confirm("Are you sure you want to delete this submission? This action cannot be undone.")) {
+      return;
+    }
+
+    setIsDeleting(true);
+
+    try {
+      const res = await fetch(`/api/modules/${submissionId}`, {
+        method: "DELETE",
+      });
+
+      if (!res.ok) {
+        throw new Error("Failed to delete submission");
+      }
+
+      router.refresh();
+    } catch (error) {
+      console.error(error);
+      alert("An error occurred while deleting the submission.");
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <button
+      onClick={handleDelete}
+      disabled={isDeleting}
+      className={`shrink-0 rounded-full border px-2 py-0.5 text-xs font-medium bg-white text-gray-600 border-gray-200 hover:bg-red-50 hover:text-red-700 hover:border-red-200 transition-colors ${
+        isDeleting ? "opacity-50 cursor-not-allowed" : ""
+      }`}
+    >
+      {isDeleting ? "Deleting..." : "Delete"}
+    </button>
+  );
+}


### PR DESCRIPTION
## What does this PR do?

Resolves the "My Submissions" status page issue. This PR extracts a new Client Component (DeleteSubmissionButton) allowing users to delete their own PENDING submissions. It successfully handles the DELETE /api/modules/[id] API call, includes a window.confirm safety prompt, and utilizes Next.js router.refresh() to update the submission list seamlessly without a full page reload.

## Related Issue

Closes #318

## How to test

1. Submit a new module to trigger a PENDING state.
2. Navigate to your /my-submissions page.
3. Verify that APPROVED or REJECTED modules do not display the delete action.
4. Click "Delete" on the PENDING module.
5. Accept the browser confirmation prompt. The UI should instantly display a "Deleting..." state and then smoothly remove the item from the list.

## Screenshots / recordings (if UI change)

<img width="1920" height="1016" alt="Screenshot 2026-04-18 230636" src="https://github.com/user-attachments/assets/eb562e08-b820-445d-875c-57d59424ca0e" />

<img width="1920" height="1017" alt="Screenshot 2026-04-18 230731" src="https://github.com/user-attachments/assets/f5806cdb-79f7-4879-b290-c22e8ba00fd1" />

<img width="1920" height="1015" alt="Screenshot 2026-04-18 230830" src="https://github.com/user-attachments/assets/aeab7017-c573-4aea-9b1e-0c71aab97684" />

## Checklist

- [x] I read the relevant code **before** writing my own
- [x] My code follows the existing patterns in the codebase
- [x] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
- [ ] I added or updated tests where applicable
- [x] I can explain every line of code I wrote (reviewer will ask)
- [x] I kept the PR focused — no unrelated changes

## Notes for reviewer

**On my AI usage:**
I utilized AI to analyze the issue requirements and map out a structured implementation plan, which I then manually reviewed and adjusted to fit the project's exact needs. Following this task breakdown, I strictly evaluated the AI's code suggestions—actively correcting any inaccuracies and only accepting the logic that precisely matched the requirements.