### PR TITLE
fix: add accessible loading state for vote button

### DIFF
--- a/src/components/vote-button.tsx
+++ b/src/components/vote-button.tsx
@@ -34,7 +34,7 @@ export function VoteButton({
     <button
       onClick={toggle}
       disabled={isLoading}
-      aria-label={voted ? "Remove vote" : "Upvote this module"}
+      aria-label={isLoading ? "Updating vote" : voted ? "Remove vote" : "Upvote this module"}
       className={`inline-flex items-center gap-1 rounded-md px-2 py-1 text-sm font-medium transition-colors
         ${voted
           ? "bg-orange-100 text-orange-600 hover:bg-orange-200"
@@ -43,7 +43,16 @@ export function VoteButton({
         disabled:opacity-50 disabled:cursor-not-allowed`}
     >
       {/* TODO [easy-challenge]: this button shows no loading state during API call — add one */}
-      <TriangleIcon filled={voted} />
+
+      {isLoading ? (
+        <>
+          <LoadingSpanner />
+          <span className="sr-only">Updating vote...</span>
+        </>
+      ) : (
+        <TriangleIcon filled={voted} />
+      )}
+
       {count}
     </button>
   );
@@ -63,4 +72,47 @@ function TriangleIcon({ filled = false }: { filled?: boolean }) {
       <path d="M6 1 L11 10 L1 10 Z" />
     </svg>
   );
+}
+
+
+function LoadingSpanner() {
+  return (
+    <svg
+      className="h-3.5 w-3.5 animate-spin-slower"
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+    >
+
+      <path
+        d="M19.5 8.5a8 8 0 0 0-13.2-2.1"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+
+      <path
+        d="M8.2 3.9 5.3 6.4 8.9 7"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+
+      <path
+        d="M4.5 15.5a8 8 0 0 0 13.2 2.1"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+
+      <path
+        d="m15.8 20.1 2.9-2.5-3.6-.6"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
 }


### PR DESCRIPTION
Adds an accessible loading state for `VoteButton` while `POST /api/votes` is in progress.  
The button keeps its disabled behavior and returns to normal after success/error.
## Test plan
- [x] Loading appears on click
- [x] Loading disappears when request completes
- [x] Disabled state preserved
- [x] `pnpm test` passes