### PR TITLE
feat(browse): add module browser with debounced search and load more …

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,6 @@
 import { db } from "@/lib/db";
 import { auth } from "@/lib/auth";
-import { ModuleCard } from "@/components/module-card";
-
-// TODO [medium-challenge]: Add category filter with URL query params (state persists on refresh)
-// See: ISSUES.md for full acceptance criteria
+import { ModuleBrowser } from "@/components/module-browser";
 
 export default async function HomePage({
   searchParams,
@@ -13,6 +10,7 @@ export default async function HomePage({
   const { q, category } = await searchParams;
   const session = await auth();
 
+  // Fetch initial modules for server-side rendering
   const modules = await db.miniApp.findMany({
     where: {
       status: "APPROVED",
@@ -48,81 +46,16 @@ export default async function HomePage({
     votedIds = new Set(votes.map((v) => v.moduleId));
   }
 
+  // Fetch categories for filter
   const categories = await db.category.findMany({ orderBy: { name: "asc" } });
 
   return (
-    <div className="space-y-6">
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-gray-900">Community Modules</h1>
-          <p className="text-sm text-gray-500">
-            Discover mini-apps built by the Intern developer community.
-          </p>
-        </div>
-
-        <form className="flex gap-2">
-          <input
-            name="q"
-            defaultValue={q}
-            placeholder="Search modules…"
-            className="rounded-lg border border-gray-300 px-3 py-2 text-sm outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
-          />
-          <button
-            type="submit"
-            className="rounded-lg bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700"
-          >
-            Search
-          </button>
-        </form>
-      </div>
-
-      {/* Category filter placeholder — see TODO above */}
-      <div className="flex flex-wrap gap-2">
-        <a
-          href="/"
-          className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
-            !category
-              ? "bg-blue-600 text-white"
-              : "bg-gray-100 text-gray-600 hover:bg-gray-200"
-          }`}
-        >
-          All
-        </a>
-        {categories.map((c) => (
-          <a
-            key={c.id}
-            href={`/?category=${c.slug}`}
-            className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
-              category === c.slug
-                ? "bg-blue-600 text-white"
-                : "bg-gray-100 text-gray-600 hover:bg-gray-200"
-            }`}
-          >
-            {c.name}
-          </a>
-        ))}
-      </div>
-
-      {modules.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-gray-300 p-12 text-center">
-          <p className="text-gray-500">No modules found.</p>
-          {q && (
-            <a href="/" className="mt-2 block text-sm text-blue-600 hover:underline">
-              Clear search
-            </a>
-          )}
-        </div>
-      ) : (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {modules.map((module) => (
-            <ModuleCard
-              key={module.id}
-              module={module}
-              hasVoted={votedIds.has(module.id)}
-            />
-          ))}
-        </div>
-      )}
-    </div>
+    <ModuleBrowser
+      initialModules={modules}
+      initialCategories={categories}
+      initialQuery={q}
+      initialCategory={category}
+      initialVotedIds={votedIds}
+    />
   );
 }

--- a/src/components/module-browser.tsx
+++ b/src/components/module-browser.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { ModuleCard } from "@/components/module-card";
+import { useDebounce } from "@/hooks/use-debounce";
+import type { Module } from "@/types";
+import type { Category } from "@prisma/client";
+
+interface ModuleBrowserProps {
+  initialModules: Module[];
+  initialCategories: Category[];
+  initialQuery?: string;
+  initialCategory?: string;
+  initialVotedIds?: Set<string>;
+}
+
+export function ModuleBrowser({
+  initialModules,
+  initialCategories,
+  initialQuery = "",
+  initialCategory = "",
+  initialVotedIds = new Set(),
+}: ModuleBrowserProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  // Search & filter state
+  const [query, setQuery] = useState(initialQuery);
+  const [selectedCategory, setSelectedCategory] = useState(initialCategory);
+  const debouncedQuery = useDebounce(query, 400);
+
+  // Pagination state
+  const [modules, setModules] = useState(initialModules);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [isSearching, setIsSearching] = useState(false);
+  const [votedIds, setVotedIds] = useState(initialVotedIds);
+
+  // When search or category changes, fetch new results
+  useEffect(() => {
+    (async () => {
+      setIsSearching(true);
+      try {
+        const params = new URLSearchParams();
+        if (debouncedQuery) params.append("q", debouncedQuery);
+        if (selectedCategory) params.append("category", selectedCategory);
+
+        const res = await fetch(`/api/modules?${params.toString()}`);
+        if (!res.ok) throw new Error("Failed to fetch modules");
+
+        const data = await res.json();
+        setModules(data.items ?? []);
+        setNextCursor(data.nextCursor ?? null);
+
+        // Update URL without reload
+        const newSearchParams = new URLSearchParams();
+        if (debouncedQuery) newSearchParams.set("q", debouncedQuery);
+        if (selectedCategory) newSearchParams.set("category", selectedCategory);
+
+        const newUrl = newSearchParams.toString()
+          ? `/?${newSearchParams.toString()}`
+          : "/";
+        router.replace(newUrl);
+      } catch (err) {
+        console.error("Search error:", err);
+      } finally {
+        setIsSearching(false);
+      }
+    })();
+  }, [debouncedQuery, selectedCategory, router]);
+
+  async function loadMore() {
+    if (!nextCursor || isLoadingMore) return;
+
+    setIsLoadingMore(true);
+    try {
+      const params = new URLSearchParams();
+      params.append("cursor", nextCursor);
+      if (debouncedQuery) params.append("q", debouncedQuery);
+      if (selectedCategory) params.append("category", selectedCategory);
+
+      const res = await fetch(`/api/modules?${params.toString()}`);
+      if (!res.ok) throw new Error("Failed to load more");
+
+      const data = await res.json();
+      setModules((prev) => [...prev, ...(data.items ?? [])]);
+      setNextCursor(data.nextCursor ?? null);
+    } catch (err) {
+      console.error("Load more error:", err);
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Community Modules</h1>
+          <p className="text-sm text-gray-500">
+            Discover mini-apps built by the Intern developer community.
+          </p>
+        </div>
+
+        <div className="flex gap-2">
+          <input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search modules…"
+            disabled={isSearching}
+            className="rounded-lg border border-gray-300 px-3 py-2 text-sm outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 disabled:opacity-50"
+          />
+          {isSearching && (
+            <div className="flex items-center px-3 py-2 text-xs text-gray-400">
+              Searching…
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Category filter pills */}
+      <div className="flex flex-wrap gap-2">
+        <button
+          onClick={() => setSelectedCategory("")}
+          className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+            !selectedCategory
+              ? "bg-blue-600 text-white"
+              : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+          }`}
+        >
+          All
+        </button>
+        {initialCategories.map((c) => (
+          <button
+            key={c.id}
+            onClick={() => setSelectedCategory(c.slug)}
+            className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+              selectedCategory === c.slug
+                ? "bg-blue-600 text-white"
+                : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+            }`}
+          >
+            {c.name}
+          </button>
+        ))}
+      </div>
+
+      {/* Modules grid */}
+      {modules.length === 0 && !isSearching ? (
+        <div className="rounded-xl border border-dashed border-gray-300 p-12 text-center">
+          <p className="text-gray-500">No modules found.</p>
+          {query && (
+            <button
+              onClick={() => setQuery("")}
+              className="mt-2 block text-sm text-blue-600 hover:underline"
+            >
+              Clear search
+            </button>
+          )}
+        </div>
+      ) : (
+        <>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {modules.map((module) => (
+              <ModuleCard
+                key={module.id}
+                module={module}
+                hasVoted={votedIds.has(module.id)}
+              />
+            ))}
+          </div>
+
+          {/* Load more button */}
+          {nextCursor && (
+            <div className="flex justify-center pt-4">
+              <button
+                onClick={loadMore}
+                disabled={isLoadingMore}
+                className="rounded-lg bg-gray-200 px-6 py-3 text-sm font-medium text-gray-900 hover:bg-gray-300 disabled:opacity-50"
+              >
+                {isLoadingMore ? "Loading…" : "Load More"}
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/use-debounce.ts
+++ b/src/hooks/use-debounce.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Debounce a value — waits for `delay` ms after the value stops changing
+ * before updating the returned state.
+ * Useful for search inputs, filter changes, etc.
+ */
+export function useDebounce<T>(value: T, delay: number = 400): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debouncedValue;
+}


### PR DESCRIPTION
…pagination

- Implement useDebounce hook for 400ms debounce on search input
- Create ModuleBrowser client component with:
  * Auto-search after user stops typing (no manual submit needed)
  * Smooth category filtering with URL state persistence
  * Cursor-based pagination with 'Load More' button
  * Loading indicators for search and pagination
  * Real-time URL updates without page reload using router.replace()
- Refactor HomePage to server-render initial data and pass to ModuleBrowser
- Maintain initial voted status from server session

Resolves: Medium challenge - Category filter with URL query params
Resolves: Medium challenge - Cursor-based pagination to module listing

BREAKING CHANGE: Browse page now requires JavaScript for interactive features

## What does this PR do?

<!-- Describe the change in 1-3 sentences. What problem does it solve? -->

## Related Issue

The new changes solve three main problems: (1) Auto-search — instead of clicking a "Search" button, users now just type and search automatically triggers after 400ms debounce, (2) Smooth category filtering — filtering by category no longer reloads the page but updates the URL in realtime using [router.replace()](vscode-file://vscode-app/c:/Users/bao/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html), and (3) Easy pagination — users can now view more modules with a "Load More" button instead of being limited to the initial 12 items.

Closes #

## How to test

<!-- Exact steps for the reviewer to verify your change works -->
1. Auto-Search Feature
Navigate to the homepage (/)
Start typing in the search input (e.g., "timer", "editor", "game")
Verify that results update automatically after ~400ms of stopping typing (no manual button click needed)
Search box should show "Searching…" indicator while fetching
Verify URL updates to [/?q=your-search-term](vscode-file://vscode-app/c:/Users/bao/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) without page reload
2. Smooth Category Filtering
On the homepage, click any category pill (e.g., "Utility", "Game")
Verify the clicked pill becomes highlighted (blue background)
Verify modules list updates instantly without page reload
Check that URL changes to [/?category=utility](vscode-file://vscode-app/c:/Users/bao/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (or respective slug)
Click "All" pill to reset category filter
Verify search and category filters work together (e.g., [/?q=timer&category=utility](vscode-file://vscode-app/c:/Users/bao/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html))
3. Load More Pagination
On the homepage, scroll down after initial modules load
Verify "Load More" button appears at the bottom if there are more modules
Click "Load More" button
Verify new modules are appended to the existing list (not replacing)
Button should show "Loading…" while fetching next page
Repeat until no "Load More" button appears (all modules loaded)
Verify works with active search/category filters

## Screenshots / recordings (if UI change)
<img width="1914" height="912" alt="Screenshot 2026-04-21 195421" src="https://github.com/user-attachments/assets/4720eb77-d776-4d55-b3e4-714d6c321a7e" />


<!-- Drag and drop a screenshot or screen recording here -->

## Checklist

- [ ] I read the relevant code **before** writing my own
- [ ] My code follows the existing patterns in the codebase
- [ ] I ran `pnpm lint` and `pnpm typecheck` locally — no errors
- [ ] I added or updated tests where applicable
- [ ] I can explain every line of code I wrote (reviewer will ask)
- [ ] I kept the PR focused — no unrelated changes

## Notes for reviewer

<!-- Anything you want to highlight, trade-offs you made, or questions you have -->
