### PR TITLE
Feat/category filter query params

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, vi, expect, afterEach } from "vitest";
 import { generateSlug, makeUniqueSlug, formatRelativeTime } from "@/lib/utils";
 
 // ============================================================
@@ -30,6 +30,23 @@ describe("generateSlug", () => {
   //
   // Hint: read `src/lib/utils.ts` to understand the exact transformation rules
   // before writing your assertions.
+
+  it("keeps an already valid slug unchanged", () => {
+    expect(generateSlug("my-cool-app")).toBe("my-cool-app");
+  });
+
+  it("preserves numbers", () => {
+    expect(generateSlug("Version 2 App 2026")).toBe("version-2-app-2026");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(generateSlug("")).toBe("");
+  });
+
+  it("removes leading/trailing hyphens after normalization", () => {
+    expect(generateSlug("---Hello---")).toBe("hello");
+  });
+
 });
 
 // ============================================================
@@ -53,6 +70,23 @@ describe("makeUniqueSlug", () => {
   // 1. When many suffixed versions already exist (e.g. -1 through -5)
   // 2. When the existing list contains similar but non-conflicting slugs
   //    e.g. existing = ["my-app-tool"] should NOT block "my-app"
+
+  it("finds the next available suffix when many are taken", () => {
+    expect(
+      makeUniqueSlug("my-app", [
+        "my-app",
+        "my-app-1",
+        "my-app-2",
+        "my-app-3",
+        "my-app-4",
+        "my-app-5",
+      ])
+    ).toBe("my-app-6");
+  });
+
+  it("ignores similar but non-conflicting slugs", () => {
+    expect(makeUniqueSlug("my-app", ["my-app-tool"])).toBe("my-app");
+  });
 });
 
 // ============================================================
@@ -69,3 +103,41 @@ describe("makeUniqueSlug", () => {
 //
 // Hint: You'll need to mock or control `Date.now()` to make these tests
 // deterministic. Look into Vitest's `vi.setSystemTime()`.
+
+
+describe("formatRelativeTime", () => {
+  const NOW = new Date("2026-04-21T12:00:00.000Z");
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+  it("returns 'just now' for less than 1 minute", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const date = new Date(NOW.getTime() - 30_000);
+    expect(formatRelativeTime(date)).toBe("just now");
+  });
+  it("returns minutes for 1-59 minutes", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    expect(formatRelativeTime(new Date(NOW.getTime() - 1 * 60_000))).toBe("1m ago");
+    expect(formatRelativeTime(new Date(NOW.getTime() - 59 * 60_000))).toBe("59m ago");
+  });
+  it("returns hours for 1-23 hours", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    expect(formatRelativeTime(new Date(NOW.getTime() - 60 * 60_000))).toBe("1h ago");
+    expect(formatRelativeTime(new Date(NOW.getTime() - 23 * 60 * 60_000))).toBe("23h ago");
+  });
+  it("returns days for 1-29 days", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    expect(formatRelativeTime(new Date(NOW.getTime() - 24 * 60 * 60_000))).toBe("1d ago");
+    expect(formatRelativeTime(new Date(NOW.getTime() - 29 * 24 * 60 * 60_000))).toBe("29d ago");
+  });
+  it("returns locale date string for 30+ days", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const date = new Date(NOW.getTime() - 30 * 24 * 60 * 60_000);
+    expect(formatRelativeTime(date)).toBe(date.toLocaleDateString());
+  });
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { db } from "@/lib/db";
 import { auth } from "@/lib/auth";
 import { ModuleCard } from "@/components/module-card";
+import { CategoryFilter } from "@/components/category-filter";
 
 // TODO [medium-challenge]: Add category filter with URL query params (state persists on refresh)
 // See: ISSUES.md for full acceptance criteria
@@ -19,11 +20,11 @@ export default async function HomePage({
       ...(category ? { category: { slug: category } } : {}),
       ...(q
         ? {
-            OR: [
-              { name: { contains: q, mode: "insensitive" } },
-              { description: { contains: q, mode: "insensitive" } },
-            ],
-          }
+          OR: [
+            { name: { contains: q, mode: "insensitive" } },
+            { description: { contains: q, mode: "insensitive" } },
+          ],
+        }
         : {}),
     },
     // DO NOT remove include — avoids N+1 on category/author fields.
@@ -78,29 +79,7 @@ export default async function HomePage({
 
       {/* Category filter placeholder — see TODO above */}
       <div className="flex flex-wrap gap-2">
-        <a
-          href="/"
-          className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
-            !category
-              ? "bg-blue-600 text-white"
-              : "bg-gray-100 text-gray-600 hover:bg-gray-200"
-          }`}
-        >
-          All
-        </a>
-        {categories.map((c) => (
-          <a
-            key={c.id}
-            href={`/?category=${c.slug}`}
-            className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
-              category === c.slug
-                ? "bg-blue-600 text-white"
-                : "bg-gray-100 text-gray-600 hover:bg-gray-200"
-            }`}
-          >
-            {c.name}
-          </a>
-        ))}
+        <CategoryFilter categories={categories} selectedCategory={category} />
       </div>
 
       {modules.length === 0 ? (

--- a/src/components/category-filter.tsx
+++ b/src/components/category-filter.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+type CategoryItem = {
+    id: string;
+    name: string;
+    slug: string;
+};
+
+type CategoryFilterProps = {
+    categories: CategoryItem[];
+    selectedCategory?: string;
+};
+
+export function CategoryFilter({
+    categories,
+    selectedCategory,
+}: CategoryFilterProps) {
+    const router = useRouter();
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
+
+    const updateCategory = (nextCategory?: string) => {
+        const params = new URLSearchParams(searchParams.toString());
+
+        if (nextCategory) {
+            params.set("category", nextCategory);
+        } else {
+            params.delete("category");
+        }
+
+        const query = params.toString();
+        router.push(query ? `${pathname}?${query}` : pathname);
+    };
+
+    return (
+        <div className="flex flex-wrap gap-2">
+            <button
+                type="button"
+                onClick={() => updateCategory(undefined)}
+                className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${!selectedCategory
+                    ? "bg-blue-600 text-white"
+                    : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+                    }`}
+            >
+                All
+            </button>
+
+            {categories.map((c) => (
+                <button
+                    key={c.id}
+                    type="button"
+                    onClick={() => updateCategory(c.slug)}
+                    className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${selectedCategory === c.slug
+                        ? "bg-blue-600 text-white"
+                        : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+                        }`}
+                >
+                    {c.name}
+                </button>
+            ))}
+        </div>
+    );
+}

--- a/src/components/module-card.tsx
+++ b/src/components/module-card.tsx
@@ -23,6 +23,7 @@ export function ModuleCard({ module, hasVoted = false }: ModuleCardProps) {
             href={module.demoUrl}
             target="_blank"
             rel="noopener noreferrer"
+            aria-label={`Open demo for ${module.name}`}
             className="shrink-0 text-gray-400 hover:text-gray-600"
           >
             <ExternalLinkIcon />

--- a/src/components/submit-form.tsx
+++ b/src/components/submit-form.tsx
@@ -9,10 +9,14 @@ interface SubmitFormProps {
   categories: Category[];
 }
 
+const DESCRIPTION_LIMIT = 500;
+const WARNING_THRESHOLD = 450;
+
 export function SubmitForm({ categories }: SubmitFormProps) {
   const router = useRouter();
   const [error, setError] = useState<Record<string, string[]>>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [descriptionLength, setDescriptionLength] = useState(0)
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -59,15 +63,37 @@ export function SubmitForm({ categories }: SubmitFormProps) {
         />
       </Field>
 
-      <Field label="Description" name="description" error={error.description} hint="Max 500 characters">
+      <Field label="Description" name="description" error={error.description} >
         {/* TODO [easy-challenge]: add a live character counter below this textarea */}
         <textarea
+          id="description"
           name="description"
           rows={4}
           placeholder="What does your module do? Who is it for?"
-          maxLength={500}
-          className={inputClass}
+          maxLength={DESCRIPTION_LIMIT}
+          onInput={(e) => {
+            const el = e.currentTarget;
+            el.style.height = "auto";
+            el.style.height = `${el.scrollHeight}px`;
+            setDescriptionLength(el.value.length);
+          }}
+          aria-describedby="description-help description-counter"
+          className={`${inputClass} resize-none overflow-hidden`}
         />
+
+        <div className="mt-1 flex min-h-5 items-center justify-between">
+          <p id="description-help" className="text-xs text-gray-400">
+            Max {DESCRIPTION_LIMIT} characters
+          </p>
+          <p
+            id="description-counter"
+            className={`text-xs ${descriptionLength >= WARNING_THRESHOLD ? "text-red-600" : "text-gray-400"
+              }`}
+            aria-live="polite"
+          >
+            {descriptionLength} / {DESCRIPTION_LIMIT}
+          </p>
+        </div>
       </Field>
 
       <Field label="Category" name="categoryId" error={error.categoryId}>
@@ -134,7 +160,7 @@ function Field({
         {label}
       </label>
       {children}
-      {hint && <p className="text-xs text-gray-400">{hint}</p>}
+      {hint && <p id={`${name}-help`} className="text-xs text-gray-400">{hint}</p>}
       {error && <p className="text-xs text-red-600">{error.join(", ")}</p>}
     </div>
   );

--- a/src/components/vote-button.tsx
+++ b/src/components/vote-button.tsx
@@ -34,7 +34,7 @@ export function VoteButton({
     <button
       onClick={toggle}
       disabled={isLoading}
-      aria-label={voted ? "Remove vote" : "Upvote this module"}
+      aria-label={isLoading ? "Updating vote" : voted ? "Remove vote" : "Upvote this module"}
       className={`inline-flex items-center gap-1 rounded-md px-2 py-1 text-sm font-medium transition-colors
         ${voted
           ? "bg-orange-100 text-orange-600 hover:bg-orange-200"
@@ -43,7 +43,16 @@ export function VoteButton({
         disabled:opacity-50 disabled:cursor-not-allowed`}
     >
       {/* TODO [easy-challenge]: this button shows no loading state during API call — add one */}
-      <TriangleIcon filled={voted} />
+
+      {isLoading ? (
+        <>
+          <LoadingSpanner />
+          <span className="sr-only">Updating vote...</span>
+        </>
+      ) : (
+        <TriangleIcon filled={voted} />
+      )}
+
       {count}
     </button>
   );
@@ -63,4 +72,47 @@ function TriangleIcon({ filled = false }: { filled?: boolean }) {
       <path d="M6 1 L11 10 L1 10 Z" />
     </svg>
   );
+}
+
+
+function LoadingSpanner() {
+  return (
+    <svg
+      className="h-3.5 w-3.5 animate-spin-slower"
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+    >
+
+      <path
+        d="M19.5 8.5a8 8 0 0 0-13.2-2.1"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+
+      <path
+        d="M8.2 3.9 5.3 6.4 8.9 7"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+
+      <path
+        d="M4.5 15.5a8 8 0 0 0 13.2 2.1"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+
+      <path
+        d="m15.8 20.1 2.9-2.5-3.6-.6"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
 }


### PR DESCRIPTION
## Summary
- Replaced category `<a>` navigation with client-side query param updates using `useRouter` + `useSearchParams`
- Added `CategoryFilter` client component for category pill interactions
- Preserved search query (`q`) when changing category and persisted filter state in URL

## Test plan
-  Click category updates URL without full page reload
-  Refresh preserves selected category from URL
- Search query and category filter work simultaneously
-  Active category pill is visually indicated
-  Browser back/forward restores filter state

## Why this approach 
- useRouter + useSearchParams enable smooth filtering without full page reload
- URL as source of truth → preserves state on refresh, shareable, supports back/forward
- Hybrid (client UI + server data) → better UX while keeping data logic clean
- Start with single-select to keep scope simple; can extend later
- Preserve q when filtering → avoids losing search context